### PR TITLE
Masses rewrite

### DIFF
--- a/dialogs/dialog_functions.py
+++ b/dialogs/dialog_functions.py
@@ -33,7 +33,6 @@ import collections
 
 import widgets.gui_utils as gutils
 
-import modules.masses as masses
 import modules.general_functions as gf
 
 from pathlib import Path
@@ -144,8 +143,7 @@ def get_updated_efficiency_files(qdialog, efficiency_files):
             cut_element = Element.from_string(item.file_name.split(".")[1])
             mass = cut_element.isotope
             if not mass:
-                mass = round(
-                    masses.get_standard_isotope(cut_element.symbol), 0)
+                mass = round(cut_element.get_st_mass(), 0)
             if cut_element.symbol == element.symbol and \
                     mass == element.isotope:
                 eff_files_used.append(eff)

--- a/dialogs/measurement/selection.py
+++ b/dialogs/measurement/selection.py
@@ -34,6 +34,7 @@ import platform
 import modules.masses as masses
 
 import widgets.input_validation as iv
+import widgets.gui_utils as gutils
 
 from pathlib import Path
 
@@ -322,9 +323,10 @@ class SelectionSettingsDialog(QtWidgets.QDialog):
             element: String representing element.
             current_isotope: String representing current isotope.
         """
+        # TODO move to gutils
         standard_mass = masses.get_standard_isotope(element)
         standard_mass_label.setText(str(round(standard_mass, 3)))
-        masses.load_isotopes(element, combobox, current_isotope)
+        gutils.load_isotopes(element, combobox, current_isotope)
 
     def __change_type(self):
         """Toggle ERD/RBS type change.

--- a/dialogs/measurement/selection.py
+++ b/dialogs/measurement/selection.py
@@ -270,10 +270,8 @@ class SelectionSettingsDialog(QtWidgets.QDialog):
         if not isotope_combobox or not isotope_combobox.isEnabled():
             self.isotope_specific_weight_factor_label.setText("")
         else:
-            isotope_index = isotope_combobox.currentIndex()
-            unused_isotope, propability = isotope_combobox.itemData(
-                isotope_index)
-            isotope_weightfactor = 100.0 / float(propability)
+            p = isotope_combobox.currentData()["abundance"]
+            isotope_weightfactor = 100.0 / p
             text = "%.3f for specific isotope" % isotope_weightfactor
             self.isotope_specific_weight_factor_label.setText(text)
 
@@ -323,7 +321,7 @@ class SelectionSettingsDialog(QtWidgets.QDialog):
             element: String representing element.
             current_isotope: String representing current isotope.
         """
-        # TODO move to gutils
+        # TODO do this with IsotopeSelectionWidget
         standard_mass = masses.get_standard_isotope(element)
         standard_mass_label.setText(str(round(standard_mass, 3)))
         gutils.load_isotopes(element, combobox, current_isotope)
@@ -352,10 +350,10 @@ class SelectionSettingsDialog(QtWidgets.QDialog):
                 self.sample_standard_mass_radio.isChecked())
 
             if self.sample_isotope_radio.isChecked():
-                mass_index = self.sample_isotope_combobox.currentIndex()
-                isotope_data = self.sample_isotope_combobox.itemData(mass_index)
-                if isotope_data:
-                    current_isotope = isotope_data[0]
+                data = self.sample_isotope_combobox.currentData()
+
+                if data:
+                    current_isotope = data["element"].isotope
                     self.rbsIsotopeInfoLabel.setVisible(False)
                     self.rbs_isotope_combobox.setStyleSheet(
                         "background-color: %s" % "None")
@@ -440,10 +438,9 @@ class SelectionSettingsDialog(QtWidgets.QDialog):
         current_isotope = None
         if self.rbs_element_button.text() != "Select":
             if self.sample_isotope_radio.isChecked():
-                mass_index = self.rbs_isotope_combobox.currentIndex()
-                isotope_data = self.rbs_isotope_combobox.itemData(mass_index)
-                if isotope_data:
-                    current_isotope = isotope_data[0]
+                data = self.rbs_isotope_combobox.currentData()
+                if data:
+                    current_isotope = data["element"].isotope
                     self.sampleIsotopeInfoLabel.setVisible(False)
                     self.sample_isotope_combobox.setStyleSheet(
                         "background-color: %s" % "None")
@@ -540,10 +537,9 @@ class SelectionSettingsDialog(QtWidgets.QDialog):
         symbol = self.sample_element_button.text()
         if self.selection.type == "ERD":
             if self.sample_isotope_radio.isChecked():
-                isotope_index = self.sample_isotope_combobox.currentIndex()
-                isotope_data = self.sample_isotope_combobox.itemData(
-                    isotope_index)
-                isotope = int(isotope_data[0])
+                # TODO use IsotopeSelectionWidget here
+                elem = self.sample_isotope_combobox.currentData()["element"]
+                isotope = elem.isotope
 
             self.selection.element_scatter = Element("")
             self.selection.element = Element(symbol, isotope)
@@ -551,10 +547,8 @@ class SelectionSettingsDialog(QtWidgets.QDialog):
         else:
             rbs_element = self.rbs_element_button.text()
             if self.rbs_isotope_radio.isChecked():
-                isotope_index = self.rbs_isotope_combobox.currentIndex()
-                isotope_data = self.rbs_isotope_combobox.itemData(
-                    isotope_index)
-                rbs_isotope = int(isotope_data[0])
+                elem = self.rbs_isotope_combobox.currentData()["element"]
+                rbs_isotope = elem.isotope
 
             self.selection.element_scatter = Element(rbs_element,
                                                      rbs_isotope)

--- a/dialogs/simulation/layer_properties.py
+++ b/dialogs/simulation/layer_properties.py
@@ -29,6 +29,7 @@ __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä \n " \
 __version__ = "2.0"
 
 import platform
+import itertools
 
 import dialogs.dialog_functions as df
 import widgets.input_validation as iv
@@ -37,6 +38,7 @@ import widgets.gui_utils as gutils
 from pathlib import Path
 
 from dialogs.element_selection import ElementSelectionDialog
+from widgets.isotope_selection import IsotopeSelectionWidget
 
 from modules.element import Element
 from modules.layer import Layer
@@ -69,10 +71,7 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         self.layer = layer
         self.ok_pressed = False
         self.simulation = simulation
-
-        iv.set_input_field_red(self.thicknessEdit)
-        iv.set_input_field_red(self.densityEdit)
-        self.amount_mismatch = False
+        self.amount_mismatch = True
 
         self.fields_are_valid = True
         iv.set_input_field_red(self.nameEdit)
@@ -86,10 +85,8 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         self.okButton.clicked.connect(self.__save_layer)
         self.cancelButton.clicked.connect(self.close)
 
-        self.thicknessEdit.valueChanged.connect(
-            lambda: self.validate_spinbox(self.thicknessEdit))
-        self.densityEdit.valueChanged.connect(
-            lambda: self.validate_spinbox(self.densityEdit))
+        self.thicknessEdit.setMinimum(0.01)
+        self.densityEdit.setMinimum(0.01)
 
         if self.layer:
             self.__show_layer_info()
@@ -136,6 +133,14 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         for elem in self.layer.elements:
             self.__add_element_layout(elem)
 
+    def get_element_widgets(self):
+        """Returns all ElementLayout child objects that the widget has."""
+        return [
+            child
+            for child in self.scrollAreaWidgetContents.layout().children()
+            if isinstance(child, ElementLayout)
+        ]
+
     def __check_if_settings_ok(self):
         """Check that all the settings are okay.
 
@@ -143,62 +148,33 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
              True if the settings are okay and false if some required fields
              are empty.
         """
+        settings_ok = True
         help_sum = 0
-        spinboxes = []
+        elem_widgets = self.get_element_widgets()
 
         # Check if 'scrollArea' is empty (no elements).
-        if self.scrollAreaWidgetContents.layout().isEmpty():
+        if not elem_widgets:
             iv.set_input_field_red(self.scrollArea)
-            self.fields_are_valid = False
-
-        # Check if 'thicknessEdit' is empty.
-        if not self.thicknessEdit.value():
-            iv.set_input_field_red(self.thicknessEdit)
-            self.fields_are_valid = False
-
-        # Check if 'densityEdit' is empty.
-        if not self.densityEdit.value():
-            iv.set_input_field_red(self.densityEdit)
-            self.fields_are_valid = False
+            settings_ok = False
 
         # Check that the element specific settings are okay.
-        for child in self.scrollAreaWidgetContents.children():
-            if type(child) is QtWidgets.QPushButton:
-                if child.text() == "Select":
-                    iv.set_input_field_red(child)
-                    self.fields_are_valid = False
-            if type(child) is QtWidgets.QDoubleSpinBox:
-                if child.isEnabled():
-                    if child.value():
-                        help_sum += child.value()
-                        spinboxes.append(child)
-                    else:
-                        iv.set_input_field_red(child)
-                        self.fields_are_valid = False
+        for widget in elem_widgets:
+            elem = widget.get_selected_element()
+            if elem is None:
+                settings_ok = False
+            else:
+                help_sum += elem.amount
 
         if help_sum != 1.0 and help_sum != 100.0:
-            for sb in spinboxes:
-                iv.set_input_field_red(sb)
-            self.fields_are_valid = False
+            for widget in elem_widgets:
+                iv.set_input_field_red(widget.amount_spinbox)
+            settings_ok = False
             self.amount_mismatch = True
         else:
-            for sb in spinboxes:
-                iv.set_input_field_white(sb)
+            for widget in elem_widgets:
+                iv.set_input_field_white(widget.amount_spinbox)
             self.amount_mismatch = False
-
-    def validate_spinbox(self, spinbox):
-        """
-        Check if given spinbox has a proper value.
-
-        Args:
-            spinbox: Spinbox to check.
-        """
-        if spinbox.value() == 0.0:
-            self.fields_are_valid = False
-            iv.set_input_field_red(spinbox)
-        else:
-            self.fields_are_valid = True
-            iv.set_input_field_white(spinbox)
+        self.fields_are_valid = settings_ok
 
     def values_changed(self):
         """
@@ -221,15 +197,9 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         """
         Check if elements have been changed in the layer.
         """
-        new_elements = self.find_elements()
-        if len(self.layer.elements) != len(new_elements):
-            return True
-        for i in range(len(self.layer.elements)):
-            elem1 = self.layer.elements[i]
-            elem2 = new_elements[i]
-            if elem1 != elem2:
-                return True
-        return False
+        return not all(e1 == e2 for e1, e2 in itertools.zip_longest(
+            self.find_elements(), self.layer.elements
+        ))
 
     def find_elements(self):
         """
@@ -237,8 +207,7 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
         """
         return [
             child.get_selected_element()
-            for child in self.scrollAreaWidgetContents.layout().children()
-            if isinstance(child, ElementLayout)
+            for child in self.get_element_widgets()
         ]
 
     def __accept_settings(self):
@@ -312,9 +281,10 @@ class LayerPropertiesDialog(QtWidgets.QDialog):
     def __add_element_layout(self, element=None):
         """Add element widget into view.
         """
+        el = ElementLayout(self.scrollAreaWidgetContents, element, self)
+        el.selection_changed.connect(self.__check_if_settings_ok)
         self.scrollArea.setStyleSheet("")
-        self.scrollAreaWidgetContents.layout().addLayout(
-            ElementLayout(self.scrollAreaWidgetContents, element, self))
+        self.scrollAreaWidgetContents.layout().addLayout(el)
 
 
 class ElementLayout(QtWidgets.QVBoxLayout):
@@ -331,43 +301,28 @@ class ElementLayout(QtWidgets.QVBoxLayout):
         parent.parentWidget().setStyleSheet("")
 
         super().__init__()
-
-        if not element:
-            btn_txt = "Select"
-            enabled = False
-        else:
-            btn_txt = element.symbol
-            enabled = True
-        self.element_button = QtWidgets.QPushButton(btn_txt)
-        self.element_button.setFixedWidth(60)
-
         self.dialog = dialog
+
+        self.element_button = QtWidgets.QPushButton("")
+        self.element_button.setFixedWidth(60)
 
         self.isotope_combobox = QtWidgets.QComboBox()
         self.isotope_combobox.setFixedWidth(130)
-        self.isotope_combobox.setEnabled(enabled)
 
         if platform.system() == "Darwin" or platform.system() == "Linux":
             self.isotope_combobox.setFixedWidth(150)
 
         self.amount_spinbox = QtWidgets.QDoubleSpinBox()
+        self.amount_spinbox.setMinimum(0.001)
         self.amount_spinbox.setMaximum(9999.00)
         self.amount_spinbox.setDecimals(3)
-        self.amount_spinbox.setEnabled(enabled)
-        self.amount_spinbox.valueChanged.connect(
-            lambda: dialog.validate_spinbox(self.amount_spinbox))
         self.amount_spinbox.setLocale(QLocale.c())
-
-        if enabled:
-            self.__load_isotopes(element.isotope)
-            self.amount_spinbox.setValue(element.amount)
 
         self.delete_button = QtWidgets.QPushButton("")
         self.delete_button.setIcon(QtGui.QIcon("ui_icons/potku/del.png"))
         self.delete_button.setFixedWidth(28)
         self.delete_button.setFixedHeight(28)
 
-        self.element_button.clicked.connect(self.__select_element)
         self.delete_button.clicked.connect(self.__delete_element_layout)
 
         self.isotope_info_label = QtWidgets.QLabel()
@@ -377,6 +332,15 @@ class ElementLayout(QtWidgets.QVBoxLayout):
         self.horizontal_layout.addWidget(self.isotope_combobox)
         self.horizontal_layout.addWidget(self.amount_spinbox)
         self.horizontal_layout.addWidget(self.delete_button)
+
+        self.isotope_selection_widget = IsotopeSelectionWidget(
+            self.element_button, self.isotope_combobox,
+            info_label=self.isotope_info_label,
+            amount_input=self.amount_spinbox,
+            parent=self.dialog
+        )
+        self.selection_changed = self.isotope_selection_widget.selection_changed
+        self.isotope_selection_widget.set_element(element)
 
         self.addLayout(self.horizontal_layout)
         self.addWidget(self.isotope_info_label)
@@ -391,49 +355,7 @@ class ElementLayout(QtWidgets.QVBoxLayout):
         self.delete_button.deleteLater()
         self.deleteLater()
 
-    def __select_element(self):
-        """Opens a dialog to select an element.
-        """
-        dialog = ElementSelectionDialog()
-
-        if dialog.element:
-            self.element_button.setStyleSheet("")
-            self.element_button.setText(dialog.element)
-            self.isotope_combobox.setEnabled(True)
-            self.amount_spinbox.setEnabled(True)
-            self.__load_isotopes()
-            if not self.amount_spinbox.value():
-                iv.set_input_field_red(self.amount_spinbox)
-
-            # Check if no isotopes
-            if not self.isotope_combobox.currentData():
-                # TODO add self.fields_are_valid attribute or method
-                iv.set_input_field_red(self.isotope_combobox)
-                self.amount_spinbox.setEnabled(False)
-                self.dialog.fields_are_valid = False
-                self.isotope_info_label.setText(
-                    "If you wish to use this element, please modify masses.dat "
-                    "file\nand change the natural abundance to 100 % on your\n"
-                    "preferred isotope and restart the application.")
-            else:
-                iv.check_text(self.dialog.nameEdit, qwidget=self.dialog)
-                self.isotope_combobox.setStyleSheet(
-                    "background-color: %s" % "None")
-                self.isotope_info_label.setText("")
-
-    def __load_isotopes(self, current_isotope=None):
-        """Loads isotopes of the element into the combobox.
-        """
-        gutils.load_isotopes(self.element_button.text(), self.isotope_combobox,
-                             current_isotope, show_std_mass=True)
-
     def get_selected_element(self) -> Element:
         """Returns the selected element object.
         """
-        try:
-            symbol = self.element_button.text()
-            isotope, _ = self.isotope_combobox.currentData()
-            amount = self.amount_spinbox.value()
-            return Element(symbol, isotope, amount)
-        except TypeError:
-            pass
+        return self.isotope_selection_widget.get_element()

--- a/dialogs/simulation/layer_properties.py
+++ b/dialogs/simulation/layer_properties.py
@@ -28,11 +28,11 @@ __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä \n " \
              "Sinikka Siironen"
 __version__ = "2.0"
 
-import modules.masses as masses
 import platform
 
 import dialogs.dialog_functions as df
 import widgets.input_validation as iv
+import widgets.gui_utils as gutils
 
 from pathlib import Path
 
@@ -424,7 +424,7 @@ class ElementLayout(QtWidgets.QVBoxLayout):
     def __load_isotopes(self, current_isotope=None):
         """Loads isotopes of the element into the combobox.
         """
-        masses.load_isotopes(self.element_button.text(), self.isotope_combobox,
+        gutils.load_isotopes(self.element_button.text(), self.isotope_combobox,
                              current_isotope, show_std_mass=True)
 
     def get_selected_element(self) -> Element:

--- a/dialogs/simulation/recoil_element_selection.py
+++ b/dialogs/simulation/recoil_element_selection.py
@@ -53,13 +53,13 @@ class RecoilElementSelectionDialog(QtWidgets.QDialog):
     def __init__(self, recoil_atom_distribution):
         """Inits simulation element selection dialog.
         """
-        # TODO this dialog needs to be wider
         super().__init__()
         uic.loadUi(Path("ui_files", "ui_recoil_element_selection_dialog.ui"),
                    self)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.recoil_atom_distribution = recoil_atom_distribution
 
+        # TODO just use element, no isotope reference is needed
         self.element = None
         self.isotope = None
         self.color = None
@@ -78,11 +78,11 @@ class RecoilElementSelectionDialog(QtWidgets.QDialog):
 
         self.isOk = False
 
+        self.setMinimumWidth(350)
+
         if platform.system() == "Darwin":
             self.isotope_combobox.setFixedHeight(23)
 
-        if platform.system() == "Linux":
-            self.setMinimumWidth(350)
         self.exec_()
 
     def __set_color_button_color(self, element):
@@ -174,6 +174,7 @@ class RecoilElementSelectionDialog(QtWidgets.QDialog):
             element: String representing element.
             current_isotope: String representing current isotope.
         """
+        # TODO do this with IsotopeSelectionWidget
         standard_mass = masses.get_standard_isotope(element)
         self.standard_mass_label.setText(str(round(standard_mass, 3)))
         gutils.load_isotopes(element, self.isotope_combobox, current_isotope)
@@ -206,9 +207,8 @@ class RecoilElementSelectionDialog(QtWidgets.QDialog):
 
         # Check if specific isotope was chosen and use that instead.
         if self.isotope_radio.isChecked():
-            isotope_index = self.isotope_combobox.currentIndex()
-            isotope_data = self.isotope_combobox.itemData(isotope_index)
-            self.isotope = isotope_data[0]
+            elem = self.isotope_combobox.currentData()["element"]
+            self.isotope = elem.isotope
 
         self.isOk = True
         self.close()

--- a/dialogs/simulation/recoil_element_selection.py
+++ b/dialogs/simulation/recoil_element_selection.py
@@ -33,6 +33,7 @@ import platform
 import modules.masses as masses
 
 import widgets.input_validation as iv
+import widgets.gui_utils as gutils
 
 from pathlib import Path
 
@@ -175,7 +176,7 @@ class RecoilElementSelectionDialog(QtWidgets.QDialog):
         """
         standard_mass = masses.get_standard_isotope(element)
         self.standard_mass_label.setText(str(round(standard_mass, 3)))
-        masses.load_isotopes(element, self.isotope_combobox, current_isotope)
+        gutils.load_isotopes(element, self.isotope_combobox, current_isotope)
         self.isotope_combobox.setEnabled(False)
         self.standard_mass_radio.setChecked(True)
 

--- a/modules/calibration.py
+++ b/modules/calibration.py
@@ -404,6 +404,7 @@ class TOFCalibrationPoint:
         # Recoiled atoms' parameters
         element = self.cut.element.symbol
         if cut.element.isotope:
+            # FIXME
             # TODO find_mass_of_isotope could handle checking if the element has
             #      an isotope
             mass = masses.find_mass_of_isotope(self.cut.element)

--- a/modules/calibration.py
+++ b/modules/calibration.py
@@ -29,13 +29,9 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen " \
 __version__ = "2.0"
 
 import collections
-import modules.masses as masses
 import scipy.optimize as optimize
 
-from modules.general_functions import carbon_stopping
-from modules.general_functions import convert_mev_to_joule
-from modules.general_functions import convert_amu_to_kg
-from modules.general_functions import hist
+import modules.general_functions as gf
 
 from numpy import array
 from numpy import linspace
@@ -64,7 +60,7 @@ class TOFCalibrationHistogram:
         self.cut = cut
         self.bin_width = bin_width
         self.use_column = use_column
-        histed_file = hist(self.cut.data, self.bin_width, self.use_column)
+        histed_file = gf.hist(self.cut.data, self.bin_width, self.use_column)
 
         self.histogram_x = [float(pair[0]) for pair in histed_file]
         self.histogram_y = [float(pair[1]) for pair in histed_file]
@@ -402,33 +398,22 @@ class TOFCalibrationPoint:
         density_in_g_per_cm3 = layer.density
 
         # Recoiled atoms' parameters
-        element = self.cut.element.symbol
+        # element = self.cut.element.symbol
+
+        mass = self.cut.element.get_mass()
         if cut.element.isotope:
-            # FIXME
-            # TODO find_mass_of_isotope could handle checking if the element has
-            #      an isotope
-            mass = masses.find_mass_of_isotope(self.cut.element)
             isotope = cut.element.isotope
         else:
-            # If the cut doesn't have a isotope, calculate standard atomic mass.
-            mass = masses.get_standard_isotope(self.cut.element.symbol)
-            isotope = masses.get_most_common_isotope(self.cut.element.symbol)[0]
-        self.recoiled_mass = convert_amu_to_kg(mass)
+            isotope = self.cut.element.get_most_common_isotope()
+        self.recoiled_mass = gf.convert_amu_to_kg(mass)
 
         if self.type == "RBS":
-            element_scatter = self.cut.element_scatter
-            if element_scatter.isotope:
-                # TODO find_mass_of_isotope could handle checking if the element
-                #      has an isotope
-                mass_scatter = masses.find_mass_of_isotope(element_scatter)
-            else:
-                mass_scatter = masses.get_standard_isotope(
-                    self.cut.element_scatter.symbol)
-            self.scatter_element_mass = convert_amu_to_kg(mass_scatter)
+            mass_scatter = self.cut.element_scatter.get_mass()
+            self.scatter_element_mass = gf.convert_amu_to_kg(mass_scatter)
 
-        beam_mass = masses.find_mass_of_isotope(run.beam.ion)
-        self.beam_mass = convert_amu_to_kg(beam_mass)
-        self.beam_energy = convert_mev_to_joule(run.beam.energy)
+        beam_mass = run.beam.ion.get_mass()
+        self.beam_mass = gf.convert_amu_to_kg(beam_mass)
+        self.beam_energy = gf.convert_mev_to_joule(run.beam.energy)
         self.length = time_of_flight_length
         # Target angle, same with both recoiled and scattered atoms when
         # using same hardware.
@@ -438,9 +423,9 @@ class TOFCalibrationPoint:
         # Carbon stopping gives a list of different result values.
         # The last value is the stopping energy.
         try:
-            carbon_stopping_energy = carbon_stopping(element, isotope, energy,
-                                                     carbon_foil_thickness_in_nm,
-                                                     density_in_g_per_cm3)
+            carbon_stopping_energy = gf.carbon_stopping(
+                self.cut.element.symbol, isotope, energy,
+                carbon_foil_thickness_in_nm, density_in_g_per_cm3)
         except:
             error_msg = "Carbon stopping doesn't work. {0} {1}".format(
                 "Continuing without it.",

--- a/modules/element.py
+++ b/modules/element.py
@@ -161,9 +161,12 @@ class Element:
 
     def get_mass(self):
         if self.isotope:
-            return masses.find_mass_of_isotope(self)
+            return masses.find_mass_of_isotope(self.symbol, self.isotope)
         else:
             return masses.get_standard_isotope(self.symbol)
+
+    def get_st_mass(self):
+        return masses.get_standard_isotope(self.symbol)
 
     def get_mcerd_params(self, return_amount=False):
         """Returns the element's mass or amount as a parameter for MCERD.
@@ -187,3 +190,27 @@ class Element:
             return f"%0.3f" % amount
 
         return "%0.2f %s" % (self.get_mass(), self.symbol)
+
+    @classmethod
+    def get_isotopes(cls, symbol, include_st_mass=True, filter_unlikely=True):
+        isotopes = []
+        if include_st_mass:
+            st_mass = masses.get_standard_isotope(symbol)
+            if st_mass:
+                isotopes.append({
+                    "element": cls(symbol),
+                    masses.ABUNDANCE_KEY: None,
+                    masses.MASS_KEY: st_mass
+                })
+
+        isotopes.extend(
+            {
+                "element": cls(symbol, iso.pop("number")),
+                **iso
+            }
+            for iso in masses.get_isotopes(symbol,
+                                           filter_unlikely=True,
+                                           sort_by_abundance=True)
+            )
+
+        return isotopes

--- a/modules/mcerd.py
+++ b/modules/mcerd.py
@@ -28,7 +28,6 @@ __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä \n" \
              "Sinikka Siironen \n Juhani Sundell"
 __version__ = "2.0"
 
-import modules.masses as masses
 import os
 import platform
 import shutil

--- a/tests/gui/test_gui_utils.py
+++ b/tests/gui/test_gui_utils.py
@@ -85,7 +85,7 @@ class TestLoadCombobox(unittest.TestCase):
 
         gutils.load_isotopes("U", combo)
         self.assertIsNone(combo.currentData())
-        self.assertFalse(combo.isEnabled())
+        self.assertEqual(0, combo.count())
 
         gutils.load_isotopes("He", combo, show_std_mass=True)
         self.assertEqual(Element("He", None), combo.currentData()["element"])

--- a/tests/gui/test_gui_utils.py
+++ b/tests/gui/test_gui_utils.py
@@ -25,10 +25,19 @@ __author__ = "Juhani Sundell"
 __version__ = ""  # TODO
 
 import unittest
+import sys
+
+import widgets.gui_utils as gutils
 
 from unittest.mock import Mock
 
+from modules.element import Element
 from widgets.gui_utils import GUIReporter
+
+from PyQt5 import QtWidgets
+from PyQt5.Qt import QApplication
+
+app = QApplication(sys.argv)
 
 
 class TestGUIReporter(unittest.TestCase):
@@ -65,6 +74,24 @@ class TestGUIReporter(unittest.TestCase):
         # This test should test that the callback is always executed in the
         # main thread.
         self.assertTrue(False)
+
+
+class TestLoadCombobox(unittest.TestCase):
+    def test_load_combox(self):
+        combo = QtWidgets.QComboBox()
+        gutils.load_isotopes("He", combo)
+        self.assertEqual(Element("He", 4), combo.currentData()["element"])
+        self.assertTrue(combo.isEnabled())
+
+        gutils.load_isotopes("U", combo)
+        self.assertIsNone(combo.currentData())
+        self.assertFalse(combo.isEnabled())
+
+        gutils.load_isotopes("He", combo, show_std_mass=True)
+        self.assertEqual(Element("He", None), combo.currentData()["element"])
+
+        gutils.load_isotopes("He", combo, show_std_mass=True, current_isotope=4)
+        self.assertEqual(Element("He", 4), combo.currentData()["element"])
 
 
 if __name__ == '__main__':

--- a/tests/gui/test_isotope_selection.py
+++ b/tests/gui/test_isotope_selection.py
@@ -1,0 +1,118 @@
+# coding=utf-8
+"""
+Created on 13.04.2020
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2020 TODO
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = ""  # TODO
+__version__ = ""  # TODO
+
+import unittest
+import sys
+
+from unittest.mock import Mock
+from modules.element import Element
+
+from widgets.isotope_selection import IsotopeSelectionWidget
+
+from PyQt5 import QtWidgets
+from PyQt5.Qt import QApplication
+
+app = QApplication(sys.argv)
+
+
+class TestIsotopeSelectionWidget(unittest.TestCase):
+    def setUp(self):
+        self.elem_btn = QtWidgets.QPushButton()
+        self.isot_box = QtWidgets.QComboBox()
+        self.amount_box = QtWidgets.QDoubleSpinBox()
+        self.info_label = QtWidgets.QLabel()
+        self.parent = Mock()
+
+    def test_elem_btn_and_isot(self):
+        """Tests a widget with only element button and """
+        w = IsotopeSelectionWidget(self.elem_btn, self.isot_box)
+
+        self.assertEqual("Select", self.elem_btn.text())
+        self.assertEqual(0, self.isot_box.count())
+        self.assertIsNone(w.get_element())
+
+        w.set_element("He")
+
+        self.assertEqual("He", self.elem_btn.text())
+        self.assertEqual(3, self.isot_box.count())
+        self.assertEqual(Element("He"), w.get_element())
+
+        # Test changing the index
+        self.isot_box.setCurrentIndex(1)
+
+        self.assertEqual(Element("He", 4), w.get_element())
+
+        # Test setting a new element
+        w.set_element("13C")
+        self.assertEqual("C", self.elem_btn.text())
+        self.assertEqual(Element("C", 13), w.get_element())
+
+    def test_bad_inputs(self):
+        w = IsotopeSelectionWidget(self.elem_btn, self.isot_box)
+        w.set_element("")
+        self.assertEqual("Select", self.elem_btn.text())
+        self.assertIsNone(w.get_element())
+
+        w.set_element(None)
+        self.assertEqual("Select", self.elem_btn.text())
+
+        w.set_element("C")
+        self.assertEqual("C", self.elem_btn.text())
+        w.set_element("")
+        self.assertEqual("Select", self.elem_btn.text())
+        self.assertIsNone(w.get_element())
+        self.assertEqual(0, self.isot_box.count())
+
+    def test_amount_box(self):
+        w = IsotopeSelectionWidget(self.elem_btn, self.isot_box,
+                                   amount_input=self.amount_box)
+
+        self.assertEqual(0, self.amount_box.value())
+
+        w.set_element("2H 15.5")
+        self.assertEqual(15.5, self.amount_box.value())
+        self.assertEqual(Element("H", 2, 15.5), w.get_element())
+
+        self.amount_box.setValue(25.5)
+        self.assertEqual(Element("H", 2, 25.5), w.get_element())
+
+    def test_element_with_no_isotopes(self):
+        w = IsotopeSelectionWidget(self.elem_btn, self.isot_box,
+                                   info_label=self.info_label,
+                                   parent=self.parent)
+
+        self.assertEqual("", self.info_label.text())
+
+        w.set_element("U")
+
+        self.assertFalse(self.isot_box.isEnabled())
+        self.assertNotEqual("", self.info_label.text())
+
+        self.assertFalse(self.parent.fields_are_valid)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/gui/test_measurement_settings.py
+++ b/tests/gui/test_measurement_settings.py
@@ -35,15 +35,12 @@ from modules.element import Element
 from widgets.measurement.settings import MeasurementSettingsWidget
 
 from PyQt5.QtWidgets import QApplication
-from PyQt5.QtTest import QTest
-from PyQt5.QtCore import Qt
 
 
 app = QApplication(sys.argv)
 
 
 class MyTestCase(unittest.TestCase):
-
     @utils.change_wd_to_root
     def setUp(self):
         with warnings.catch_warnings():
@@ -76,7 +73,10 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual("Select", self.mesu_widget.beamIonButton.text())
         self.assertFalse(self.mesu_widget.isotopeComboBox.isEnabled())
 
+    def test_update_settings(self):
         # Assert that measurement's ion is changed to widget's ion after update
+        elem = Element("H", 2)
+        self.mesu_widget.beam_ion = elem
         self.assertNotEqual(self.mesu_widget.obj.run.beam.ion,
                             self.mesu_widget.beam_ion)
         self.mesu_widget.update_settings()

--- a/tests/gui/test_measurement_settings.py
+++ b/tests/gui/test_measurement_settings.py
@@ -66,8 +66,9 @@ class MyTestCase(unittest.TestCase):
         self.assertIsNot(elem, self.mesu_widget.beam_ion)
         self.assertEqual(elem, self.mesu_widget.beam_ion)
         self.assertEqual("C", self.mesu_widget.beamIonButton.text())
-        idx = self.mesu_widget.isotopeComboBox.currentIndex()
-        self.assertEqual(13, self.mesu_widget.isotopeComboBox.itemData(idx)[0])
+        self.assertEqual(
+            13,
+            self.mesu_widget.isotopeComboBox.currentData()["element"].isotope)
 
         # Set ion to None
         self.mesu_widget.beam_ion = None

--- a/tests/gui/test_scientific_spinbox.py
+++ b/tests/gui/test_scientific_spinbox.py
@@ -95,8 +95,8 @@ class TestSciSpinbox(unittest.TestCase):
         self.assertEqual(5e22, self.sbox.get_value())
 
         # Try setting a roman numeral
-        self.assertRaises(ValueError, self.sbox.set_value("XVII"))
-        self.assertEqual(5e22, self.sbox.get_value())
+        self.sbox.set_value("XVII")
+        self.assertRaises(ValueError, lambda: self.sbox.get_value())
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_element.py
+++ b/tests/unit/test_element.py
@@ -27,6 +27,8 @@ __version__ = ""  # TODO
 import unittest
 import random
 
+import tests.mock_objects as mo
+
 from modules.element import Element
 
 
@@ -110,6 +112,37 @@ class TestElement(unittest.TestCase):
                             Element.from_string("H"))
 
         self.assertNotEqual(Element.from_string("H"), "H")
+
+    def test_equals_prop_based(self):
+        n = 1000
+        for _ in range(n):
+            elem1 = mo.get_element(randomize=True)
+            elem1_str = str(elem1)
+            elem2 = Element.from_string(elem1_str)
+            self.assertIsNot(elem1, elem2)
+            self.assertEqual(elem1, elem2)
+
+
+    def test_get_isotopes(self):
+        self.assert_isotopes_match("H", (1, 2), include_st_mass=False)
+        self.assert_isotopes_match("H", (None, 1, 2), include_st_mass=True)
+        self.assertEqual([], Element.get_isotopes("U", include_st_mass=True,
+                                                  filter_unlikely=True))
+
+    def assert_isotopes_match(self, symbol, isotopes, include_st_mass):
+        isos = Element.get_isotopes(symbol, include_st_mass=include_st_mass)
+
+        self.assertEqual(len(isotopes), len(isos))
+
+        if include_st_mass and isos:
+            self.assertIsNone(isos[0]["abundance"])
+
+        for n, iso in zip(isotopes, isos):
+            self.assertEqual(
+                ["element", "abundance", "mass"],
+                list(iso.keys())
+            )
+            self.assertEqual(Element("H", n), iso["element"])
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_masses.py
+++ b/tests/unit/test_masses.py
@@ -1,0 +1,137 @@
+# coding=utf-8
+"""
+Created on 10.04.2020
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2020 TODO
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = ""  # TODO
+__version__ = ""  # TODO
+
+import unittest
+import itertools
+
+import modules.masses as masses
+
+
+# TODO checksum for masses.dat
+
+class TestMasses(unittest.TestCase):
+    def test_identities(self):
+        # Assert that lists are cloned
+        c_isos1 = masses.get_isotopes("C")
+        c_isos2 = masses.get_isotopes("C")
+        self.assertEqual(c_isos1, c_isos2)
+        self.assertIsNot(c_isos1, c_isos2)
+
+        for c1, c2 in itertools.product(c_isos1, c_isos2):
+            self.assertIsNot(c1, c2)
+
+        self.assertNotEqual(masses.get_isotopes("C"),
+                            masses.get_isotopes("He"))
+
+    def test_filtering_unlikely(self):
+        # By default, unlikely isotopes (i.e. ones with natural abundance of 0)
+        # are filtered out
+        default = masses.get_isotopes("O")
+        filtered = masses.get_isotopes("O", filter_unlikely=True)
+        self.assertEqual(default, filtered)
+
+        unfiltered = masses.get_isotopes("O", filter_unlikely=False)
+        self.assertNotEqual(filtered, unfiltered)
+        self.assertLess(len(filtered), len(unfiltered))
+
+        for iso in filtered:
+            self.assertIn(iso, unfiltered)
+
+    def test_sort_by_abundance(self):
+        # By default, isotopes are sorted by abundance
+        default = masses.get_isotopes("Li", filter_unlikely=False)
+        sorted_isos = masses.get_isotopes("Li", sort_by_abundance=True,
+                                          filter_unlikely=False)
+        self.assertEqual(default, sorted_isos)
+
+        unsorted = masses.get_isotopes("Li", sort_by_abundance=False,
+                                       filter_unlikely=False)
+        self.assertEqual(len(sorted_isos), len(unsorted))
+        self.assertNotEqual(sorted_isos, unsorted)
+        for iso in sorted_isos:
+            self.assertLessEqual(
+                iso["abundance"],
+                sorted_isos[0]["abundance"])
+            self.assertIn(iso, unsorted)
+
+    def test_rare_and_unknown_isotopes(self):
+        # Assert that 'foo' is not in the dictionary, and neither it gets
+        # added to it.
+        self.assertNotIn("foo", masses._ISOTOPES)
+        self.assertEqual([], masses.get_isotopes("foo", filter_unlikely=False))
+        self.assertNotIn("foo", masses._ISOTOPES)
+
+        # Uranium has some isotopes, but no abundances so they get filtered out
+        self.assertIn("U", masses._ISOTOPES)
+        u_all_isos = masses.get_isotopes("U", filter_unlikely=False)
+        self.assertNotEqual([], u_all_isos)
+
+        u_filtered = masses.get_isotopes("U", filter_unlikely=True)
+        self.assertEqual([], u_filtered)
+
+    def test_get_mass(self):
+        self.assertIsNone(masses.find_mass_of_isotope("H", 0))
+        self.assertAlmostEqual(1.007825, masses.find_mass_of_isotope("H", 1),
+                               places=5)
+        self.assertAlmostEqual(2.014101, masses.find_mass_of_isotope("H", 2),
+                               places=5)
+        self.assertIsNone(masses.find_mass_of_isotope("H", 3))
+
+        self.assertIsNone(masses.find_mass_of_isotope("foo", 42))
+
+    def test_get_st_mass(self):
+        self.assertAlmostEqual(1.00015, masses.get_standard_isotope("H"),
+                               places=5)
+        self.assertAlmostEqual(4, masses.get_standard_isotope("He"),
+                               places=5)
+        self.assertAlmostEqual(12.0110, masses.get_standard_isotope("C"),
+                               places=5)
+        self.assertAlmostEqual(6.925, masses.get_standard_isotope("Li"),
+                               places=5)
+
+        self.assertEqual(0, masses.get_standard_isotope("U"))
+        self.assertEqual(0, masses.get_standard_isotope("foo"))
+
+    def test_get_most_common(self):
+        elems = ["C", "He", "Mn", "Li"]
+        for elem in elems:
+            isotopes = masses.get_isotopes(elem, sort_by_abundance=False,
+                                           filter_unlikely=False)
+
+            most_common = masses.get_most_common_isotope(elem)
+            self.assertIn(most_common, isotopes)
+
+            for iso in isotopes:
+                self.assertLessEqual(
+                    iso["abundance"],
+                    most_common["abundance"])
+
+        self.assertIsNone(masses.get_most_common_isotope("U"))
+        self.assertIsNone(masses.get_most_common_isotope("foo"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/widgets/binding.py
+++ b/widgets/binding.py
@@ -29,6 +29,7 @@ import abc
 import json
 
 from widgets.scientific_spinbox import ScientificSpinBox
+from widgets.isotope_selection import IsotopeSelectionWidget
 
 from PyQt5 import QtWidgets
 from PyQt5 import QtCore
@@ -53,12 +54,14 @@ def to_qtime(seconds: int) -> QTime:
 _DEFAULT_GETTERS = {
     QtWidgets.QTimeEdit: lambda qobj: from_qtime(qobj.time()),
     QtWidgets.QLineEdit: lambda qobj: qobj.text(),
+    # TODO change the next one to currentData
     QtWidgets.QComboBox: lambda qobj: qobj.currentText(),
     QtWidgets.QTextEdit: lambda qobj: qobj.toPlainText(),
     QtWidgets.QCheckBox: lambda qobj: qobj.isChecked(),
     QtWidgets.QLabel: lambda qobj: qobj.text(),
     QtWidgets.QPlainTextEdit: lambda qobj: qobj.toPlainText(),
-    ScientificSpinBox: lambda qobj: qobj.get_value()
+    ScientificSpinBox: lambda qobj: qobj.get_value(),
+    IsotopeSelectionWidget: lambda qobj: qobj.get_element()
 }
 
 _DEFAULT_SETTERS = {
@@ -70,7 +73,8 @@ _DEFAULT_SETTERS = {
     QtWidgets.QCheckBox: lambda qobj, b: qobj.setChecked(b),
     QtWidgets.QLabel: lambda qobj, txt: qobj.setText(txt),
     QtWidgets.QPlainTextEdit: lambda qobj, txt: qobj.setPlainText(txt),
-    ScientificSpinBox: lambda qobj, value: qobj.set_value.setText(value)
+    ScientificSpinBox: lambda qobj, value: qobj.set_value(value),
+    IsotopeSelectionWidget: lambda qobj, elem: qobj.set_element(elem)
 }
 
 

--- a/widgets/gui_utils.py
+++ b/widgets/gui_utils.py
@@ -224,8 +224,7 @@ def change_arrow(qbutton: QtWidgets.QPushButton, arrow=None):
     qbutton.setText(arrow)
 
 
-def load_isotopes(symbol, combobox, current_isotope=None, show_std_mass=False,
-                  disable_if_empty=True):
+def load_isotopes(symbol, combobox, current_isotope=None, show_std_mass=False):
     """Load isotopes of given element into given combobox.
 
     Args:
@@ -250,6 +249,3 @@ def load_isotopes(symbol, combobox, current_isotope=None, show_std_mass=False,
         combobox.addItem(txt, userData=iso)
         if current_isotope == iso["element"].isotope:
             combobox.setCurrentIndex(idx)
-
-    if disable_if_empty:
-        combobox.setEnabled(combobox.count() > 0)

--- a/widgets/gui_utils.py
+++ b/widgets/gui_utils.py
@@ -28,6 +28,7 @@ import abc
 import platform
 
 from modules.observing import ProgressReporter
+from modules.element import Element
 
 from PyQt5 import QtCore
 from PyQt5 import QtWidgets
@@ -221,3 +222,34 @@ def change_arrow(qbutton: QtWidgets.QPushButton, arrow=None):
         raise ValueError(f"change_arrow function expected either a '<', "
                          f"'>' or None, '{arrow}' given.")
     qbutton.setText(arrow)
+
+
+def load_isotopes(symbol, combobox, current_isotope=None, show_std_mass=False,
+                  disable_if_empty=True):
+    """Load isotopes of given element into given combobox.
+
+    Args:
+        symbol: string representation of an element, e.g. 'He'.
+        combobox: QComboBox to which items are added.
+        current_isotope: Current isotope to select it on combobox by default.
+        show_std_mass: if True, std mass is added as the first element
+    """
+    # TODO this function could be moved to gui_utils
+    combobox.clear()
+    # Sort isotopes based on their natural abundance
+    isotopes = Element.get_isotopes(symbol, include_st_mass=show_std_mass,
+                                    filter_unlikely=True)
+
+    for idx, iso in enumerate(isotopes):
+        if iso["element"].isotope is None:
+            # Standard mass option
+            txt = f"{round(iso['element'].get_mass())} (st. mass)"
+        else:
+            # Isotope specific options
+            txt = f"{iso['element'].isotope} ({round(iso['abundance'], 3)}%)"
+        combobox.addItem(txt, userData=iso)
+        if current_isotope == iso["element"].isotope:
+            combobox.setCurrentIndex(idx)
+
+    if disable_if_empty:
+        combobox.setEnabled(combobox.count() > 0)

--- a/widgets/isotope_selection.py
+++ b/widgets/isotope_selection.py
@@ -42,17 +42,28 @@ from PyQt5.QtCore import pyqtSignal
 
 
 class IsotopeSelectionWidget(QObject):
+    """IsotopeSelectionWidget is a helper class for selecting isotopes in
+    GUI.
+
+    Currently it has no corresponding 'ui' file nor does it dynamically add
+    any GUI elements to the screen. Instead, GUI elements are provided as
+    parameters when the IsotopeSelectionWidget is initialized.
+    """
     DEFAULT_BTN_TXT = "Select"
     MISSING_ISOTOPE_TXT = "If you wish to use this element, please modify " \
                           "masses.dat file\nand change the natural abundance " \
                           "to 100 % on your\npreferred isotope and restart " \
                           "the application."
+
+    # Signal that is emitted when isotope selection has changed
     selection_changed = pyqtSignal()
 
     def __init__(self, symbol_input: QPushButton,
                  isotope_input: QComboBox, amount_input: QDoubleSpinBox = None,
                  st_mass_input: QWidget = None, info_label: QLabel = None,
                  parent: QWidget = None):
+        """Initializes a new IsotopeSelectionWidget.
+        """
         super().__init__()
         self._symbol_input = symbol_input
         self._isotope_input = isotope_input
@@ -69,12 +80,17 @@ class IsotopeSelectionWidget(QObject):
         self._isotope_input.setEnabled(False)
 
     def show_element_dialog(self):
+        """Opens up the ElementSelectionDialog that allows user
+        to choose the element.
+        """
         dialog = ElementSelectionDialog()
 
         if dialog.element:
             self.set_element(dialog.element)
 
     def set_element(self, element: Element):
+        """Sets currently selected element.
+        """
         if not isinstance(element, Element):
             try:
                 element = Element.from_string(element)
@@ -98,6 +114,9 @@ class IsotopeSelectionWidget(QObject):
         self.selection_changed.emit()
 
     def validate(self):
+        """Validates the contents of the Widget, setting background colors
+        and error messages if necessary.
+        """
         valid_selection = bool(self.get_element())
         self._isotope_input.setEnabled(valid_selection)
 
@@ -116,6 +135,8 @@ class IsotopeSelectionWidget(QObject):
                 self._parent.fields_are_valid = False
 
     def get_element(self) -> Element:
+        """Returns the selected element.
+        """
         element: Element = None
         data = self._isotope_input.currentData()
         if data is not None:

--- a/widgets/isotope_selection.py
+++ b/widgets/isotope_selection.py
@@ -1,0 +1,128 @@
+# coding=utf-8
+"""
+Created on 13.04.2020
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2020 TODO
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = ""  # TODO
+__version__ = ""  # TODO
+
+
+import widgets.gui_utils as gutils
+import widgets.input_validation as iv
+
+from modules.element import Element
+
+from dialogs.element_selection import ElementSelectionDialog
+
+from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QPushButton
+from PyQt5.QtWidgets import QComboBox
+from PyQt5.QtWidgets import QLabel
+from PyQt5.QtWidgets import QDoubleSpinBox
+from PyQt5.QtCore import QObject
+from PyQt5.QtCore import pyqtSignal
+
+
+class IsotopeSelectionWidget(QObject):
+    DEFAULT_BTN_TXT = "Select"
+    MISSING_ISOTOPE_TXT = "If you wish to use this element, please modify " \
+                          "masses.dat file\nand change the natural abundance " \
+                          "to 100 % on your\npreferred isotope and restart " \
+                          "the application."
+    selection_changed = pyqtSignal()
+
+    def __init__(self, symbol_input: QPushButton,
+                 isotope_input: QComboBox, amount_input: QDoubleSpinBox = None,
+                 st_mass_input: QWidget = None, info_label: QLabel = None,
+                 parent: QWidget = None):
+        super().__init__()
+        self._symbol_input = symbol_input
+        self._isotope_input = isotope_input
+        self._amount_input = amount_input
+        self._st_mass_input = st_mass_input
+        self._info_label = info_label
+        self._parent = parent
+
+        self._symbol_input.setText(IsotopeSelectionWidget.DEFAULT_BTN_TXT)
+        self._symbol_input.setStyleSheet("")
+        self._symbol_input.setEnabled(True)
+        self._symbol_input.clicked.connect(self.show_element_dialog)
+
+        self._isotope_input.setEnabled(False)
+
+    def show_element_dialog(self):
+        dialog = ElementSelectionDialog()
+
+        if dialog.element:
+            self.set_element(dialog.element)
+
+    def set_element(self, element: Element):
+        if not isinstance(element, Element):
+            try:
+                element = Element.from_string(element)
+            except (ValueError, AttributeError):
+                self._isotope_input.clear()
+                self.validate()
+                self.selection_changed.emit()
+                return
+
+        show_st_mass_in_combobox = self._st_mass_input is None
+
+        self._symbol_input.setText(element.symbol)
+        gutils.load_isotopes(element.symbol, self._isotope_input,
+                             show_std_mass=show_st_mass_in_combobox,
+                             current_isotope=element.isotope)
+
+        if self._amount_input is not None and element.amount:
+            self._amount_input.setValue(element.amount)
+
+        self.validate()
+        self.selection_changed.emit()
+
+    def validate(self):
+        valid_selection = bool(self.get_element())
+        self._isotope_input.setEnabled(valid_selection)
+
+        if valid_selection:
+            self._isotope_input.setStyleSheet(
+                "background-color: %s" % "None")
+            if self._info_label is not None:
+                self._info_label.setText("")
+        else:
+            iv.set_input_field_red(self._isotope_input)
+            self._symbol_input.setText("Select")
+            if self._info_label is not None:
+                self._info_label.setText(
+                    IsotopeSelectionWidget.MISSING_ISOTOPE_TXT)
+            if self._parent is not None:
+                self._parent.fields_are_valid = False
+
+    def get_element(self) -> Element:
+        element: Element = None
+        data = self._isotope_input.currentData()
+        if data is not None:
+            element = data["element"]
+
+        if element is not None and self._amount_input is not None:
+            element.amount = self._amount_input.value()
+
+        return element
+

--- a/widgets/matplotlib/calibration/curve_fitting.py
+++ b/widgets/matplotlib/calibration/curve_fitting.py
@@ -28,8 +28,6 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen " \
              "Samuel Kaiponen \n Heta Rekilä \n Sinikka Siironen"
 __version__ = "2.0"
 
-import modules.masses as masses
-
 from modules.calibration import TOFCalibrationPoint
 from modules.calibration import TOFCalibrationHistogram
 from widgets.matplotlib.base import MatplotlibWidget
@@ -130,10 +128,11 @@ class MatplotlibCalibrationCurveFittingWidget(MatplotlibWidget):
             self.cut = cut
             self.selectButton.setChecked(False)
             self.selection_given_manually = False
-            self.cut_standard_mass = masses.get_standard_isotope(
-                self.cut.element.symbol)
-            self.cut_standard_scatter_mass = masses.get_standard_isotope(
-                self.cut.element_scatter.symbol)
+            self.cut_standard_mass = self.cut.element.get_st_mass()
+            # TODO check if it is ok for this to be 0 when the scatter
+            #   element is None
+            self.cut_standard_scatter_mass = \
+                self.cut.element_scatter.get_st_mass()
         self.on_draw()
 
     def change_bin_width(self, bin_width):

--- a/widgets/matplotlib/measurement/element_losses.py
+++ b/widgets/matplotlib/measurement/element_losses.py
@@ -29,7 +29,6 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen \n " \
              "Samuel Kaiponen \n Heta Rekilä \n Sinikka Siironen"
 __version__ = "2.0"
 
-import modules.masses as masses
 import os
 
 from dialogs.graph_ignore_elements import GraphIgnoreElements
@@ -90,7 +89,7 @@ class MatplotlibElementLossesWidget(MatplotlibWidget):
         self.mpl_toolbar.addSeparator()
         self.__button_scale = QtWidgets.QToolButton(self)
         self.__button_scale.clicked.connect(self.__toggle_scaling)
-        self.__button_scale.setToolTip("Toggle scaling mode for the graph " + \
+        self.__button_scale.setToolTip("Toggle scaling mode for the graph "
                                        "default, log and 100%.")
         self.__icon_manager.set_icon(self.__button_scale,
                                      self.__icons[self.__scale_mode])

--- a/widgets/matplotlib/measurement/tofe_histogram.py
+++ b/widgets/matplotlib/measurement/tofe_histogram.py
@@ -29,7 +29,6 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen \n " \
              "Samuel Kaiponen \n Heta Rekilä \n Sinikka Siironen"
 __version__ = "2.0"
 
-import modules.masses as masses
 import os
 
 from widgets.gui_utils import GUIReporter
@@ -343,8 +342,7 @@ class MatplotlibHistogramWidget(MatplotlibWidget):
                 isotope_str = str(int(element.isotope))
                 add = r"$^{" + isotope_str + "}$"
             else:
-                isotope_str = str(
-                    int(masses.get_standard_isotope(element.symbol)))
+                isotope_str = str(round(element.get_st_mass()))
                 add = ""
 
             label = add + element.symbol + rbs_string

--- a/widgets/measurement/settings.py
+++ b/widgets/measurement/settings.py
@@ -34,7 +34,7 @@ import os
 
 import widgets.binding as bnd
 import widgets.input_validation as iv
-import modules.masses as masses
+import widgets.gui_utils as gutils
 
 from pathlib import Path
 from modules.element import Element
@@ -60,10 +60,8 @@ def element_from_gui(instance, attrs):
     if symbol == "Select":
         return None
     if isotope_box.currentIndex() == -1:
-        isotope = None
-    else:
-        isotope = isotope_box.itemData(isotope_box.currentIndex())[0]
-    return Element(symbol, isotope)
+        return Element(symbol, None)
+    return isotope_box.currentData()["element"]
 
 
 def element_to_gui(instance, attrs, value: Element):
@@ -76,7 +74,7 @@ def element_to_gui(instance, attrs, value: Element):
         isotope_box.setEnabled(False)
     else:
         symbol_btn.setText(value.symbol)
-        masses.load_isotopes(value.symbol, isotope_box, value.isotope)
+        gutils.load_isotopes(value.symbol, isotope_box, value.isotope)
 
 
 class MeasurementSettingsWidget(QtWidgets.QWidget,
@@ -394,7 +392,7 @@ class MeasurementSettingsWidget(QtWidgets.QWidget,
         dialog = ElementSelectionDialog()
         if dialog.element:
             self.beamIonButton.setText(dialog.element)
-            masses.load_isotopes(dialog.element, self.isotopeComboBox)
+            gutils.load_isotopes(dialog.element, self.isotopeComboBox)
 
             # Check if no isotopes
             if self.isotopeComboBox.count() == 0:

--- a/widgets/measurement/settings.py
+++ b/widgets/measurement/settings.py
@@ -72,9 +72,11 @@ def element_to_gui(instance, attrs, value: Element):
     if value is None:
         symbol_btn.setText("Select")
         isotope_box.setEnabled(False)
+        isotope_box.clear()
     else:
         symbol_btn.setText(value.symbol)
         gutils.load_isotopes(value.symbol, isotope_box, value.isotope)
+        isotope_box.setEnabled(isotope_box.count() > 0)
 
 
 class MeasurementSettingsWidget(QtWidgets.QWidget,
@@ -392,6 +394,7 @@ class MeasurementSettingsWidget(QtWidgets.QWidget,
         dialog = ElementSelectionDialog()
         if dialog.element:
             self.beamIonButton.setText(dialog.element)
+            # TODO use IsotopeSelectionWidget
             gutils.load_isotopes(dialog.element, self.isotopeComboBox)
 
             # Check if no isotopes


### PR DESCRIPTION
This PR makes some changes to the masses module. Element class now acts as the main interface to the module. The idea is to simplify the loading of isotopes to various comboboxes. 

There is also an initial implementation of a IsotopeSelectionWidget that is meant to be a reusable component to handle all isotope selections. Currently the widget is only used in LayerProperties dialog.   