### PR TITLE
fill_cuts_treewidget function moved to gui_utils module

### DIFF
--- a/dialogs/energy_spectrum.py
+++ b/dialogs/energy_spectrum.py
@@ -35,6 +35,7 @@ import os
 import shutil
 
 import dialogs.dialog_functions as df
+import widgets.gui_utils as gutils
 
 from pathlib import Path
 
@@ -105,8 +106,9 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
             m_name = self.measurement.name
             if m_name not in EnergySpectrumParamsDialog.checked_cuts.keys():
                 EnergySpectrumParamsDialog.checked_cuts[m_name] = []
-            self.measurement.fill_cuts_treewidget(
-                self.treeWidget, True,
+
+            gutils.fill_cuts_treewidget(
+                self.measurement, self.treeWidget, True,
                 EnergySpectrumParamsDialog.checked_cuts[m_name])
 
             self.__update_eff_files()

--- a/dialogs/measurement/depth_profile.py
+++ b/dialogs/measurement/depth_profile.py
@@ -35,6 +35,7 @@ import time
 import logging
 
 import dialogs.dialog_functions as df
+import widgets.gui_utils as gutils
 
 from pathlib import Path
 
@@ -98,7 +99,9 @@ class DepthProfileDialog(QtWidgets.QDialog):
         m_name = self.parent.obj.name
         if m_name not in DepthProfileDialog.checked_cuts.keys():
             DepthProfileDialog.checked_cuts[m_name] = []
-        self.measurement.fill_cuts_treewidget(
+
+        gutils.fill_cuts_treewidget(
+            self.measurement,
             self.treeWidget, True,
             DepthProfileDialog.checked_cuts[m_name])
         

--- a/dialogs/measurement/element_losses.py
+++ b/dialogs/measurement/element_losses.py
@@ -34,6 +34,7 @@ import os
 import sys
 
 import dialogs.dialog_functions as df
+import widgets.gui_utils as gutils
 import modules.cut_file as cut_file
 
 from pathlib import Path
@@ -92,9 +93,9 @@ class ElementLossesDialog(QtWidgets.QDialog):
 
         if m_name not in ElementLossesDialog.checked_cuts.keys():
             ElementLossesDialog.checked_cuts[m_name] = []
-        parent.obj.fill_cuts_treewidget(
-            self.targetCutTree,
-            True,
+
+        gutils.fill_cuts_treewidget(
+            parent.obj, self.targetCutTree, True,
             ElementLossesDialog.checked_cuts[m_name])
 
         self.partitionCount.setValue(ElementLossesDialog.split_count)

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -48,9 +48,6 @@ from modules.selection import Selector
 from modules.target import Target
 from modules.ui_log_handlers import Logger
 
-from PyQt5 import QtCore
-from PyQt5 import QtWidgets
-
 
 class Measurements:
     """ Measurements class handles multiple measurements.
@@ -1003,44 +1000,6 @@ class Measurement(Logger):
                         "Changes",
                         f))]
         return cuts, elemloss
-
-    def fill_cuts_treewidget(self, treewidget, use_elemloss=False,
-                             checked_files=None):
-        """ Fill QTreeWidget with cut files.
-        
-        Args:
-            treewidget: A QtGui.QTreeWidget, where cut files are added to.
-            use_elemloss: A boolean representing whether to add elemental
-                          losses.
-            checked_files: A list of previously checked files.
-        """
-        if checked_files is None:
-            checked_files = []
-        treewidget.clear()
-        cuts, cuts_elemloss = self.get_cut_files()
-        for cut in cuts:
-            item = QtWidgets.QTreeWidgetItem([cut])
-            item.directory = os.path.join(self.directory, self.directory_cuts)
-            item.file_name = cut
-            if not checked_files or item.file_name in checked_files:
-                item.setCheckState(0, QtCore.Qt.Checked)
-            else:
-                item.setCheckState(0, QtCore.Qt.Unchecked)
-            treewidget.addTopLevelItem(item)
-        if use_elemloss and cuts_elemloss:
-            elem_root = QtWidgets.QTreeWidgetItem(["Elemental Losses"])
-            for elemloss in cuts_elemloss:
-                item = QtWidgets.QTreeWidgetItem([elemloss])
-                item.directory = os.path.join(
-                    self.directory, self.directory_composition_changes,
-                    "Changes")
-                item.file_name = elemloss
-                if item.file_name in checked_files:
-                    item.setCheckState(0, QtCore.Qt.Checked)
-                else:
-                    item.setCheckState(0, QtCore.Qt.Unchecked)
-                elem_root.addChild(item)
-            treewidget.addTopLevelItem(elem_root)
 
     def load_selection(self, filename, progress=None, percent_add=0.0,
                        start=40):

--- a/widgets/gui_utils.py
+++ b/widgets/gui_utils.py
@@ -27,6 +27,8 @@ __version__ = "2.0"
 import abc
 import platform
 
+from pathlib import Path
+
 from modules.observing import ProgressReporter
 from modules.element import Element
 
@@ -248,3 +250,44 @@ def load_isotopes(symbol, combobox, current_isotope=None, show_std_mass=False):
         combobox.addItem(txt, userData=iso)
         if current_isotope == iso["element"].isotope:
             combobox.setCurrentIndex(idx)
+
+
+def fill_cuts_treewidget(measurement, treewidget, use_elemloss=False,
+                         checked_files=None):
+    """ Fill QTreeWidget with cut files.
+
+    Args:
+        measurement: Measurement object
+        treewidget: A QtGui.QTreeWidget, where cut files are added to.
+        use_elemloss: A boolean representing whether to add elemental
+                      losses.
+        checked_files: A list of previously checked files.
+    """
+    if checked_files is None:
+        checked_files = []
+    treewidget.clear()
+    cuts, cuts_elemloss = measurement.get_cut_files()
+    for cut in cuts:
+        item = QtWidgets.QTreeWidgetItem([cut])
+        item.directory = Path(measurement.directory, measurement.directory_cuts)
+        item.file_name = cut
+        if not checked_files or item.file_name in checked_files:
+            item.setCheckState(0, QtCore.Qt.Checked)
+        else:
+            item.setCheckState(0, QtCore.Qt.Unchecked)
+        treewidget.addTopLevelItem(item)
+    if use_elemloss and cuts_elemloss:
+        elem_root = QtWidgets.QTreeWidgetItem(["Elemental Losses"])
+        for elemloss in cuts_elemloss:
+            item = QtWidgets.QTreeWidgetItem([elemloss])
+            item.directory = Path(
+                measurement.directory,
+                measurement.directory_composition_changes,
+                "Changes")
+            item.file_name = elemloss
+            if item.file_name in checked_files:
+                item.setCheckState(0, QtCore.Qt.Checked)
+            else:
+                item.setCheckState(0, QtCore.Qt.Unchecked)
+            elem_root.addChild(item)
+        treewidget.addTopLevelItem(elem_root)


### PR DESCRIPTION
This commit moves the fill_cuts_treewidget function from measurement module to gui_utils module. This way we can get rid of PyQt references in measurement module