### PR TITLE
Hard coded Selector dependency removed from measurement module

### DIFF
--- a/potku.py
+++ b/potku.py
@@ -64,6 +64,7 @@ from modules.global_settings import GlobalSettings
 from modules.measurement import Measurement
 from modules.request import Request
 from modules.simulation import Simulation
+from modules.selection import Selector
 
 from PyQt5 import QtCore
 from PyQt5 import QtWidgets
@@ -1136,7 +1137,8 @@ class Potku(QtWidgets.QMainWindow):
             measurement = \
                 self.request.samples.measurements.add_measurement_file(
                     sample, filepath, self.tab_id, object_name,
-                    import_evnt_or_binary=import_evnt_or_binary)
+                    import_evnt_or_binary=import_evnt_or_binary,
+                    selector_cls=Selector)
             if measurement == "already exists":
                 return None
             if measurement:


### PR DESCRIPTION
Instead of measurement module importing Selector from modules.selection (and therefore also importing matplotlib and PyQt), selector's class is provided as a parameter for Measurement's
add_measurement_file method. The allows the caller to decide which kind of Selector is being used, making the backend GUI independent.