### PR TITLE
Issue 3 tofin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ Pipfile.lock
 # Temporary QT Creator files
 *.ui.autosave
 
-/.DS_Store
+.DS_Store
 
 # Directories created by pyinstaller
 /dist

--- a/dialogs/dialog_functions.py
+++ b/dialogs/dialog_functions.py
@@ -29,13 +29,15 @@ __version__ = "2.0"
 import os
 import itertools
 from collections import namedtuple, defaultdict
+from typing import Union
+from pathlib import Path
 
 import widgets.gui_utils as gutils
 
-from pathlib import Path
-
 from modules.base import ElementSimulationContainer
 from modules.detector import Detector
+from modules.measurement import Measurement
+from modules.simulation import Simulation
 
 from PyQt5 import QtWidgets
 from PyQt5 import QtGui
@@ -160,22 +162,22 @@ def delete_recoil_espe(tab, recoil_name):
 # TODO common base class for settings dialogs
 
 
-def update_detector_settings(entity, det_folder_path: Path,
-                             measurement_settings_file_path: Path):
+def update_detector_settings(entity: Union[Measurement, Simulation],
+                             detector_folder: Path, measurement_file: Path):
     """
 
     Args:
         entity: either a Measurement or Simulation
-        det_folder_path: path to the detector's folder,
-        measurement_settings_file_path: TODO
+        detector_folder: path to the detector's folder,
+        measurement_file: path to .measurement file
     """
     # Create default Detector for Measurement
-    detector_file_path = Path(det_folder_path, "Default.detector")
-    det_folder_path.mkdir(exist_ok=True)
+    detector_file_path = Path(detector_folder, "Default.detector")
+    detector_folder.mkdir(exist_ok=True)
 
     entity.detector = Detector(
-        detector_file_path, measurement_settings_file_path)
-    entity.detector.update_directories(det_folder_path)
+        detector_file_path, measurement_file)
+    entity.detector.update_directories(detector_folder)
 
     # Transfer the default detector efficiencies to new
     # Detector

--- a/dialogs/energy_spectrum.py
+++ b/dialogs/energy_spectrum.py
@@ -188,10 +188,7 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
                                     file.rsplit('.', 1)[0]
                                 all_cuts.append(file_name_without_suffix)
 
-                        for file_2 in os.listdir(
-                                os.path.join(
-                                    measurement.directory_composition_changes,
-                                    "Changes")):
+                        for file_2 in os.listdir(measurement.get_changes_dir()):
                             if file_2.endswith(".cut"):
                                 file_name_without_suffix = \
                                     file_2.rsplit('.', 1)[0]
@@ -262,9 +259,9 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
                                         f"{item.text(0)}.cut")
                     else:
                         cut_file = Path(
-                            measurement.directory_composition_changes,
-                            "Changes", f"{item.text(0)}.cut")
-                    result_file = Path(measurement.directory_energy_spectra,
+                            measurement.get_changes_dir(),
+                            f"{item.text(0)}.cut")
+                    result_file = Path(measurement.get_energy_spectra_dir(),
                                        f"{item.text(0)}.no_foil.hist")
                     used_measurements.setdefault(measurement, []).append({
                             "cut_file": cut_file,
@@ -390,8 +387,7 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
                     item.file_name)
             child_count = item.childCount()
             if child_count > 0:  # Elemental Losses
-                dir_elo = os.path.join(
-                    self.measurement.directory_composition_changes, "Changes")
+                dir_elo = self.measurement.get_changes_dir()
                 for j in range(child_count):
                     item_child = item.child(j)
                     if item_child.checkState(0):
@@ -587,13 +583,11 @@ class EnergySpectrumWidget(QtWidgets.QWidget):
                 sbh.remove_progress_bar()
 
     def update_use_cuts(self):
+        """Update used cuts list with new Measurement cuts.
         """
-        Update used cuts list with new Measurement cuts.
-        """
-        changes_dir = Path(self.parent.obj.directory_composition_changes,
-                           "Changes")
+        changes_dir = self.measurement.get_changes_dir()
         df.update_cuts(
-            self.use_cuts, self.parent.obj.directory_cuts, changes_dir)
+            self.use_cuts, self.measurement.directory_cuts, changes_dir)
 
     def delete(self):
         """Delete variables and do clean up.
@@ -628,7 +622,7 @@ class EnergySpectrumWidget(QtWidgets.QWidget):
             files = "\t".join([os.path.relpath(tmp,
                                                self.measurement.directory)
                                for tmp in self.use_cuts])
-            file = os.path.join(self.measurement.directory_energy_spectra,
+            file = os.path.join(self.measurement.get_energy_spectra_dir(),
                                 self.save_file)
         else:
             files = "\t".join([str(tmp) for tmp in self.use_cuts])

--- a/dialogs/measurement/depth_profile.py
+++ b/dialogs/measurement/depth_profile.py
@@ -131,7 +131,7 @@ class DepthProfileDialog(QtWidgets.QDialog):
 
         try:
             use_cut = []
-            output_dir = self.measurement.directory_depth_profiles
+            output_dir = self.measurement.get_depth_profile_dir()
             elements = []
 
             sbh.reporter.report(10)
@@ -155,12 +155,10 @@ class DepthProfileDialog(QtWidgets.QDialog):
                         item_child = item.child(j)
                         if item_child.checkState(0):
                             name = item_child.file_name
-                            dir_e = Path(
-                                self.parent.obj.directory_composition_changes,
-                                "Changes")
+                            dir_e = self.measurement.get_changes_dir()
                             use_cut.append(Path(dir_e, name))
-                            element = Element.from_string(item_child.file_name.
-                                                          split(".")[1])
+                            element = Element.from_string(
+                                item_child.file_name.split(".")[1])
                             elements.append(element)
                             DepthProfileDialog.checked_cuts[m_name].\
                                 append(item_child.file_name)
@@ -518,7 +516,7 @@ class DepthProfileWidget(QtWidgets.QWidget):
         output_dir = os.path.relpath(self.output_dir,
                                      self.parent.obj.directory)
 
-        file = Path(self.parent.obj.directory_depth_profiles, self.save_file)
+        file = Path(self.parent.obj.get_depth_profile_dir(), self.save_file)
 
         with open(file, "wt") as fh:
             fh.write("{0}\n".format(output_dir))
@@ -535,10 +533,9 @@ class DepthProfileWidget(QtWidgets.QWidget):
         """
         Update used cuts list with new Measurement cuts.
         """
-        changes_dir = Path(self.parent.obj.directory_composition_changes,
-                           "Changes")
+        changes_dir = self.measurement.get_changes_dir()
         df.update_cuts(self.use_cuts,
-                       self.parent.obj.directory_cuts,
+                       self.measurement.directory_cuts,
                        changes_dir)
 
-        self.output_dir = self.parent.obj.directory_depth_profiles
+        self.output_dir = self.measurement.get_depth_profile_dir()

--- a/dialogs/measurement/settings.py
+++ b/dialogs/measurement/settings.py
@@ -146,23 +146,9 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
             try:
                 self.measurement.use_default_profile_settings = \
                     self.defaultSettingsCheckBox.isChecked()
-                if self.measurement.measurement_setting_file_name is None:
-                    file_name = "temp"
-                else:
-                    file_name = self.measurement.\
-                        measurement_setting_file_name
 
                 det_folder_path = Path(self.measurement.directory,
                                        "Detector")
-                measurement_settings_file_path = \
-                    Path(self.measurement.directory,
-                         f"{file_name}.measurement")
-
-                if self.measurement.detector is None:
-                    df.update_detector_settings(
-                        self.measurement,
-                        det_folder_path,
-                        measurement_settings_file_path)
 
                 # Set Detector object to settings widget
                 self.detector_settings_widget.obj = \
@@ -173,9 +159,9 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
                 self.detector_settings_widget.update_settings()
 
                 self.profile_settings_widget.update_settings()
-                self.measurement.detector.path = \
-                    Path(det_folder_path,
-                         f"{self.measurement.detector.name}.detector")
+                self.measurement.detector.path = Path(
+                    det_folder_path,
+                    f"{self.measurement.detector.name}.detector")
 
                 # Delete possible extra .measurement and .profile files
                 gf.remove_matching_files(
@@ -183,34 +169,7 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
                     exts={".measurement", ".profile"})
 
                 # Save general measurement settings parameters.
-                new_measurement_settings_file_path = Path(
-                    self.measurement.directory,
-                    self.measurement.measurement_setting_file_name +
-                    ".measurement")
-
-                self.measurement.measurement_to_file(
-                    new_measurement_settings_file_path)
-
-                # Save profile parameters
-                profile_file_path = Path(
-                    self.measurement.directory,
-                    f"{self.measurement.profile_name}.profile")
-                self.measurement.profile_to_file(profile_file_path)
-
-                # Save run parameters
-                self.measurement.run.to_file(
-                    new_measurement_settings_file_path)
-                # Save detector parameters
-                self.measurement.detector.to_file(
-                    self.measurement.detector.path,
-                    new_measurement_settings_file_path)
-
-                # Save target parameters
-                target_file_path = Path(
-                    self.measurement.directory,
-                    f"{self.measurement.target.name}.target")
-                self.measurement.target.to_file(
-                    target_file_path, new_measurement_settings_file_path)
+                self.measurement.to_file()
                 return True
             except TypeError:
                 QtWidgets.QMessageBox.question(

--- a/dialogs/measurement/settings.py
+++ b/dialogs/measurement/settings.py
@@ -178,7 +178,7 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
                          f"{self.measurement.detector.name}.detector")
 
                 # Delete possible extra .measurement and .profile files
-                gf.remove_files(
+                gf.remove_matching_files(
                     self.measurement.directory,
                     exts={".measurement", ".profile"})
 

--- a/dialogs/measurement/settings.py
+++ b/dialogs/measurement/settings.py
@@ -29,7 +29,6 @@ __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä " \
              "\n Sinikka Siironen"
 __version__ = "2.0"
 
-import shutil
 import time
 
 import dialogs.dialog_functions as df
@@ -37,8 +36,6 @@ import modules.general_functions as gf
 
 from pathlib import Path
 
-from modules.run import Run
-from modules.target import Target
 from modules.measurement import Measurement
 
 from PyQt5 import QtCore
@@ -72,8 +69,8 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         screen_geometry = QtWidgets.QDesktopWidget.availableGeometry(
             QtWidgets.QApplication.desktop())
-        self.resize(self.geometry().width() * 1.2,
-                    screen_geometry.size().height() * 0.8)
+        self.resize(int(self.geometry().width() * 1.2),
+                    int(screen_geometry.size().height() * 0.8))
         self.defaultSettingsCheckBox.stateChanged.connect(
             self.__change_used_settings)
         self.OKButton.clicked.connect(self.__save_settings_and_close)
@@ -90,25 +87,20 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
         )
 
         # Add detector settings view to the settings view
-        if self.measurement.detector:
-            detector_object = self.measurement.detector
-        else:
-            detector_object = self.measurement.request.default_detector
         self.detector_settings_widget = DetectorSettingsWidget(
-            detector_object, self.measurement.request, self.icon_manager,
-            self.measurement_settings_widget.tmp_run)
+            self.measurement.detector, self.measurement.request,
+            self.icon_manager, self.measurement_settings_widget.tmp_run)
 
         self.tabs.addTab(self.detector_settings_widget, "Detector")
 
-        if self.measurement.detector is not None:
-            self.defaultSettingsCheckBox.setCheckState(0)
-            self.measurement_settings_widget.nameLineEdit.setText(
-                self.measurement.measurement_setting_file_name)
-            self.measurement_settings_widget.descriptionPlainTextEdit \
-                .setPlainText(
-                    self.measurement.measurement_setting_file_description)
-            self.measurement_settings_widget.dateLabel.setText(time.strftime(
-                "%c %z %Z", time.localtime(self.measurement.modification_time)))
+        self.defaultSettingsCheckBox.setChecked(
+            self.measurement.use_default_profile_settings)
+        self.measurement_settings_widget.nameLineEdit.setText(
+            self.measurement.measurement_setting_file_name)
+        self.measurement_settings_widget.descriptionPlainTextEdit.setPlainText(
+                self.measurement.measurement_setting_file_description)
+        self.measurement_settings_widget.dateLabel.setText(time.strftime(
+            "%c %z %Z", time.localtime(self.measurement.modification_time)))
 
         # Add profile settings view to the settings view
         self.profile_settings_widget = ProfileSettingsWidget(self.measurement)
@@ -126,17 +118,12 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
             self.tabs.setEnabled(True)
 
     def __update_parameters(self):
-        """Update Measurement's Run, Detector and Target objects. If measurement
-        specific parameters are in use, save them into a file.
-        """
         if self.measurement_settings_widget.isotopeComboBox.currentIndex()\
                 == -1:
-            QtWidgets.QMessageBox.critical(self, "Warning",
-                                           "No isotope selected.\n\nPlease "
-                                           "select an isotope for the beam "
-                                           "element.",
-                                           QtWidgets.QMessageBox.Ok,
-                                           QtWidgets.QMessageBox.Ok)
+            QtWidgets.QMessageBox.critical(
+                self, "Warning",
+                "No isotope selected.\n\nPlease select an isotope for the beam "
+                "element.", QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
             return False
 
         if not self.measurement.measurement_setting_file_name:
@@ -145,125 +132,92 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
         if not self.measurement.profile_name:
             self.measurement.profile_name = self.measurement.name
 
-        check_box = self.defaultSettingsCheckBox
-        if check_box.isChecked():
-            # Use request settings
-            def_mesu = self.measurement.request.default_measurement
-            self.measurement.run = None
-            self.measurement.detector = None
-            self.measurement.use_default_profile_settings = True
-            self.measurement.measurement_setting_file_description = \
-                def_mesu.measurement_setting_file_description
-            self.measurement.target = None
+        # Check the target and detector angles
+        ok_pressed = self.measurement_settings_widget.check_angles()
+        if ok_pressed:
+            if not self.tabs.currentWidget().fields_are_valid:
+                QtWidgets.QMessageBox.critical(
+                    self, "Warning",
+                    "Some of the setting values have not been set.\n"
+                    "Please input values in fields indicated in red.",
+                    QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
+                return False
+            # Use Measurement specific settings
+            try:
+                self.measurement.use_default_profile_settings = \
+                    self.defaultSettingsCheckBox.isChecked()
+                if self.measurement.measurement_setting_file_name is None:
+                    file_name = "temp"
+                else:
+                    file_name = self.measurement.\
+                        measurement_setting_file_name
 
-            # Revert all profile parameters to default.
-            self.measurement.copy_settings_from(def_mesu)
+                det_folder_path = Path(self.measurement.directory,
+                                       "Detector")
+                measurement_settings_file_path = \
+                    Path(self.measurement.directory,
+                         f"{file_name}.measurement")
 
-            det_folder_path = Path(self.measurement.directory, "Detector")
-            if det_folder_path.exists():
-                # Remove Measurement specific Detector files
-                shutil.rmtree(det_folder_path)
+                if self.measurement.detector is None:
+                    df.update_detector_settings(
+                        self.measurement,
+                        det_folder_path,
+                        measurement_settings_file_path)
 
-            gf.remove_files(
-                self.measurement.directory,
-                exts={".measurement", ".profile", ".target"})
-            return True
-        else:
-            # Check the target and detector angles
-            ok_pressed = self.measurement_settings_widget.check_angles()
-            if ok_pressed:
-                if not self.tabs.currentWidget().fields_are_valid:
-                    QtWidgets.QMessageBox.critical(self, "Warning",
-                                                   "Some of the setting values "
-                                                   "have not been set.\n" +
-                                                   "Please input values in "
-                                                   "fields indicated in red.",
-                                                   QtWidgets.QMessageBox.Ok,
-                                                   QtWidgets.QMessageBox.Ok)
-                    return False
-                # Use Measurement specific settings
-                try:
-                    self.measurement.use_default_profile_settings = False
-                    if self.measurement.measurement_setting_file_name is None:
-                        file_name = "temp"
-                    else:
-                        file_name = self.measurement.\
-                            measurement_setting_file_name
+                # Set Detector object to settings widget
+                self.detector_settings_widget.obj = \
+                    self.measurement.detector
 
-                    if self.measurement.target is None:
-                        # Create default Target object for Measurement
-                        self.measurement.target = Target()
-                    if self.measurement.run is None:
-                        # Create default Run object for Measurement
-                        self.measurement.run = Run()
+                # Update settings
+                self.measurement_settings_widget.update_settings()
+                self.detector_settings_widget.update_settings()
 
-                    det_folder_path = Path(self.measurement.directory,
-                                           "Detector")
-                    measurement_settings_file_path = \
-                        Path(self.measurement.directory,
-                             f"{file_name}.measurement")
+                self.profile_settings_widget.update_settings()
+                self.measurement.detector.path = \
+                    Path(det_folder_path,
+                         f"{self.measurement.detector.name}.detector")
 
-                    if self.measurement.detector is None:
-                        df.update_detector_settings(
-                            self.measurement,
-                            det_folder_path,
-                            measurement_settings_file_path)
+                # Delete possible extra .measurement and .profile files
+                gf.remove_files(
+                    self.measurement.directory,
+                    exts={".measurement", ".profile"})
 
-                    # Set Detector object to settings widget
-                    self.detector_settings_widget.obj = \
-                        self.measurement.detector
+                # Save general measurement settings parameters.
+                new_measurement_settings_file_path = Path(
+                    self.measurement.directory,
+                    self.measurement.measurement_setting_file_name +
+                    ".measurement")
 
-                    # Update settings
-                    self.measurement_settings_widget.update_settings()
-                    self.detector_settings_widget.update_settings()
+                self.measurement.measurement_to_file(
+                    new_measurement_settings_file_path)
 
-                    self.profile_settings_widget.update_settings()
-                    self.measurement.detector.path = \
-                        Path(det_folder_path,
-                             f"{self.measurement.detector.name}.detector")
+                # Save profile parameters
+                profile_file_path = Path(
+                    self.measurement.directory,
+                    f"{self.measurement.profile_name}.profile")
+                self.measurement.profile_to_file(profile_file_path)
 
-                    # Delete possible extra .measurement and .profile files
-                    gf.remove_files(
-                        self.measurement.directory,
-                        exts={".measurement", ".profile"})
+                # Save run parameters
+                self.measurement.run.to_file(
+                    new_measurement_settings_file_path)
+                # Save detector parameters
+                self.measurement.detector.to_file(
+                    self.measurement.detector.path,
+                    new_measurement_settings_file_path)
 
-                    # Save general measurement settings parameters.
-                    new_measurement_settings_file_path = Path(
-                        self.measurement.directory,
-                        self.measurement.measurement_setting_file_name +
-                        ".measurement")
-                    self.measurement.measurement_to_file(
-                        new_measurement_settings_file_path)
-
-                    # Save run parameters
-                    self.measurement.run.to_file(
-                        new_measurement_settings_file_path)
-                    # Save detector parameters
-                    self.measurement.detector.to_file(
-                        self.measurement.detector.path,
-                        new_measurement_settings_file_path)
-
-                    # Save profile parameters
-                    profile_file_path = Path(
-                        self.measurement.directory,
-                        f"{self.measurement.profile_name}.profile")
-                    self.measurement.profile_to_file(profile_file_path)
-
-                    # Save target parameters
-                    target_file_path = Path(
-                        self.measurement.directory,
-                        f"{self.measurement.target.name}.target")
-                    self.measurement.target.to_file(
-                        target_file_path, new_measurement_settings_file_path)
-                    return True
-                except TypeError:
-                    QtWidgets.QMessageBox.question(self, "Warning",
-                                                   "Some of the setting values "
-                                                   "have not been set.\n" +
-                                                   "Please input setting values"
-                                                   " to save them.",
-                                                   QtWidgets.QMessageBox.Ok,
-                                                   QtWidgets.QMessageBox.Ok)
+                # Save target parameters
+                target_file_path = Path(
+                    self.measurement.directory,
+                    f"{self.measurement.target.name}.target")
+                self.measurement.target.to_file(
+                    target_file_path, new_measurement_settings_file_path)
+                return True
+            except TypeError:
+                QtWidgets.QMessageBox.question(
+                    self, "Warning",
+                    "Some of the setting values have not been set.\n"
+                    "Please input setting values to save them.",
+                    QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
         return False
 
     def __save_settings_and_close(self):

--- a/dialogs/request_settings.py
+++ b/dialogs/request_settings.py
@@ -188,41 +188,29 @@ class RequestSettingsDialog(QtWidgets.QDialog):
                 filter_func = lambda e: e.simulation.use_request_settings
             else:
                 filter_func = lambda e: e.use_default_settings
-            if not df.delete_element_simulations(self, self.request,
-                                                 msg="request settings",
-                                                 filter_func=filter_func):
+            if not df.delete_element_simulations(
+                    self, self.request, msg="request settings",
+                    filter_func=filter_func):
                 return False
 
         try:
             self.measurement_settings_widget.update_settings()
             self.profile_settings_widget.update_settings()
 
-            default_measurement_settings_file = Path(
+            measurement_file = Path(
                 self.request.default_measurement.directory,
                 "Default.measurement")
+            profile_file = Path(
+                self.request.default_measurement.directory, "Default.profile")
 
-            self.request.default_measurement.measurement_to_file(
-                default_measurement_settings_file)
-
-            self.request.default_measurement.profile_to_file(Path(
-                self.request.default_measurement.directory,
-                "Default.profile"))
-
-            self.request.default_measurement.run.to_file(
-                default_measurement_settings_file)
-            
-            self.request.default_target.to_file(
-                None, default_measurement_settings_file)
+            self.request.default_measurement.to_file(
+                measurement_file, profile_file=profile_file)
 
             # Detector settings
             self.detector_settings_widget.update_settings()
 
             # Simulation settings
             self.simulation_settings_widget.update_settings()
-
-            self.request.default_detector.to_file(
-                Path(self.request.default_detector_folder, "Default.detector"),
-                default_measurement_settings_file)
 
             self.request.default_simulation.to_file(
                 Path(self.request.default_folder, "Default.simulation"))

--- a/dialogs/request_settings.py
+++ b/dialogs/request_settings.py
@@ -72,8 +72,8 @@ class RequestSettingsDialog(QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         screen_geometry = \
             QDesktopWidget.availableGeometry(QApplication.desktop())
-        self.resize(self.geometry().width() * 1.2,
-                    screen_geometry.size().height() * 0.8)
+        self.resize(int(self.geometry().width() * 1.2),
+                    int(screen_geometry.size().height() * 0.8))
 
         self.main_window = main_window
         self.request = request
@@ -200,13 +200,17 @@ class RequestSettingsDialog(QtWidgets.QDialog):
             default_measurement_settings_file = Path(
                 self.request.default_measurement.directory,
                 "Default.measurement")
+
             self.request.default_measurement.measurement_to_file(
                 default_measurement_settings_file)
+
             self.request.default_measurement.profile_to_file(Path(
                 self.request.default_measurement.directory,
                 "Default.profile"))
+
             self.request.default_measurement.run.to_file(
                 default_measurement_settings_file)
+            
             self.request.default_target.to_file(
                 None, default_measurement_settings_file)
 

--- a/dialogs/simulation/element_simulation_settings.py
+++ b/dialogs/simulation/element_simulation_settings.py
@@ -73,8 +73,8 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
         self.tabs.setTabBarAutoHide(True)
         screen_geometry = QDesktopWidget \
             .availableGeometry(QApplication.desktop())
-        self.resize(self.geometry().width() * 1.2,
-                    screen_geometry.size().height() * 0.8)
+        self.resize(int(self.geometry().width() * 1.2),
+                    int(screen_geometry.size().height() * 0.8))
 
         self.OKButton.clicked.connect(self.update_settings_and_close)
         self.applyButton.clicked.connect(self.update_settings)
@@ -154,7 +154,7 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
 
         if self.element_simulation.name != self.sim_widget.name:
             # Remove current simu file if name has been changed
-            self.element_simulation.remove_file()
+            self.element_simulation.remove_files()
 
         self.element_simulation.use_default_settings = self.use_default_settings
         self.sim_widget.update_settings()

--- a/dialogs/simulation/optimization.py
+++ b/dialogs/simulation/optimization.py
@@ -154,10 +154,7 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
                                 file.rsplit('.', 1)[0]
                             all_cuts.append(file_name_without_suffix)
 
-                    for file_2 in os.listdir(
-                            os.path.join(
-                                measurement.directory_composition_changes,
-                                "Changes")):
+                    for file_2 in os.listdir(measurement.get_changes_dir()):
                         if file_2.endswith(".cut"):
                             file_name_without_suffix = \
                                 file_2.rsplit('.', 1)[0]
@@ -283,8 +280,8 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
                                         item.text(0) + ".cut")
                     else:
                         cut_file = Path(
-                            used_measurement.directory_composition_changes,
-                            "Changes", item.text(0) + ".cut")
+                            used_measurement.get_changes_dir(),
+                            f"{item.text(0)}.cut")
                     cut_file_found = True
                     break
             i += 1

--- a/dialogs/simulation/settings.py
+++ b/dialogs/simulation/settings.py
@@ -173,20 +173,8 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
             # Update simulation settings
             self.simulation.use_request_settings = \
                 self.use_request_settings
-            measurement_settings_file_path = Path(
-                self.simulation.directory,
-                f"{self.simulation.measurement_setting_file_name}.measurement")
-            target_file_path = Path(self.simulation.directory,
-                                    f"{self.simulation.target.name}.target")
-            det_folder_path = Path(self.simulation.directory, "Detector")
 
-            if self.simulation.run is None:
-                # Create a default Run for simulation
-                self.simulation.run = Run()
-            if self.simulation.detector is None:
-                df.update_detector_settings(self.simulation,
-                                            det_folder_path,
-                                            measurement_settings_file_path)
+            det_folder_path = Path(self.simulation.directory, "Detector")
 
             # Set Detector object to settings widget
             self.detector_settings_widget.obj = self.simulation.detector
@@ -194,54 +182,14 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
             # Update settings
             self.measurement_settings_widget.update_settings()
             self.detector_settings_widget.update_settings()
-            self.simulation.detector.path = \
-                Path(det_folder_path,
-                     f"{self.simulation.detector.name}.detector")
-
-            # Save measurement settings parameters.
-            new_measurement_settings_file_path = Path(
-                self.simulation.directory,
-                self.simulation.measurement_setting_file_name +
-                ".measurement")
-            general_obj = {
-                "name": self.simulation.measurement_setting_file_name,
-                "description":
-                    self.simulation.measurement_setting_file_description,
-                "modification_time":
-                    time.strftime("%c %z %Z", time.localtime(
-                        time.time())),
-                "modification_time_unix": time.time(),
-                "use_request_settings": self.simulation.use_request_settings
-            }
-
-            if new_measurement_settings_file_path.exists():
-                with open(new_measurement_settings_file_path) as mesu:
-                    obj = json.load(mesu)
-                obj["general"] = general_obj
-            else:
-                obj = {
-                    "general": general_obj
-                }
+            self.simulation.detector.path = Path(
+                det_folder_path, f"{self.simulation.detector.name}.detector")
 
             # Delete possible extra .measurement files
             gf.remove_matching_files(self.simulation.directory,
                                      exts={".measurement"})
 
-            # Write measurement settings to file
-            with open(new_measurement_settings_file_path, "w") as file:
-                json.dump(obj, file, indent=4)
-
-            self.simulation.to_file(self.simulation.path)
-
-            # Save Run object to file
-            self.simulation.run.to_file(new_measurement_settings_file_path)
-            # Save Detector object to file
-            self.simulation.detector.to_file(self.simulation.detector.path,
-                                             new_measurement_settings_file_path)
-
-            # Save Target object to file
-            self.simulation.target.to_file(target_file_path,
-                                           new_measurement_settings_file_path)
+            self.simulation.to_file()
             return True
 
         except TypeError:

--- a/dialogs/simulation/settings.py
+++ b/dialogs/simulation/settings.py
@@ -74,8 +74,8 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         screen_geometry = QtWidgets.QDesktopWidget.availableGeometry(
             QtWidgets.QApplication.desktop())
-        self.resize(self.geometry().width() * 1.2,
-                    screen_geometry.size().height() * 0.8)
+        self.resize(int(self.geometry().width() * 1.2),
+                    int(screen_geometry.size().height() * 0.8))
         self.defaultSettingsCheckBox.stateChanged.connect(
             self.__change_used_settings)
         self.OKButton.clicked.connect(self.__save_settings_and_close)
@@ -224,8 +224,8 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
                 }
 
             # Delete possible extra .measurement files
-            gf.remove_files(self.simulation.directory,
-                            exts={".measurement"})
+            gf.remove_matching_files(self.simulation.directory,
+                                     exts={".measurement"})
 
             # Write measurement settings to file
             with open(new_measurement_settings_file_path, "w") as file:

--- a/modules/beam.py
+++ b/modules/beam.py
@@ -31,6 +31,7 @@ __version__ = "2.0"
 from .base import AdjustableSettings
 from .base import MCERDParameterContainer
 from .element import Element
+from .enums import Profile
 
 
 class Beam(AdjustableSettings, MCERDParameterContainer):
@@ -39,7 +40,7 @@ class Beam(AdjustableSettings, MCERDParameterContainer):
     """
     def __init__(self, ion=None, energy=10, charge=4,
                  energy_distribution=0, spot_size=(3.0, 5.0), divergence=0,
-                 profile="Uniform"):
+                 profile=Profile.UNIFORM):
         """
         Initializes the Beam object.
 
@@ -62,7 +63,11 @@ class Beam(AdjustableSettings, MCERDParameterContainer):
         self.energy_distribution = energy_distribution
         self.spot_size = spot_size
         self.divergence = divergence
-        self.profile = profile
+
+        try:
+            self.profile = Profile(profile.lower())
+        except (ValueError, AttributeError):
+            self.profile = Profile.UNIFORM
 
     def get_mcerd_params(self):
         """Returns a list of strings that are passed as parameters for MCERD.

--- a/modules/depth_files.py
+++ b/modules/depth_files.py
@@ -65,7 +65,7 @@ class DepthFileGenerator:
                 created.
             tof_in_dir: path to directory where tof.in is located
         """
-        self.__new_cut_files = [gf.copy_cut_file_to_temp(f) for f in file_paths]
+        self.__new_cut_files = [gf.copy_file_to_temp(f) for f in file_paths]
         self.__output_path = Path(output_directory, prefix)
         if tof_in_dir is None:
             self.__tof_in_path = Path("tof.in")

--- a/modules/detector.py
+++ b/modules/detector.py
@@ -253,7 +253,7 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
 
     @classmethod
     def from_file(cls, detector_file_path: Path, measurement_file_path: Path,
-                  request, save=True):
+                  request, save_on_creation=True):
         """Initialize Detector from a JSON file.
 
         Args:
@@ -262,7 +262,7 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
             measurement_file_path: A file path to measurement settings file
                                    which has detector angles.
             request: Request object which has default detector angles.
-            save: Whether to save created detector or not.
+            save_on_creation: Whether to save created detector or not.
 
         Return:
             Detector object.
@@ -303,12 +303,13 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
             except AttributeError:
                 return cls(path=detector_file_path,
                            measurement_settings_file_path=measurement_file_path,
-                           foils=foils, save_on_creation=save, **detector)
+                           foils=foils, save_on_creation=save_on_creation,
+                           **detector)
 
         return cls(path=detector_file_path,
                    measurement_settings_file_path=measurement_file_path,
                    foils=foils, detector_theta=detector_theta,
-                   save_on_creation=save, **detector)
+                   save_on_creation=save_on_creation, **detector)
 
     def to_file(self, detector_file_path: Path, measurement_file_path: Path):
         """Save detector settings to a file.

--- a/modules/detector.py
+++ b/modules/detector.py
@@ -31,10 +31,10 @@ import json
 import os
 import shutil
 import time
+from typing import Optional
+from pathlib import Path
 
 from . import general_functions as gf
-
-from pathlib import Path
 
 from .base import Serializable
 from .base import AdjustableSettings
@@ -55,13 +55,12 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
     __slots__ = "name", "description", "date", "type", "foils",\
                 "tof_foils", "virtual_size", "tof_slope", "tof_offset",\
                 "angle_slope", "angle_offset", "path", "modification_time",\
-                "efficiency_directory", "timeres", \
-                "detector_theta", "_measurement_settings_file_path",
+                "efficiency_directory", "timeres", "detector_theta"
 
     EFFICIENCY_DIR = "Efficiency_files"
     USED_EFFICIENCIES_DIR = "Used_efficiencies"
 
-    def __init__(self, path, measurement_settings_file_path, name="Default",
+    def __init__(self, path, measurement_file, name="Default",
                  description="", modification_time=None,
                  detector_type=DetectorType.TOF,
                  foils=None, tof_foils=None, virtual_size=(2.0, 5.0),
@@ -73,8 +72,8 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         Args:
             path: Path to .detector file.
             name: Detector name.
-            measurement_settings_file_path: Path to measurement settings file
-                which has detector angles.
+            measurement_file: Path to a .measurement file which has detector
+                angles.
             description: Detector parameters description.
             modification_time: Modification time of detector file in Unix time.
             detector_type: Type of detector.
@@ -92,8 +91,6 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         self.path = Path(path)
 
         self.name = name
-        self._measurement_settings_file_path = Path(
-            measurement_settings_file_path)
         self.description = description
         if modification_time is None:
             self.modification_time = time.time()
@@ -139,13 +136,15 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         self.efficiency_directory = None
 
         if save_on_creation:
-            self.to_file(self.path, self._measurement_settings_file_path)
+            self.to_file(self.path, measurement_file)
 
     def update_directories(self, directory):
         """Creates directories if they do not exist and updates paths.
         Args:
             directory: Path to where all the detector information goes.
         """
+        # FIXME __init__ docstring states that path is the path to .detector
+        #   file, not the directory
         self.path = Path(directory)
         self.path.mkdir(exist_ok=True)
 
@@ -252,14 +251,14 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
             pass
 
     @classmethod
-    def from_file(cls, detector_file_path: Path, measurement_file_path: Path,
+    def from_file(cls, detector_file: Path, measurement_file: Path,
                   request, save_on_creation=True):
         """Initialize Detector from a JSON file.
 
         Args:
-            detector_file_path: A file path to JSON file containing the
+            detector_file: A file path to JSON file containing the
                                 detector parameters.
-            measurement_file_path: A file path to measurement settings file
+            measurement_file: A file path to measurement settings file
                                    which has detector angles.
             request: Request object which has default detector angles.
             save_on_creation: Whether to save created detector or not.
@@ -267,7 +266,7 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         Return:
             Detector object.
         """
-        with detector_file_path.open("r") as dfp:
+        with detector_file.open("r") as dfp:
             detector = json.load(dfp)
 
         detector["modification_time"] = detector.pop("modification_time_unix")
@@ -293,37 +292,35 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
 
         try:
             # Read .measurement file and update detector angle
-            with measurement_file_path.open("r") as mesu_file:
+            with measurement_file.open("r") as mesu_file:
                 measurement_obj = json.load(mesu_file)
             detector_theta = measurement_obj["geometry"]["detector_theta"]
-        except (KeyError, json.JSONDecodeError, OSError):
+        except (KeyError, json.JSONDecodeError, OSError, AttributeError):
             # Get default detector angle from default detector
             try:
                 detector_theta = request.default_detector.detector_theta
             except AttributeError:
-                return cls(path=detector_file_path,
-                           measurement_settings_file_path=measurement_file_path,
+                return cls(path=detector_file,
+                           measurement_file=measurement_file,
                            foils=foils, save_on_creation=save_on_creation,
                            **detector)
 
-        return cls(path=detector_file_path,
-                   measurement_settings_file_path=measurement_file_path,
+        return cls(path=detector_file, measurement_file=measurement_file,
                    foils=foils, detector_theta=detector_theta,
                    save_on_creation=save_on_creation, **detector)
 
-    def to_file(self, detector_file_path: Path, measurement_file_path: Path):
+    def to_file(self, detector_file: Path,
+                measurement_file: Optional[Path] = None):
         """Save detector settings to a file.
 
         Args:
-            detector_file_path: File in which the detector settings will be
+            detector_file: File in which the detector settings will be
                 saved.
-            measurement_file_path: File in which the detector_theta angle is
+            measurement_file: File in which the detector_theta angle is
                 saved.
         """
         # Delete possible extra .detector files
-        detector_file_path = Path(detector_file_path)
-        measurement_file_path = Path(measurement_file_path)
-        det_folder = detector_file_path.parent
+        det_folder = detector_file.parent
         det_folder.mkdir(exist_ok=True)
         gf.remove_matching_files(det_folder, exts={".detector"})
 
@@ -341,14 +338,14 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
             "modification_time_unix": timestamp
         }
 
-        with detector_file_path.open("w") as file:
+        with detector_file.open("w") as file:
             json.dump(obj, file, indent=4)
 
-        if measurement_file_path is None:
+        if measurement_file is None:
             return
         # Read .measurement to obj to update only detector angles
         try:
-            with measurement_file_path.open("r") as mesu:
+            with measurement_file.open("r") as mesu:
                 obj = json.load(mesu)
             try:
                 # Change existing detector theta
@@ -360,7 +357,7 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
             # Write new .measurement file
             obj = {"geometry": {"detector_theta": self.detector_theta}}
 
-        with measurement_file_path.open("w") as file:
+        with measurement_file.open("w") as file:
             json.dump(obj, file, indent=4)
 
     def get_mcerd_params(self):

--- a/modules/detector.py
+++ b/modules/detector.py
@@ -138,17 +138,15 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         if save_on_creation:
             self.to_file(self.path, measurement_file)
 
-    def update_directories(self, directory):
+    def update_directories(self, directory: Path):
         """Creates directories if they do not exist and updates paths.
         Args:
             directory: Path to where all the detector information goes.
         """
-        # FIXME __init__ docstring states that path is the path to .detector
-        #   file, not the directory
-        self.path = Path(directory)
-        self.path.mkdir(exist_ok=True)
+        self.path = directory / self.path.name
+        directory.mkdir(exist_ok=True)
 
-        self.efficiency_directory = Path(self.path, Detector.EFFICIENCY_DIR)
+        self.efficiency_directory = directory / Detector.EFFICIENCY_DIR
         self.efficiency_directory.mkdir(exist_ok=True)
 
     def update_directory_references(self, obj):
@@ -321,8 +319,7 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         """
         # Delete possible extra .detector files
         det_folder = detector_file.parent
-        det_folder.mkdir(exist_ok=True)
-        gf.remove_matching_files(det_folder, exts={".detector"})
+        det_folder.mkdir(parents=True, exist_ok=True)
 
         timestamp = time.time()
 

--- a/modules/detector.py
+++ b/modules/detector.py
@@ -325,7 +325,7 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         measurement_file_path = Path(measurement_file_path)
         det_folder = detector_file_path.parent
         det_folder.mkdir(exist_ok=True)
-        gf.remove_files(det_folder, exts={".detector"})
+        gf.remove_matching_files(det_folder, exts={".detector"})
 
         timestamp = time.time()
 
@@ -447,7 +447,7 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         destination = self.get_used_efficiencies_dir()
         destination.mkdir(exist_ok=True)
         # Remove previous files
-        gf.remove_files(destination, {".eff"})
+        gf.remove_matching_files(destination, {".eff"})
 
         for eff in self.get_efficiency_files(full_path=True):
             try:

--- a/modules/element_simulation.py
+++ b/modules/element_simulation.py
@@ -301,7 +301,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
 
         # Delete possible extra rec files.
         # TODO use name instead of startswith
-        gf.remove_files(
+        gf.remove_matching_files(
             self.directory, exts={".rec", ".sct"},
             filter_func=lambda x: x.startswith(old_name))
 
@@ -923,7 +923,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
         else:
             raise ValueError(f"Unknown optimization type: {optim_mode}.")
 
-        gf.remove_files(
+        gf.remove_matching_files(
             self.directory,
             exts={".recoil", ".erd", ".simu", ".scatter", ".rec"},
             filter_func=filter_func)
@@ -940,7 +940,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
             return any(file.startswith(pre) for pre in prefixes) and \
                 "opt" not in file
 
-        gf.remove_files(
+        gf.remove_matching_files(
             self.directory,
             exts={".recoil", ".erd", ".simu", ".scatter"},
             filter_func=filter_func)

--- a/modules/element_simulation.py
+++ b/modules/element_simulation.py
@@ -339,7 +339,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
     @classmethod
     def from_file(cls, request, prefix: str, simulation_folder: Path,
                   mcsimu_file_path: Path, profile_file_path: Path,
-                  sample=None, detector=None, simulation=None):
+                  sample=None, detector=None, simulation=None, run=None):
         """Initialize ElementSimulation from JSON files.
 
         Args:
@@ -356,6 +356,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
             detector: detector that is used when simulation is not run with
                 request settings.
             simulation: parent Simulation object of this ElementSimulation
+            run: ElementSimulation's run object
         """
         with mcsimu_file_path.open("r") as mcsimu_file:
             mcsimu = json.load(mcsimu_file)
@@ -444,7 +445,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
             optimization_recoils=optimized_recoils,
             optimized_fluence=optimized_fluence,
             main_recoil=main_recoil, sample=sample, detector=detector,
-            **kwargs, **mcsimu, simulation=simulation)
+            **kwargs, **mcsimu, simulation=simulation, run=run)
 
     def get_full_name(self):
         """Returns the full name of the ElementSimulation object.

--- a/modules/element_simulation.py
+++ b/modules/element_simulation.py
@@ -339,7 +339,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
     @classmethod
     def from_file(cls, request, prefix: str, simulation_folder: Path,
                   mcsimu_file_path: Path, profile_file_path: Path,
-                  sample=None, detector=None):
+                  sample=None, detector=None, simulation=None):
         """Initialize ElementSimulation from JSON files.
 
         Args:
@@ -355,6 +355,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
             sample: sample under which the parent simulation belongs to
             detector: detector that is used when simulation is not run with
                 request settings.
+            simulation: parent Simulation object of this ElementSimulation
         """
         with mcsimu_file_path.open("r") as mcsimu_file:
             mcsimu = json.load(mcsimu_file)
@@ -443,7 +444,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
             optimization_recoils=optimized_recoils,
             optimized_fluence=optimized_fluence,
             main_recoil=main_recoil, sample=sample, detector=detector,
-            **kwargs, **mcsimu)
+            **kwargs, **mcsimu, simulation=simulation)
 
     def get_full_name(self):
         """Returns the full name of the ElementSimulation object.
@@ -997,8 +998,11 @@ class ERDFileHandler:
         Return:
             new ERDFileHandler.
         """
-        full_paths = (Path(directory, file)
-                      for file in os.scandir(directory))
+        try:
+            full_paths = (Path(directory, file)
+                          for file in os.scandir(directory))
+        except OSError:
+            full_paths = []
         return cls(full_paths, recoil_element)
 
     def __iter__(self):

--- a/modules/energy_spectrum.py
+++ b/modules/energy_spectrum.py
@@ -65,7 +65,7 @@ class EnergySpectrum:
         self.__global_settings = self.__measurement.request.global_settings
         self.__cut_files = cut_files
         self.__spectrum_width = spectrum_width
-        self.__directory_es = measurement.directory_energy_spectra
+        self.__directory_es = measurement.get_energy_spectra_dir()
         # TODO ATM tof_in is generated twice when calculating espes. This
         #      should be refactored
         self.__measurement.generate_tof_in(no_foil=no_foil)
@@ -125,7 +125,7 @@ class EnergySpectrum:
             save_output = self.__global_settings.is_es_output_saved()
             count = len(self.__cut_files)
             
-            os.makedirs(self.__directory_es, exist_ok=True)
+            self.__directory_es.mkdir(exist_ok=True)
             
             for i, cut_file in enumerate(self.__cut_files):
                 filename_split = os.path.basename(cut_file).split('.')
@@ -172,7 +172,8 @@ class EnergySpectrum:
             logger_name: name of a logging entity
 
         Returns:
-            Returns cut file as list transformed through Arstila's tof_list program.
+            Returns cut file as list transformed through Arstila's tof_list
+            program.
         """
         bin_dir = gf.get_bin_dir()
 
@@ -201,7 +202,7 @@ class EnergySpectrum:
                 if directory is None:
                     directory = Path.cwd() / "energy_spectrum_output"
 
-                os.makedirs(directory, exist_ok=True)
+                directory.mkdir(exist_ok=True)
 
                 if no_foil:
                     foil_txt = ".no_foil"

--- a/modules/energy_spectrum.py
+++ b/modules/energy_spectrum.py
@@ -33,14 +33,14 @@ import logging
 import os
 
 from . import general_functions as gf
-
+from .measurement import Measurement
 from .element import Element
 
 
 class EnergySpectrum:
-    """ Class for energy spectrum.
+    """Class for energy spectrum.
     """
-    def __init__(self, measurement, cut_files, spectrum_width,
+    def __init__(self, measurement: Measurement, cut_files, spectrum_width,
                  progress=None, no_foil=False):
         """Inits energy spectrum
         

--- a/modules/energy_spectrum.py
+++ b/modules/energy_spectrum.py
@@ -31,11 +31,20 @@ __version__ = "2.0"
 
 import logging
 import os
+import subprocess
+import platform
+
+import numpy as np
+
+from pathlib import Path
 
 from . import general_functions as gf
+from .parsing import ToFListParser
 from .measurement import Measurement
 from .element import Element
 
+
+# TODO rename and refactor functions
 
 class EnergySpectrum:
     """Class for energy spectrum.
@@ -57,31 +66,49 @@ class EnergySpectrum:
         self.__cut_files = cut_files
         self.__spectrum_width = spectrum_width
         self.__directory_es = measurement.directory_energy_spectra
-        # tof_list files here just in case progress bar might happen to
-        # 'disappear'.
         # TODO ATM tof_in is generated twice when calculating espes. This
         #      should be refactored
         self.__measurement.generate_tof_in(no_foil=no_foil)
-        self.__tof_listed_files = self.__load_cuts(no_foil=no_foil,
-                                                   progress=progress)
+        self.__tof_listed_files = self.__load_cuts(
+            no_foil=no_foil, progress=progress)
+
+    @staticmethod
+    def calculate_measured_spectra(measurement: Measurement, cut_files,
+                                   spectrum_width, progress=None,
+                                   no_foil=False):
+        """Calculates the measured energy spectra for the given .cut files.
+
+        Args:
+            measurement: Measurement whose settings will be used when
+                calculating spectra
+            cut_files: collection of .cut file paths
+            spectrum_width: Float representing energy spectrum graph width.
+            progress: ProgressReporter object.
+            no_foil: whether foil thickness is set to 0 when running tof_list
+
+        Returns:
+            energy spectra as a dictionary
+        """
+        es = EnergySpectrum(measurement, cut_files, spectrum_width,
+                            progress=progress, no_foil=no_foil)
+        return es.calculate_spectrum(no_foil=no_foil)
 
     def calculate_spectrum(self, no_foil=False):
         """Calculate energy spectrum data from cut files.
 
         Args:
             no_foil: whether foil thickness is set to 0 or original foil
-                     thickness is used
+                thickness is used
         
-        Returns list of cut files 
+        Returns:
+            energy spectra as a dictionary
         """
         # First generate tof.in file to match the measurement whose energy
         # spectra are drawn.
         self.__measurement.generate_tof_in(no_foil=no_foil)
-        return gf.calculate_spectrum(self.__tof_listed_files,
-                                     self.__spectrum_width,
-                                     self.__measurement,
-                                     self.__directory_es,
-                                     no_foil=no_foil)
+        return EnergySpectrum._calculate_spectrum(
+            self.__tof_listed_files, self.__spectrum_width, self.__measurement,
+            self.__directory_es, no_foil=no_foil)
 
     def __load_cuts(self, no_foil=False, progress=None):
         """Loads cut files through tof_list into list.
@@ -103,24 +130,154 @@ class EnergySpectrum:
             for i, cut_file in enumerate(self.__cut_files):
                 filename_split = os.path.basename(cut_file).split('.')
                 element = Element.from_string(filename_split[1])
+
                 if len(filename_split) == 5:  # Regular cut file
-                    key = "{0}.{1}.{2}".format(element,
-                                               filename_split[2],
-                                               filename_split[3])
+                    # TODO name the split parts
+                    key = "{0}.{1}.{2}".format(
+                        element, filename_split[2], filename_split[3])
                 else:  # Elemental Losses cut file
-                    key = "{0}.{1}.{2}.{3}".format(element,
-                                                   filename_split[2],
-                                                   filename_split[3],
-                                                   filename_split[4])
-                cut_dict[key] = gf.tof_list(cut_file,
-                                            self.__directory_es,
-                                            save_output=save_output,
-                                            no_foil=no_foil,
-                                            logger_name=self.__measurement.name)
+                    key = "{0}.{1}.{2}.{3}".format(
+                        element, filename_split[2], filename_split[3],
+                        filename_split[4])
+
+                cut_dict[key] = EnergySpectrum.tof_list(
+                    cut_file, self.__directory_es, save_output=save_output,
+                    no_foil=no_foil, logger_name=self.__measurement.name)
 
                 if progress is not None:
-                    progress.report(i / count * 100)
+                    progress.report(i / count * 90)
         except Exception as e:
             msg = f"Could not calculate Energy Spectrum: {e}."
             logging.getLogger(self.__measurement.name).error(msg)
+        finally:
+            if progress is not None:
+                progress.report(100)
         return cut_dict
+
+    @staticmethod
+    def tof_list(cut_file: Path, directory: Path = None, save_output=False,
+                 no_foil=False, logger_name=None):
+        """ToF_list
+
+        Arstila's tof_list executables interface for Python.
+
+        Args:
+            cut_file: A Path representing cut file to be ran through tof_list.
+            directory: A Path representing measurement's energy spectrum
+                directory.
+            save_output: A boolean representing whether tof_list output is
+                saved.
+            no_foil: whether foil thickness was used when .cut files were
+                generated. This affects the file path when saving output
+            logger_name: name of a logging entity
+
+        Returns:
+            Returns cut file as list transformed through Arstila's tof_list program.
+        """
+        bin_dir = gf.get_bin_dir()
+
+        if not cut_file:
+            return []
+
+        new_cut_file = gf.copy_file_to_temp(cut_file)
+        tof_parser = ToFListParser()
+
+        try:
+            if platform.system() == 'Windows':
+                executable = str(bin_dir / "tof_list.exe")
+            else:
+                executable = "./tof_list"
+
+            cmd = executable, str(new_cut_file)
+            p = subprocess.Popen(
+                cmd, cwd=bin_dir, stdout=subprocess.PIPE,
+                universal_newlines=True)
+
+            raw_output = iter(p.stdout.readline, "")
+            parsed_output = tof_parser.parse_strs(
+                raw_output, method="row", ignore="w")
+
+            if save_output:
+                if directory is None:
+                    directory = Path.cwd() / "energy_spectrum_output"
+
+                os.makedirs(directory, exist_ok=True)
+
+                if no_foil:
+                    foil_txt = ".no_foil"
+                else:
+                    foil_txt = ""
+
+                es_file = directory / f"{cut_file.stem}{foil_txt}.tof_list"
+                ls = []
+                with es_file.open("w") as file:
+                    for row in parsed_output:
+                        file.write(f"{' '.join(str(col) for col in row)}\n")
+                        ls.append(row)
+                return ls
+            return list(parsed_output)
+        except Exception as e:
+            msg = f"Error in tof_list: {e}"
+            if logger_name is not None:
+                logging.getLogger(logger_name).error(msg)
+            else:
+                print(msg)
+            return []
+        finally:
+            gf.remove_files(new_cut_file)
+
+    @staticmethod
+    def _calculate_spectrum(tof_listed_files, spectrum_width: float,
+                            measurement: Measurement,
+                            directory_es: Path, no_foil=False):
+        """Calculate energy spectrum data from .tof_list files and writes the
+        results to .hist files.
+
+        Args:
+            tof_listed_files: contents of .tof_list files belonging to the
+                              measurement as a dict.
+            spectrum_width: TODO
+            measurement: measurement which the .tof_list files belong to
+            directory_es: directory
+            no_foil: whether foil thickeness was set to 0 or not. This affects
+                     the file name
+
+        Returns:
+            contents of .hist files as a dict
+        """
+        histed_files = {}
+        keys = tof_listed_files.keys()
+        invalid_keys = set()
+
+        for key in keys:
+            histed_files[key] = gf.hist(
+                tof_listed_files[key], spectrum_width, 3)
+            if not histed_files[key]:
+                invalid_keys.add(key)
+                continue
+            first_val = (histed_files[key][0][0] - spectrum_width, 0)
+            last_val = (histed_files[key][-1][0] + spectrum_width, 0)
+            histed_files[key].insert(0, first_val)
+            histed_files[key].append(last_val)
+
+        for key in keys:
+            if key in invalid_keys:
+                continue
+            file = measurement.name
+            histed = histed_files[key]
+
+            if no_foil:
+                foil_txt = ".no_foil"
+            else:
+                foil_txt = ""
+
+            filename = Path(directory_es,
+                            "{0}.{1}{2}.hist".format(os.path.splitext(file)[0],
+                                                     key,
+                                                     foil_txt))
+            numpy_array = np.array(histed,
+                                   dtype=[('float', float), ('int', int)])
+
+            np.savetxt(filename, numpy_array, delimiter=" ", fmt="%5.5f %6d")
+
+        return histed_files

--- a/modules/enums.py
+++ b/modules/enums.py
@@ -181,3 +181,12 @@ class ToFEColorScheme(str, Enum):
         if self is ToFEColorScheme.GREYSCALE:
             return "Greyscale"
         return "Greyscale (inverted)"
+
+
+@enum.unique
+class Profile(str, Enum):
+    UNIFORM = "uniform"
+    GAUSSIAN = "gaussian"
+
+    def __str__(self):
+        return self.value.capitalize()

--- a/modules/general_functions.py
+++ b/modules/general_functions.py
@@ -43,6 +43,8 @@ import time
 from timeit import default_timer as timer
 from pathlib import Path
 from decimal import Decimal
+from typing import Dict
+from typing import List
 
 
 # TODO this could still be organized into smaller modules
@@ -136,6 +138,28 @@ def remove_matching_files(directory, exts=None, filter_func=None):
         pass
 
 
+def find_files_by_extension(directory: Path, *exts) -> Dict[str, List[Path]]:
+    """Searches given directory and returns files that have given extensions.
+
+    Args:
+        directory: a Path object
+        exts: collection of files extensions to look for
+
+    Return:
+        dictionary where keys are strings (file extensions) and values are
+        lists of Path objects.
+    """
+    search_dict = {
+        ext: [] for ext in exts
+    }
+    for entry in os.scandir(directory):
+        path = Path(entry.path)
+        suffix = path.suffix
+        if suffix in search_dict and path.is_file():
+            search_dict[suffix].append(path)
+    return search_dict
+
+
 def hist(data, width=1.0, col=1):
     """Format data into slices of given width.
 
@@ -195,7 +219,7 @@ def copy_file_to_temp(file: Path) -> Path:
     return tmp_file
 
 
-def convert_mev_to_joule(energy_in_MeV):
+def convert_mev_to_joule(energy_in_MeV: float) -> float:
     """Converts MeV (mega electron volts) to joules.
     
     Args:
@@ -209,7 +233,7 @@ def convert_mev_to_joule(energy_in_MeV):
     return float(energy_in_MeV) * 1000000.0 / joule
 
 
-def convert_amu_to_kg(mass_in_amus):
+def convert_amu_to_kg(mass_in_amus: float) -> float:
     """Converts amus (atomic mass units) to kilograms.
     
     Args:

--- a/modules/general_functions.py
+++ b/modules/general_functions.py
@@ -33,20 +33,16 @@ __version__ = "2.0"
 
 import bisect
 import hashlib
-import numpy as np
 import os
 import platform
 import shutil
 import subprocess
 import tempfile
-import logging
 import time
 
 from timeit import default_timer as timer
 from pathlib import Path
 from decimal import Decimal
-
-from .parsing import ToFListParser
 
 
 # TODO this could still be organized into smaller modules
@@ -94,23 +90,20 @@ def rename_file(old_path, new_name):
     return new_file
 
 
-def remove_file(file_path):
-    """Removes file or directory.
+def remove_files(*file_paths):
+    """Removes files.
 
     Args:
-        file_path: Path of file or directory to remove.
+        *file_paths: file paths to remove
     """
-    if not file_path:
-        return
-    try:
-        # shutil.rmtree(file_path)
-        os.remove(file_path)
-    except Exception as e:
-        # Removal failed
-        print(e)
+    for f in file_paths:
+        try:
+            f.unlink()
+        except OSError:
+            pass
 
 
-def remove_files(directory, exts=None, filter_func=None):
+def remove_matching_files(directory, exts=None, filter_func=None):
     """Removes all files in a directory that match given conditions.
 
     Args:
@@ -121,6 +114,7 @@ def remove_files(directory, exts=None, filter_func=None):
             provided, only the files that have the correct extension and match
             the filter_func condition will be deleted.
     """
+    # TODO should also allow deleting files while not declaring extensions
     if not exts:
         return
     if filter_func is None:
@@ -182,165 +176,23 @@ def hist(data, width=1.0, col=1):
     return hist_list
 
 
-def calculate_spectrum(tof_listed_files, spectrum_width, measurement,
-                       directory_es, no_foil=False):
-    """Calculate energy spectrum data from .tof_list files and writes the
-    results to .hist files.
+def copy_file_to_temp(file: Path) -> Path:
+    """Copy file into temp directory.
 
     Args:
-        tof_listed_files: contents of .tof_list files belonging to the
-                          measurement as a dict.
-        spectrum_width: TODO
-        measurement: measurement which the .tof_list files belong to
-        directory_es: directory
-        no_foil: whether foil thickeness was set to 0 or not. This affects
-                 the file name
-
-    Returns:
-        contents of .hist files as a dict
-    """
-    histed_files = {}
-    keys = tof_listed_files.keys()
-    invalid_keys = set()
-
-    for key in keys:
-        histed_files[key] = hist(tof_listed_files[key],
-                                 spectrum_width, 3)
-        if not histed_files[key]:
-            invalid_keys.add(key)
-            continue
-        first_val = (histed_files[key][0][0] - spectrum_width, 0)
-        last_val = (histed_files[key][-1][0] + spectrum_width, 0)
-        histed_files[key].insert(0, first_val)
-        histed_files[key].append(last_val)
-
-    for key in keys:
-        if key in invalid_keys:
-            continue
-        file = measurement.name
-        histed = histed_files[key]
-
-        if no_foil:
-            foil_txt = ".no_foil"
-        else:
-            foil_txt = ""
-
-        filename = Path(directory_es,
-                        "{0}.{1}{2}.hist".format(os.path.splitext(file)[0],
-                                                 key,
-                                                 foil_txt))
-        numpy_array = np.array(histed, dtype=[('float', float), ('int', int)])
-
-        np.savetxt(filename, numpy_array, delimiter=" ", fmt="%5.5f %6d")
-
-    return histed_files
-
-
-def copy_cut_file_to_temp(cut_file) -> Path:
-    """
-    Copy cut file into temp directory.
-
-    Args:
-        cut_file: Cut file to copy.
+        file: path to the file to copy.
 
     Return:
-        Path to the cut file in temp directory.
+        Path to the file in temp directory.
     """
-    # Move cut file to temp folder, at least in Windows tof_list works
-    # properly when cut file is there.
-    # TODO: check that this works in mac and Linux
-    cut_file_name = Path(cut_file).name
+    fname = Path(file).name
 
     # OS specific directory where temporary MCERD files will be stored.
     # In case of Linux and Mac this will be /tmp and in Windows this will
     # be the C:\Users\<username>\AppData\Local\Temp.
-    tmp = tempfile.gettempdir()
-
-    new_cut_file = Path(tmp, cut_file_name)
-    shutil.copyfile(cut_file, new_cut_file)
-    return new_cut_file
-
-
-def tof_list(cut_file, directory, save_output=False, no_foil=False,
-             logger_name=None):
-    """ToF_list
-
-    Arstila's tof_list executables interface for Python.
-
-    Args:
-        cut_file: A string representing cut file to be ran through tof_list.
-        directory: A string representing measurement's energy spectrum
-                   directory.
-        save_output: A boolean representing whether tof_list output is saved.
-        no_foil: whether foil thickness was used when .cut files were generated.
-                 This affects the file path when saving output
-        logger_name: name of a logging entity
-
-    Returns:
-        Returns cut file as list transformed through Arstila's tof_list program.
-    """
-    bin_dir = get_bin_dir()
-
-    if not cut_file:
-        return []
-
-    new_cut_file = copy_cut_file_to_temp(cut_file)
-    tof_parser = ToFListParser()
-
-    try:
-        if platform.system() == 'Windows':
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            command = (str(bin_dir / "tof_list.exe"), str(new_cut_file))
-            stdout = subprocess.check_output(command,
-                                             cwd=bin_dir,
-                                             shell=True,
-                                             startupinfo=startupinfo)
-        else:
-            command = "{0} {1}".format("./tof_list", str(new_cut_file))
-            p = subprocess.Popen(command.split(' ', 1),
-                                 cwd=bin_dir,
-                                 stdin=subprocess.PIPE,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
-            stdout, _ = p.communicate()
-
-        tof_output = list(tof_parser.parse_strs(
-            stdout.decode().splitlines(), method="row", ignore="w"))
-
-        if save_output:
-            if not directory:
-                directory = Path(
-                    os.path.realpath(os.path.curdir), "energy_spectrum_output")
-
-            os.makedirs(directory, exist_ok=True)
-
-            if no_foil:
-                foil_txt = ".no_foil"
-            else:
-                foil_txt = ""
-
-            directory_es_file = Path(
-                directory,
-                "{0}{1}.tof_list".format(Path(cut_file).stem,
-                                         foil_txt))
-            numpy_array = np.array(
-                tof_output, dtype=[
-                    ('float1', float), ('float2', float), ('float3', float),
-                    ('int1', int), ('float4', float), ('string', np.str_, 3),
-                    ('float5', float), ('int2', int)])
-            np.savetxt(directory_es_file, numpy_array, delimiter=" ",
-                       fmt="%5.1f %5.1f %10.5f %3d %8.4f %s %6.3f %d")
-        return tof_output
-    except Exception as e:
-        msg = f"Error in tof_list: {e}"
-        if logger_name is not None:
-            logging.getLogger(logger_name).error(msg)
-        else:
-            print(msg)
-        return []
-    finally:
-        remove_file(new_cut_file)
+    tmp_file = Path(tempfile.gettempdir(), fname)
+    shutil.copyfile(file, tmp_file)
+    return tmp_file
 
 
 def convert_mev_to_joule(energy_in_MeV):
@@ -584,53 +436,14 @@ def find_nearest(x, lst):
         return before
 
 
-def calculate_new_point(previous_point, new_x, next_point,
-                        area_points):
-    """
-    Calculate a new point whose x coordinate is given, between previous
-    and next point.
-
-    Args:
-        previous_point: Previous point.
-        new_x: X coordinate for new point.
-        next_point: Next point.
-        area_points: List of points where a new point is added.
-    """
-    try:
-        previous_x = previous_point.get_x()
-        previous_y = previous_point.get_y()
-
-        next_x = next_point.get_x()
-        next_y = next_point.get_y()
-    except AttributeError:
-        previous_x = previous_point[0]
-        previous_y = previous_point[1]
-        next_x = next_point[0]
-        next_y = next_point[1]
-
-    x_diff = round(next_x - previous_x, 4)
-    y_diff = round(next_y - previous_y, 4)
-
-    if x_diff == 0.0:
-        # If existing points are close enough
-        return
-
-    k = y_diff / x_diff
-    new_y = k * new_x - k * previous_x + previous_y
-
-    new_point = (new_x, new_y)
-    area_points.append(new_point)
-
-
-def uniform_espe_lists(lists, channel_width):
-    """
-    Modify given energy spectra lists to have the same amount of items.
+def uniform_espe_lists(espe1, espe2, channel_width=0.025):
+    """Modify given energy spectra lists to have the same amount of items.
 
     Return:
         Modified lists.
     """
-    first = lists[0]
-    second = lists[1]
+    first = espe1
+    second = espe2
     # check if first x values don't match
     # add zero values to the one missing the x values
     if second[0][0] < first[0][0]:
@@ -762,7 +575,4 @@ def get_bin_dir() -> Path:
 def get_data_dir() -> Path:
     """Returns absolute path to Potku's data directory.
     """
-    # TODO maybe add -DDEVELOPER_MODE_ENABLE=ON option to Jibal's CMake
-    #   configuration and change data dir to external/data instead of
-    #   external/share
     return _get_external_dir() / "share"

--- a/modules/mcerd.py
+++ b/modules/mcerd.py
@@ -28,7 +28,6 @@ __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä \n" \
              "Sinikka Siironen \n Juhani Sundell"
 __version__ = "2.0"
 
-import os
 import platform
 import shutil
 import subprocess
@@ -445,28 +444,25 @@ class MCERD:
         Args:
             destination: Destination folder.
         """
-        shutil.copy(self.result_file, destination)
-        shutil.copy(self.recoil_file, destination)
+        try:
+            shutil.copy(self.result_file, destination)
+            shutil.copy(self.recoil_file, destination)
+        except OSError:
+            # TODO log
+            pass
 
     def delete_unneeded_files(self):
         """
         Delete mcerd files that are not needed anymore.
         """
-        def delete_files(*files):
-            for f in files:
-                try:
-                    f.unlink()
-                except OSError:
-                    pass
-
-        delete_files(
+        gf.remove_files(
             self.__command_file, self.__detector_file, self.__target_file,
             self.__foils_file)
 
         def filter_func(f):
             return f.startswith(self.__rec_filename)
 
-        gf.remove_files(
+        gf.remove_matching_files(
             self.sim_dir, exts={".out", ".dat", ".range", ".pre"},
             filter_func=filter_func)
 

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -283,7 +283,9 @@ class Measurement(Logger, AdjustableSettings, Serializable):
         self.tab_id = tab_id
 
         self.request = request  # To which request be belong to
-        self.path = Path(path)
+        self.sample = sample
+
+        self.path = Path(path)  # TODO rename this to info_file
         self.name = name
         self.description = description
         if modification_time is None:
@@ -291,8 +293,7 @@ class Measurement(Logger, AdjustableSettings, Serializable):
         else:
             self.modification_time = modification_time
 
-        self.sample = sample
-
+        # TODO rename 'measurement_setting_file_name' to 'measurement_file_name'
         self.measurement_setting_file_name = measurement_setting_file_name
         if not self.measurement_setting_file_name:
             self.measurement_setting_file_name = name
@@ -337,7 +338,7 @@ class Measurement(Logger, AdjustableSettings, Serializable):
         if detector is None:
             self.detector = Detector(
                 self.directory / "Detector" / "measurement.detector",
-                self.measurement_setting_file_name,
+                self.get_measurement_file(),
                 save_on_creation=save_on_creation)
         else:
             self.detector = detector
@@ -359,6 +360,13 @@ class Measurement(Logger, AdjustableSettings, Serializable):
         """
         detector, *_ = self._get_used_settings()
         return detector
+
+    def get_measurement_file(self) -> Path:
+        """Returns the path to .measurement file that contains the settings
+        of this Measurement.
+        """
+        return Path(self.path.parent,
+                    f"{self.measurement_setting_file_name}.measurement")
 
     def update_folders_and_selector(self, selector_cls=None):
         """Update folders and selector. Initializes a new selector if

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -947,20 +947,6 @@ class Measurement(Logger, AdjustableSettings, Serializable):
         """
         self.selector.remove_selected()
 
-    def delete_all_cuts(self):
-        """
-        Delete all cuts from cut folder.
-
-        Return:
-            If something was deletd or not.
-        """
-        deleted = False
-        for file in os.listdir(self.directory_cuts):
-            file_path = Path(self.directory_cuts, file)
-            gf.remove_file(file_path)
-            deleted = True
-        return deleted
-
     def save_cuts(self, progress=None):
         """ Save cut files
         
@@ -1028,10 +1014,10 @@ class Measurement(Logger, AdjustableSettings, Serializable):
         """
         Remove old cut files.
         """
-        gf.remove_files(self.directory_cuts, exts={".cut"})
+        gf.remove_matching_files(self.directory_cuts, exts={".cut"})
         directory_changes = Path(
             self.directory_composition_changes, "Changes")
-        gf.remove_files(directory_changes, exts={".cut"})
+        gf.remove_matching_files(directory_changes, exts={".cut"})
 
     def get_cut_files(self):
         """ Get cut files from a measurement.

--- a/modules/nsgaii.py
+++ b/modules/nsgaii.py
@@ -156,11 +156,10 @@ class Nsgaii(Observable):
 
         self.element_simulation.optimized_fluence = None
 
-        es = EnergySpectrum(self.measurement, [self.cut_file],
-                            self.channel_width, no_foil=True)
+        EnergySpectrum.calculate_measured_spectra(
+            self.measurement, [self.cut_file], self.channel_width, no_foil=True)
 
         # TODO maybe just use he value returned by calc_spectrum?
-        es.calculate_spectrum(no_foil=True)
         # Add result files
         hist_file = Path(self.measurement.directory_energy_spectra,
                          f"{self.cut_file.stem}.no_foil.hist")
@@ -368,8 +367,8 @@ class Nsgaii(Observable):
         if optim_espe:
             # Make spectra the same size
             optim_espe, measured_espe = gf.uniform_espe_lists(
-                [optim_espe, self.measured_espe],
-                self.element_simulation.channel_width)
+                optim_espe, self.measured_espe,
+                channel_width=self.element_simulation.channel_width)
 
             # Find the area between simulated and measured energy
             # spectra
@@ -1404,7 +1403,8 @@ def get_optim_espe(elem_sim: ElementSimulation,
 def calculate_change(espe1, espe2, channel_width):
     if not espe1 or not espe2:
         return math.inf
-    uniespe1, uniespe2 = gf.uniform_espe_lists([espe1, espe2], channel_width)
+    uniespe1, uniespe2 = gf.uniform_espe_lists(
+        espe1, espe2, channel_width=channel_width)
 
     # Calculate distance between energy spectra
     # TODO move this to math_functions

--- a/modules/nsgaii.py
+++ b/modules/nsgaii.py
@@ -161,7 +161,7 @@ class Nsgaii(Observable):
 
         # TODO maybe just use he value returned by calc_spectrum?
         # Add result files
-        hist_file = Path(self.measurement.directory_energy_spectra,
+        hist_file = Path(self.measurement.get_energy_spectra_dir(),
                          f"{self.cut_file.stem}.no_foil.hist")
 
         parser = CSVParser((0, float), (1, float))

--- a/modules/request.py
+++ b/modules/request.py
@@ -195,45 +195,27 @@ class Request(ElementSimulationContainer):
     def _create_default_measurement(self, save_on_creation) -> Measurement:
         """Returns default measurement.
         """
-        measurement_info_path = Path(self.default_folder, "Default.info")
-        if measurement_info_path.exists():
+        info_path = Path(self.default_folder, "Default.info")
+        if info_path.exists():
             # Read measurement from file
             measurement = Measurement.from_file(
-                measurement_info_path,
+                info_path,
                 Path(self.default_folder, "Default.measurement"),
                 Path(self.default_folder, "Default.profile"),
                 self)
             self.default_run = Run.from_file(self.default_measurement_file_path)
         else:
             # Create default measurement for request
-            default_info_path = Path(self.default_folder, "Default.info")
             measurement = Measurement(
-                self, path=default_info_path, run=self.default_run,
+                self, path=info_path, run=self.default_run,
                 detector=self.default_detector,
                 description="This is a default measurement.",
                 profile_description="These are default profile parameters.",
                 measurement_setting_file_description="These are default "
                                                      "measurement "
                                                      "parameters.",
-                use_default_profile_settings=False)
-            if save_on_creation:
-                # TODO should be mesu init param
-                measurement.info_to_file(Path(
-                    self.default_folder, f"{measurement.name}.info"))
-
-                measurement.measurement_to_file(Path(
-                    self.default_folder,
-                    measurement.measurement_setting_file_name
-                    + ".measurement"))
-
-                measurement.profile_to_file(Path(
-                    self.default_folder,
-                    f"{measurement.profile_name}.profile"))
-
-                measurement.run.to_file(Path(
-                    self.default_folder,
-                    measurement.measurement_setting_file_name +
-                    ".measurement"))
+                use_default_profile_settings=False,
+                save_on_creation=save_on_creation)
 
         return measurement
 

--- a/modules/request.py
+++ b/modules/request.py
@@ -286,9 +286,10 @@ class Request(ElementSimulationContainer):
             sim = Simulation(
                 Path(self.default_folder, "Default.simulation"), self,
                 save_on_creation=save_on_creation,
+                detector=self.default_detector,
                 description="This is a default simulation.",
                 measurement_setting_file_description="These are default "
-                                                     "measurement "
+                                                     "simulation "
                                                      "parameters.")
 
         mcsimu_path = Path(self.default_folder, "Default.mcsimu")

--- a/modules/request.py
+++ b/modules/request.py
@@ -349,7 +349,7 @@ class Request(ElementSimulationContainer):
         """
         return self.__request_information["meta"]["request_name"]
 
-    def get_master(self):
+    def get_master(self) -> Measurement:
         """ Get master measurement of the request.
         """
         return self.__master_measurement

--- a/modules/run.py
+++ b/modules/run.py
@@ -67,12 +67,12 @@ class Run(Serializable, AdjustableSettings):
         # List for undoing fluence values
         self.previous_fluence = []
 
-    def to_file(self, measurement_file_path: Path):
+    def to_file(self, measurement_file: Path):
         """
         Saves Run object and Beam object parameters into a file.
 
         Args:
-            measurement_file_path: Path to the .measurement file in which the
+            measurement_file: Path to the .measurement file in which the
                                    parameters are written.
         """
         run_obj = {
@@ -92,7 +92,7 @@ class Run(Serializable, AdjustableSettings):
         }
 
         try:
-            with measurement_file_path.open("r") as mesu:
+            with measurement_file.open("r") as mesu:
                 obj = json.load(mesu)
             timestamp = time.time()
             obj["general"]["modification_time"] = time.strftime(
@@ -104,20 +104,20 @@ class Run(Serializable, AdjustableSettings):
         obj["run"] = run_obj
         obj["beam"] = beam_obj
 
-        with measurement_file_path.open("w") as file:
+        with measurement_file.open("w") as file:
             json.dump(obj, file, indent=4)
 
     @classmethod
-    def from_file(cls, measurement_file_path):
+    def from_file(cls, measurement_file: Path):
         """
         Reads parameter sfrom file and makes a Run object from them.
         Args:
-             measurement_file_path: Filepath of the .measurement file.
+             measurement_file: Filepath of the .measurement file.
 
         Return:
             Returns the created Run object.
         """
-        with measurement_file_path.open("r") as mesu:
+        with measurement_file.open("r") as mesu:
             mesu = json.load(mesu)
 
         try:

--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -35,9 +35,12 @@ import logging
 import os
 import time
 
-from . import general_functions as gf
-
+from collections import namedtuple
 from pathlib import Path
+from typing import Optional
+from typing import List
+
+from . import general_functions as gf
 
 from .base import ElementSimulationContainer
 from .base import Serializable
@@ -82,12 +85,12 @@ class Simulations:
             return None
         return self.simulations[key]
 
-    def add_simulation_file(self, sample, simulation_path: Path, tab_id):
+    def add_simulation_file(self, sample, simulation_file: Path, tab_id):
         """Add a new file to simulations.
 
         Args:
             sample: The sample under which the simulation is put.
-            simulation_path: Path of the .simulation file.
+            simulation_file: Path of the .simulation file.
             tab_id: Integer representing identifier for simulation's tab.
 
         Return:
@@ -95,116 +98,75 @@ class Simulations:
         """
         simulation = None
 
-        simulation_folder_path, simulation_file = simulation_path.parent, \
-            simulation_path.name
-        sample_folder, simulation_folder = simulation_folder_path.parent, \
-            simulation_folder_path.name
+        simulation_folder = simulation_file.parent
         directory_prefix = Simulation.DIRECTORY_PREFIX
-        target_extension = ".target"
-        measurement_extension = ".measurement"
-        detector_extension = ".detector"
-        measurement_settings_file = ""
-        element_simulation_extension = ".mcsimu"
-        profile_extension = ".profile"
 
         # Create simulation from file
-        if simulation_path.exists():
-            simulation = Simulation.from_file(sample.request, simulation_path)
-            simulation.sample = sample
-            serial_number = int(simulation_folder[len(directory_prefix):len(
-                directory_prefix) + 2])
+        if simulation_file.exists():
+            (target_file, mesu_file,
+             elem_sim_files, profile_files,
+             detector_file) = Simulation.find_simulation_files(
+                simulation_folder)
+
+            if target_file is not None:
+                target = Target.from_file(
+                    target_file, mesu_file, sample.request)
+            else:
+                target = None
+
+            if detector_file is not None:
+                detector = Detector.from_file(
+                    detector_file, mesu_file, sample.request)
+            else:
+                detector = None
+
+            simulation = Simulation.from_file(
+                sample.request, simulation_file, measurement_file=mesu_file,
+                sample=sample, target=target, detector=detector)
+
+            serial_number = int(
+                simulation_folder.name[
+                    len(directory_prefix):len(directory_prefix) + 2])
             simulation.serial_number = serial_number
             simulation.tab_id = tab_id
 
-            # TODO provide detector, run and target as parameters to the
-            #  Simulation.from_file method or make Simulation read those files
-            #  too in that method
-            # TODO refactor these os.listdir iterations into something more
-            #   reusable and stable
+            for mcsimu_file in elem_sim_files:
+                element_str_with_name = mcsimu_file.stem
 
-            for entry in os.scandir(simulation_folder_path):
-                f = Path(entry.path)
-                if f.suffix == measurement_extension:
-                    measurement_settings_file = f
-                    simulation.run = Run.from_file(measurement_settings_file)
-                    with measurement_settings_file.open("r") as mesu_f:
-                        mesu_settings = json.load(mesu_f)
+                prefix, name = element_str_with_name.split("-")
 
-                    try:
-                        simulation.measurement_setting_file_name = \
-                            mesu_settings["general"]["name"]
-                        simulation.measurement_setting_file_description = \
-                            mesu_settings["general"]["description"]
-                        simulation.modification_time = \
-                            mesu_settings["general"]["modification_time_unix"]
-                    except KeyError:
-                        pass
-                    break
+                profile_file = next(
+                    p for p in profile_files if p.name.startswith(prefix)
+                )
 
-            # Read Detector information from file.
-            det_folder = Path(simulation_folder_path, "Detector")
-            if det_folder.is_dir():
-                for entry in os.scandir(det_folder):
-                    file = Path(entry.path)
-                    if file.suffix == detector_extension:
-                        simulation.detector = Detector.from_file(
-                            file, measurement_settings_file, self.request)
-                        simulation.detector.update_directories(det_folder)
-                        break
-
-            for entry in os.scandir(simulation_folder_path):
-                file = Path(entry.path)
-                # Read Target information from file.
-                if file.suffix == target_extension:
-                    simulation.target = Target.from_file(
-                        file, measurement_settings_file, self.request)
-
-                # Read read ElementSimulation information from files.
-                elif file.suffix == element_simulation_extension:
-                    # .mcsimu file
-                    mcsimu_file_path = file
-
-                    element_str_with_name = file.stem
-
-                    prefix, name = element_str_with_name.split("-")
-                    profile_file_path = None
-
-                    for e in os.scandir(simulation.directory):
-                        f = Path(e.path)
-                        if f.suffix == profile_extension and f.name.startswith(
-                                prefix):
-                            profile_file_path = f
-                            break
-
-                    if profile_file_path is not None \
-                            and profile_file_path.exists():
-                        # Create ElementSimulation from files
-                        element_simulation = ElementSimulation.from_file(
-                            self.request, prefix, simulation_folder_path,
-                            mcsimu_file_path, profile_file_path,
-                            sample=simulation.sample,
-                            detector=simulation.detector
-                        )
-                        simulation.element_simulations.append(
-                            element_simulation)
-                        element_simulation.run = simulation.run
-                        element_simulation.simulation = simulation
+                if profile_file is not None:
+                    # Create ElementSimulation from files
+                    element_simulation = ElementSimulation.from_file(
+                        self.request, prefix, simulation_folder,
+                        mcsimu_file, profile_file,
+                        sample=simulation.sample,
+                        detector=simulation.detector,
+                        run=simulation.run,
+                        simulation=simulation
+                    )
+                    simulation.element_simulations.append(
+                        element_simulation)
 
         # Create a new simulation
         else:
             # Not stripping the extension
-            simulation_name, extension = os.path.splitext(simulation_file)
+            simulation_name = simulation_file.stem
             try:
                 keys = sample.simulations.simulations.keys()
                 for key in keys:
                     if sample.simulations.simulations[key].directory == \
                             simulation_name:
                         return simulation  # simulation = None
-                simulation = Simulation(simulation_path, self.request,
-                                        name=simulation_name, tab_id=tab_id,
-                                        sample=sample)
-                serial_number = int(simulation_folder[len(directory_prefix):len(
-                    directory_prefix) + 2])
+                simulation = Simulation(
+                    simulation_file, self.request, name=simulation_name,
+                    tab_id=tab_id, sample=sample)
+                serial_number = int(simulation_folder.name[len(
+                    directory_prefix):len(directory_prefix) + 2])
                 simulation.serial_number = serial_number
                 self.request.samples.simulations.simulations[tab_id] = \
                     simulation
@@ -252,8 +214,10 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
 
     def __init__(self, path: Path, request, name="Default",
                  description="",
-                 modification_time=None, tab_id=-1, run=None,
-                 detector=None, target=None,
+                 modification_time=None, tab_id=-1,
+                 run: Optional[Run] = None,
+                 detector: Optional[Detector] = None,
+                 target: Optional[Target] = None,
                  measurement_setting_file_name="",
                  measurement_setting_file_description="", sample=None,
                  use_request_settings=True,
@@ -284,6 +248,7 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
 
         self.tab_id = tab_id
         self.path = Path(path)
+        self.directory, self.simulation_file = self.path.parent, self.path.name
         self.request = request
         self.sample = sample
 
@@ -303,54 +268,91 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
 
         self.element_simulations = []
 
-        self.run = run
-        self.detector = detector
-        self.target = target
         self.use_request_settings = use_request_settings
-        if self.target is None:
+
+        if target is None:
             self.target = Target()
+        else:
+            self.target = target
+
+        if run is None:
+            self.run = Run()
+        else:
+            self.run = run
+
+        if detector is None:
+            self.detector = Detector(
+                self.directory / "Detector" / "simulation.detector",
+                self.get_measurement_file(),
+                save_on_creation=save_on_creation)
+        else:
+            self.detector = detector
 
         self.serial_number = 0
-
-        self.directory, self.simulation_file = self.path.parent, self.path.name
 
         if save_on_creation:
             self.create_folder_structure()
             self.to_file(self.path)
 
     def create_folder_structure(self):
+        """Create folder structure for simulation.
         """
-        Create folder structure for simulation.
-        """
-        self.__make_directories(self.directory)
+        if not self.directory.exists():
+            self.directory.mkdir(exist_ok=True)
+            log = f"Created a directory {self.directory}."
+            logging.getLogger("request").info(log)
         self.set_loggers(self.directory, self.request.directory)
 
-    @staticmethod
-    def __make_directories(directory: Path):
+    def get_measurement_file(self) -> Path:
+        """Returns the path to .measurement file that contains the settings
+        of this Simulation.
         """
-        Makes a directory and adds the event to log.
-
-        Args:
-             directory: Directory to create.
-        """
-        if not directory.exists():
-            directory.mkdir(exist_ok=True)
-            log = "Created a directory {0}.".format(directory)
-            logging.getLogger("request").info(log)
+        # TODO this method should be defined in a common base class
+        return Path(self.path.parent,
+                    f"{self.measurement_setting_file_name}.measurement")
 
     def rename_simulation_file(self):
         """Renames the simulation files with self.simulatio_file.
         """
-        simulation_file = None
         for file in os.listdir(self.directory):
             if file.endswith(".simulation"):
-                simulation_file = file
-                break
-        if simulation_file:
-            gf.rename_file(Path(self.directory, simulation_file),
-                           self.simulation_file)
+                gf.rename_file(
+                    Path(self.directory, file),
+                    self.simulation_file)
 
-    def add_element_simulation(self, recoil_element):
+    @staticmethod
+    def find_simulation_files(simulation_dir: Path):
+        res = gf.find_files_by_extension(
+            simulation_dir, ".mcsimu", ".target", ".measurement", ".profile")
+        try:
+            det_res = gf.find_files_by_extension(
+                simulation_dir / "Detector", ".detector")
+        except OSError:
+            det_res = {".detector": []}
+
+        if res[".target"]:
+            target_file = res[".target"][0]
+        else:
+            target_file = None
+        if res[".measurement"]:
+            mesu_file = res[".measurement"][0]
+        else:
+            mesu_file = None
+
+        if det_res[".detector"]:
+            detector_file = det_res[".detector"][0]
+        else:
+            detector_file = None
+
+        sim_files = namedtuple(
+            "Simulation_files",
+            ("target", "measurement", "element_simulations", "profiles",
+             "detector"))
+        return sim_files(
+            target_file, mesu_file, res[".mcsimu"], res[".profile"],
+            detector_file)
+
+    def add_element_simulation(self, recoil_element) -> ElementSimulation:
         """Adds ElementSimulation to Simulation.
 
         Args:
@@ -369,19 +371,21 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
             name_prefix=element_str, name=name, detector=self.detector,
             recoil_elements=[recoil_element], run=self.run, sample=self.sample,
             simulation_type=simulation_type)
-        # element_simulation.recoil_elements.append(recoil_element)
+
         self.element_simulations.append(element_simulation)
         return element_simulation
 
     @classmethod
-    def from_file(cls, request, file_path: Path, detector=None, target=None,
-                  run=None, sample=None, save_on_creation=True):
+    def from_file(cls, request, simulation_file: Path,
+                  measurement_file: Optional[Path] = None,
+                  detector=None, target=None, run=None, sample=None,
+                  save_on_creation=True):
         """Initialize Simulation from a JSON file.
 
         Args:
             request: Request which the Simulation belongs to.
-            file_path: A file path to JSON file containing the
-                simulation information.
+            simulation_file: path to .simulation file
+            measurement_file: path to .measurement file
             detector: Detector used by this simulation
             target: Target used by this simulation
             run: Run used by this simulation
@@ -389,25 +393,45 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
             save_on_creation: whether Simulation object is saved to file
                 after initialization
         """
-        with file_path.open("r") as file:
+        with simulation_file.open("r") as file:
             simu_obj = json.load(file)
 
         # Overwrite the human readable time stamp with unix time stamp, as
         # that is what the Simulation object uses internally
         simu_obj["modification_time"] = simu_obj.pop("modification_time_unix")
 
-        return cls(
-            file_path, request, detector=detector, target=target, run=run,
-            sample=sample, **simu_obj, save_on_creation=save_on_creation)
+        if measurement_file is not None:
+            run = Run.from_file(measurement_file)
+            with measurement_file.open("r") as mesu_f:
+                mesu_settings = json.load(mesu_f)
 
-    def to_file(self, file_path):
+            try:
+                general = {
+                    "measurement_setting_file_name": mesu_settings["name"],
+                    "measurement_setting_file_description": mesu_settings[
+                        "description"]
+                }
+            except KeyError:
+                general = {}
+        else:
+            general = {}
+
+        return cls(
+            simulation_file, request, detector=detector, target=target, run=run,
+            sample=sample, **simu_obj, save_on_creation=save_on_creation,
+            **general)
+
+    def to_file(self, simulation_file: Optional[Path] = None,
+                measurement_file: Optional[Path] = None):
         """Save simulation settings to a file.
 
         Args:
-            file_path: File in which the simulation settings will be saved.
+            simulation_file: path to a .simulation file
+            measurement_file: path to a .measurement_file
         """
+        if simulation_file is None:
+            simulation_file = self.path
 
-        # TODO could add file paths to detector and run files here too
         time_stamp = time.time()
         obj = {
             "name": self.name,
@@ -418,12 +442,47 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
             "use_request_settings": self.use_request_settings
         }
 
-        with open(file_path, "w") as file:
+        with simulation_file.open("w") as file:
             json.dump(obj, file, indent=4)
 
-    def update_directory_references(self, new_dir):
-        """
-        Update simualtion's directory references.
+        # Save measurement settings parameters.
+        if measurement_file is None:
+            measurement_file = self.get_measurement_file()
+
+        general_obj = {
+            "name": self.measurement_setting_file_name,
+            "description":
+                self.measurement_setting_file_description,
+            "modification_time":
+                time.strftime("%c %z %Z", time.localtime(time_stamp)),
+            "modification_time_unix": time_stamp,
+            "use_request_settings": self.use_request_settings
+        }
+
+        if measurement_file.exists():
+            with measurement_file.open("r") as mesu:
+                obj = json.load(mesu)
+            obj["general"] = general_obj
+        else:
+            obj = {
+                "general": general_obj
+            }
+
+        # Write measurement settings to file
+        with measurement_file.open("w") as file:
+            json.dump(obj, file, indent=4)
+
+        # Save Run object to file
+        self.run.to_file(measurement_file)
+        # Save Detector object to file
+        self.detector.to_file(self.detector.path, measurement_file)
+
+        # Save Target object to file
+        target_file = Path(self.directory, f"{self.target.name}.target")
+        self.target.to_file(target_file, measurement_file)
+
+    def update_directory_references(self, new_dir: Path):
+        """Update simulation's directory references.
 
         Args:
             new_dir: Path to simulation folder with new name.
@@ -440,25 +499,34 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
 
         self.set_loggers(self.directory, self.request.directory)
 
-    def get_running_simulations(self):
+    def get_running_simulations(self) -> List[ElementSimulation]:
+        """Returns a list of currently running simulations.
+        """
         return list(
             elem_sim for elem_sim in self.element_simulations
             if elem_sim.is_simulation_running()
         )
 
-    def get_finished_simulations(self):
+    def get_finished_simulations(self) -> List[ElementSimulation]:
+        """Returns a list of simulations that are finished.
+        """
         return list(
             elem_sim for elem_sim in self.element_simulations
             if elem_sim.is_simulation_finished()
         )
 
-    def get_running_optimizations(self):
+    def get_running_optimizations(self) -> List[ElementSimulation]:
+        """Returns a list of simulations currently involved in a running
+        optimization.
+        """
         return list(
             elem_sim for elem_sim in self.element_simulations
             if elem_sim.is_optimization_running()
         )
 
-    def get_finished_optimizations(self):
+    def get_finished_optimizations(self) -> List[ElementSimulation]:
+        """Returns a list of simulations that have optimizations results.
+        """
         return list(
             elem_sim for elem_sim in self.element_simulations
             if elem_sim.is_optimization_finished()

--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -307,18 +307,15 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
         self.detector = detector
         self.target = target
         self.use_request_settings = use_request_settings
-        if not self.target:
+        if self.target is None:
             self.target = Target()
 
         self.serial_number = 0
 
-        self.defaultlog = None
-        self.errorlog = None
-
         self.directory, self.simulation_file = self.path.parent, self.path.name
-        self.create_folder_structure()
 
         if save_on_creation:
+            self.create_folder_structure()
             self.to_file(self.path)
 
     def create_folder_structure(self):
@@ -378,7 +375,7 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
 
     @classmethod
     def from_file(cls, request, file_path: Path, detector=None, target=None,
-                  run=None, sample=None):
+                  run=None, sample=None, save_on_creation=True):
         """Initialize Simulation from a JSON file.
 
         Args:
@@ -389,6 +386,8 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
             target: Target used by this simulation
             run: Run used by this simulation
             sample: Sample under which this simulation belongs to
+            save_on_creation: whether Simulation object is saved to file
+                after initialization
         """
         with file_path.open("r") as file:
             simu_obj = json.load(file)
@@ -397,8 +396,9 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
         # that is what the Simulation object uses internally
         simu_obj["modification_time"] = simu_obj.pop("modification_time_unix")
 
-        return cls(file_path, request, detector=detector, target=target,
-                   run=run, sample=sample, **simu_obj)
+        return cls(
+            file_path, request, detector=detector, target=target, run=run,
+            sample=sample, **simu_obj, save_on_creation=save_on_creation)
 
     def to_file(self, file_path):
         """Save simulation settings to a file.

--- a/modules/target.py
+++ b/modules/target.py
@@ -32,6 +32,7 @@ import json
 import time
 
 from pathlib import Path
+from typing import Optional
 
 from .element import Element
 from .layer import Layer
@@ -133,13 +134,13 @@ class Target:
         # the __init__ method.
         return cls(**target, target_theta=target_theta, layers=layers)
 
-    def to_file(self, target_file_path: Path, measurement_file_path: Path):
-        """
-        Save target parameters into files.
+    def to_file(self, target_file: Path,
+                measurement_file: Optional[Path] = None):
+        """Save target parameters into files.
 
         Args:
-            target_file_path: File in which the target params will be saved.
-            measurement_file_path: File in which target angles will be saved.
+            target_file: File in which the target params will be saved.
+            measurement_file: File in which target angles will be saved.
         """
         timestamp = time.time()
         obj = {
@@ -165,14 +166,13 @@ class Target:
             }
             obj["layers"].append(layer_obj)
 
-        if target_file_path is not None:
-            with target_file_path.open("w") as file:
-                json.dump(obj, file, indent=4)
+        with target_file.open("w") as file:
+            json.dump(obj, file, indent=4)
 
-        if measurement_file_path is not None:
+        if measurement_file is not None:
             # Read .measurement to obj to update only target angles
             try:
-                with measurement_file_path.open("r") as mesu:
+                with measurement_file.open("r") as mesu:
                     obj = json.load(mesu)
                 obj["geometry"]["target_theta"] = self.target_theta
             except (OSError, KeyError):
@@ -180,5 +180,5 @@ class Target:
                         "target_theta": self.target_theta
                     }
 
-            with measurement_file_path.open("w") as file:
+            with measurement_file.open("w") as file:
                 json.dump(obj, file, indent=4)

--- a/potku.py
+++ b/potku.py
@@ -285,8 +285,6 @@ class Potku(QtWidgets.QMainWindow):
             if type(clicked_item.obj) is Measurement:
                 try:
                     clicked_item.obj.rename_info_file(new_name)
-                    clicked_item.obj.info_to_file(
-                        Path(new_dir, clicked_item.obj.name + ".info"))
                 except OSError as e:
                     QtWidgets.QMessageBox.critical(
                         self, "Error", f"Failed to rename info file: {e}.",

--- a/potku.py
+++ b/potku.py
@@ -302,9 +302,8 @@ class Potku(QtWidgets.QMainWindow):
                         QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
                 # Rename all split files
                 try:
-                    clicked_item.obj.rename_files_in_directory(Path(
-                        clicked_item.obj.directory_composition_changes,
-                        "Changes"))
+                    clicked_item.obj.rename_files_in_directory(
+                        clicked_item.obj.get_changes_dir())
                 except OSError as e:
                     QtWidgets.QMessageBox.critical(
                         self, "Error", f"Failed to rename splits {e}",
@@ -1289,9 +1288,9 @@ class Potku(QtWidgets.QMainWindow):
         master = self.request.get_master()
         master_tab = self.tab_widgets[master.tab_id]
         master_name = master.name
-        directory_d = master.directory_depth_profiles
-        directory_e = master.directory_energy_spectra
-        directory_c = master.directory_composition_changes
+        directory_d = master.get_depth_profile_dir()
+        directory_e = master.get_energy_spectra_dir()
+        directory_c = master.get_composition_changes_dir()
 
         # Load selections and save cut files
         # TODO: Make a check for these if identical already -> don't redo.

--- a/tests/gui/test_measurement_settings.py
+++ b/tests/gui/test_measurement_settings.py
@@ -31,6 +31,7 @@ import tests.mock_objects as mo
 import tests.utils as utils
 
 from modules.element import Element
+from modules.enums import Profile
 from widgets.measurement.settings import MeasurementSettingsWidget
 
 from PyQt5.QtWidgets import QApplication
@@ -79,6 +80,11 @@ class MyTestCase(unittest.TestCase):
         self.mesu_widget.update_settings()
         self.assertEqual(self.mesu_widget.obj.run.beam.ion,
                          self.mesu_widget.beam_ion)
+
+    def test_profile_value(self):
+        self.assertEqual(self.mesu_widget.beam_profile, Profile.UNIFORM)
+        self.mesu_widget.beam_profile = Profile.GAUSSIAN
+        self.assertEqual(self.mesu_widget.beam_profile, Profile.GAUSSIAN)
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_element_simulation.py
+++ b/tests/integration/test_element_simulation.py
@@ -58,7 +58,7 @@ class TestElementSimulationSettings(unittest.TestCase):
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
             # File paths
-            tmp_dir = Path(tmp_dir)
+            tmp_dir = Path(tmp_dir).resolve()
             mesu_file = tmp_dir / "mesu"
             det_dir = tmp_dir / "det"
             sim_dir = tmp_dir / "Sample_01-foo" / \

--- a/tests/mock_objects.py
+++ b/tests/mock_objects.py
@@ -44,8 +44,8 @@ from modules.point import Point
 from modules.layer import Layer
 from modules.measurement import Measurement
 from modules.global_settings import GlobalSettings
-from modules.sample import Samples
 from modules.observing import Observer
+from modules.request import Request
 
 
 # This module can be used to generate various helper objects for testing
@@ -147,9 +147,8 @@ def get_measurement(request=None) -> Measurement:
     if request is None:
         request = get_request()
 
-    return Measurement(request, Path(tempfile.gettempdir(), "mesu"),
-                       run=get_run(), detector=get_detector(),
-                       target=get_target())
+    return Measurement(
+        request, Path(tempfile.gettempdir(), "mesu"), save_on_creation=False)
 
 
 def get_layer(element_count=1, randomize=False) -> Layer:
@@ -175,24 +174,14 @@ def get_global_settings() -> GlobalSettings:
         config_dir=tempfile.gettempdir(), save_on_creation=False)
 
 
-def get_request(return_real=False):
+def get_request() -> Request:
     """Returns a MockRequest object.
 
     This is done to avoid lengthy file writing operations when a real
     Request is initialized
     """
-    class MockRequest:
-        def __init__(self):
-            self.default_detector = get_detector()
-            self.default_element_simulation = get_element_simulation(
-                request=self)
-            self.directory = Path(tempfile.gettempdir())
-            self.default_run = get_run()
-            self.default_target = get_target()
-            self.default_measurement = get_measurement(self)
-            self.global_settings = get_global_settings()
-            self.samples = Samples(self)
-    return MockRequest()
+    return Request(tempfile.gettempdir(), "request", get_global_settings(),
+                   save_on_creation=False, enable_logging=False)
 
 
 class TestObserver(Observer):

--- a/tests/unit/test_beam.py
+++ b/tests/unit/test_beam.py
@@ -31,6 +31,7 @@ import tests.mock_objects as mo
 
 from modules.beam import Beam
 from modules.element import Element
+from modules.enums import Profile
 
 
 class TestBeam(unittest.TestCase):
@@ -56,3 +57,18 @@ class TestBeam(unittest.TestCase):
         self.assertNotEqual(kwargs, beam.get_settings())
         beam.set_settings(**kwargs)
         self.assertEqual(kwargs, beam.get_settings())
+
+    def test_profile(self):
+        self.assertEqual(Profile.UNIFORM, Beam().profile)
+        self.assertEqual(
+            Profile.GAUSSIAN, Beam(profile=Profile.GAUSSIAN).profile)
+        self.assertEqual(
+            Profile.UNIFORM, Beam(profile="unIfoRm").profile)
+        self.assertEqual(
+            Profile.GAUSSIAN, Beam(profile="gaUssIan").profile)
+
+        self.assertEqual(
+            Profile.UNIFORM, Beam(profile="gaussiann").profile)
+
+        self.assertEqual(
+            Profile.UNIFORM, Beam(profile=None).profile)

--- a/tests/unit/test_detector.py
+++ b/tests/unit/test_detector.py
@@ -112,7 +112,7 @@ class TestBeam(unittest.TestCase):
             det1.to_file(det_file, mesu_file)
 
             det2 = Detector.from_file(det_file, mesu_file, mo.get_request(),
-                                      save=False)
+                                      save_on_creation=False)
             self.assertIsNot(det1, det2)
             self.assertEqual(det1.name, det2.name)
             self.assertEqual(det1.description, det2.description)

--- a/tests/unit/test_detector.py
+++ b/tests/unit/test_detector.py
@@ -168,7 +168,7 @@ class TestEfficiencyFiles(unittest.TestCase):
             self.assertIsNone(self.det.efficiency_directory)
             self.assertEqual([], self.det.get_efficiency_files())
 
-            self.det.update_directories(tmp_dir)
+            self.det.update_directories(Path(tmp_dir))
             self.assertTrue(self.det.efficiency_directory.exists())
             self.create_eff_files(self.det.efficiency_directory, self.eff_files)
             self.assertNotEqual(
@@ -210,15 +210,16 @@ class TestEfficiencyFiles(unittest.TestCase):
             # If detector dir has not yet been established with the
             # update_directories_method, add_efficiency_file raises an error
             path = Path(tmp_dir, "1H.eff")
+            tmp_path = Path(tmp_dir)
             self.assertTrue(path.exists())
             self.assertRaises(
                 TypeError, lambda: self.det.add_efficiency_file(path))
 
-            self.det.update_directories(tmp_dir)
+            self.det.update_directories(tmp_path)
 
             self.assertEqual([], os.listdir(self.det.efficiency_directory))
             for file in self.eff_files:
-                self.det.add_efficiency_file(Path(tmp_dir, file))
+                self.det.add_efficiency_file(Path(tmp_path, file))
 
             self.assertNotEqual(
                 sorted(self.eff_files.keys()),
@@ -255,7 +256,8 @@ class TestEfficiencyFiles(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             effs_folder = Path(tmp_dir, Detector.EFFICIENCY_DIR)
             used_folder = effs_folder / Detector.USED_EFFICIENCIES_DIR
-            self.det.update_directories(tmp_dir)
+            tmp_path = Path(tmp_dir)
+            self.det.update_directories(tmp_path)
 
             self.assertEqual(effs_folder, self.det.efficiency_directory)
             self.assertEqual(used_folder, self.det.get_used_efficiencies_dir())
@@ -284,7 +286,7 @@ class TestEfficiencyFiles(unittest.TestCase):
         the efficiency directory and the used efficiencies directory.
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
-            self.det.update_directories(tmp_dir)
+            self.det.update_directories(Path(tmp_dir))
             self.create_eff_files(self.det.efficiency_directory, self.eff_files)
 
             self.det.copy_efficiency_files()
@@ -325,7 +327,7 @@ class TestEfficiencyFiles(unittest.TestCase):
             expected = Path(tmp_dir, Detector.EFFICIENCY_DIR)
             self.assertFalse(expected.exists())
 
-            self.det.update_directories(tmp_dir)
+            self.det.update_directories(Path(tmp_dir))
 
             self.assertTrue(self.det.efficiency_directory.exists())
             self.assertEqual(expected, self.det.efficiency_directory)

--- a/tests/unit/test_general_functions.py
+++ b/tests/unit/test_general_functions.py
@@ -245,14 +245,14 @@ class TestFileIO(unittest.TestCase):
             self.assertTrue(foo2_file.exists())
             self.assertTrue(bar_dir.exists())
 
-            gf.remove_files(tmp_dir, exts={".bar"})
+            gf.remove_matching_files(tmp_dir, exts={".bar"})
 
             self.assertFalse(bar_file.exists())
             self.assertTrue(foo_file.exists())
             self.assertTrue(foo2_file.exists())
             self.assertTrue(bar_dir.exists())
 
-            gf.remove_files(tmp_dir, exts={".foo", ".foo2"})
+            gf.remove_matching_files(tmp_dir, exts={".foo", ".foo2"})
 
             self.assertFalse(foo_file.exists())
             self.assertFalse(foo2_file.exists())
@@ -264,12 +264,12 @@ class TestFileIO(unittest.TestCase):
             open(no_ext, "a").close()
             self.assertTrue(no_ext.exists())
 
-            gf.remove_files(tmp_dir)
-            gf.remove_files(tmp_dir, exts=[])
+            gf.remove_matching_files(tmp_dir)
+            gf.remove_matching_files(tmp_dir, exts=[])
 
             self.assertTrue(no_ext.exists())
 
-            gf.remove_files(tmp_dir, exts=[""])
+            gf.remove_matching_files(tmp_dir, exts=[""])
             self.assertFalse(no_ext.exists())
 
     def test_file_name_conditions(self):
@@ -289,8 +289,8 @@ class TestFileIO(unittest.TestCase):
             self.assertTrue(foo_file.exists())
             self.assertTrue(foo2_file.exists())
 
-            gf.remove_files(tmp_dir, exts={".bar"},
-                            filter_func=lambda f: f.startswith("bar."))
+            gf.remove_matching_files(tmp_dir, exts={".bar"},
+                                     filter_func=lambda f: f.startswith("bar."))
 
             self.assertTrue(bar_file.exists())
             self.assertFalse(bar2_file.exists())
@@ -302,13 +302,13 @@ class TestFileIO(unittest.TestCase):
             # Nonexistent directories cause no changes
             path = Path(tmp_dir, "foo.bar")
             self.assertFalse(path.exists())
-            gf.remove_files(path, exts={".bar"})
+            gf.remove_matching_files(path, exts={".bar"})
             self.assertFalse(path.exists())
 
             # Neither if the directory is actually a file
             open(path, "a").close()
             self.assertTrue(path.is_file())
-            gf.remove_files(path, exts={".bar"})
+            gf.remove_matching_files(path, exts={".bar"})
             self.assertTrue(path.is_file())
 
 

--- a/tests/unit/test_general_functions.py
+++ b/tests/unit/test_general_functions.py
@@ -311,6 +311,26 @@ class TestFileIO(unittest.TestCase):
             gf.remove_matching_files(path, exts={".bar"})
             self.assertTrue(path.is_file())
 
+    def test_find_files_by_extension(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            files = ["a.foo", "b.foo", "c.fooo", "d.foo.", "e", "d.bar"]
+            paths = [Path(tmp_dir, f) for f in files]
+            for p in paths:
+                p.open("w").close()
 
-if __name__ == "__main__":
-    unittest.main()
+            self.assertEqual({
+                ".foo": [Path(tmp_dir, "a.foo"), Path(tmp_dir, "b.foo")]
+            }, gf.find_files_by_extension(Path(tmp_dir), ".foo"))
+
+            self.assertEqual({
+                ".foo": [Path(tmp_dir, "a.foo"), Path(tmp_dir, "b.foo")],
+                ".bar": [Path(tmp_dir, "d.bar")],
+                ".zip": []
+            }, gf.find_files_by_extension(
+                Path(tmp_dir), ".foo", ".bar", ".zip"))
+
+            self.assertEqual({
+            }, gf.find_files_by_extension(Path(tmp_dir)))
+
+        self.assertRaises(
+            OSError, lambda: gf.find_files_by_extension(Path(tmp_dir)))

--- a/tests/unit/test_general_functions.py
+++ b/tests/unit/test_general_functions.py
@@ -313,7 +313,7 @@ class TestFileIO(unittest.TestCase):
 
     def test_find_files_by_extension(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            files = ["a.foo", "b.foo", "c.fooo", "d.foo.", "e", "d.bar"]
+            files = ["a.foo", "b.foo", "c.fooo", "d.foo.fo", "e", "d.bar"]
             paths = [Path(tmp_dir, f) for f in files]
             for p in paths:
                 p.open("w").close()

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -39,6 +39,7 @@ from modules.measurement import Measurement
 class TestFolderStructure(unittest.TestCase):
     def setUp(self):
         self.mesu_name = "foo"
+        self.settings_file = "baz"
         self.profile_name = "bar"
         self.mesu_folder = "mesu"
         self.folder_structure = {
@@ -61,8 +62,9 @@ class TestFolderStructure(unittest.TestCase):
             "Detector": {
                 "measurement.detector": None
             },
+            f"{self.mesu_name}.info": None,
             f"{self.profile_name}.profile": None,
-            f"{self.mesu_name}.measurement": None,
+            f"{self.settings_file}.measurement": None,
             "Default.target": None
         })
 
@@ -70,8 +72,9 @@ class TestFolderStructure(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir, self.mesu_folder)
             mesu = Measurement(
-                mo.get_request(), path / "mesu.info",
-                measurement_setting_file_name=self.mesu_name,
+                mo.get_request(), path / f"{self.mesu_name}.info",
+                name=self.mesu_name,
+                measurement_setting_file_name=self.settings_file,
                 profile_name=self.profile_name, save_on_creation=False)
             utils.disable_logging()
 

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -114,4 +114,3 @@ class TestFolderStructure(unittest.TestCase):
                 path / f"Default.target", tgt_file)
             self.assertEqual(
                 path / "Detector" / f"measurement.detector", det_file)
-

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -91,6 +91,8 @@ class TestFolderStructure(unittest.TestCase):
             utils.assert_folder_structure_equal(
                 self.after_to_file, Path(tmp_dir))
 
+            utils.disable_logging()
+
     def test_get_measurement_files(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir, self.mesu_folder)
@@ -114,3 +116,5 @@ class TestFolderStructure(unittest.TestCase):
                 path / f"Default.target", tgt_file)
             self.assertEqual(
                 path / "Detector" / f"measurement.detector", det_file)
+
+            utils.disable_logging()

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -1,0 +1,114 @@
+# coding=utf-8
+"""
+Created on 05.06.2020
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2020 TODO
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = "Juhani Sundell"
+__version__ = "2.0"
+
+import unittest
+import tempfile
+import copy
+
+import tests.utils as utils
+import tests.mock_objects as mo
+
+from pathlib import Path
+
+from modules.measurement import Measurement
+
+
+class TestFolderStructure(unittest.TestCase):
+    def setUp(self):
+        self.mesu_name = "foo"
+        self.profile_name = "bar"
+        self.mesu_folder = "mesu"
+        self.folder_structure = {
+            "mesu": {
+                "Depth_profiles": {},
+                "tof_in": {},
+                "Data": {
+                    "Cuts": {}
+                },
+                "Energy_spectra": {},
+                "Composition_changes": {
+                    "Changes": {}
+                },
+                "default.log": None,
+                "errors.log": None
+            }
+        }
+        self.after_to_file = copy.deepcopy(self.folder_structure)
+        self.after_to_file["mesu"].update({
+            "Detector": {
+                "measurement.detector": None
+            },
+            f"{self.profile_name}.profile": None,
+            f"{self.mesu_name}.measurement": None,
+            "Default.target": None
+        })
+
+    def test_folder_structure(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir, self.mesu_folder)
+            mesu = Measurement(
+                mo.get_request(), path / "mesu.info",
+                measurement_setting_file_name=self.mesu_name,
+                profile_name=self.profile_name, save_on_creation=False)
+            utils.disable_logging()
+
+            # No files or folders should be created...
+            utils.assert_folder_structure_equal({}, Path(tmp_dir))
+
+            # ... until create_folder_structure is called
+            mesu.create_folder_structure(path)
+            utils.assert_folder_structure_equal(
+                self.folder_structure, Path(tmp_dir))
+
+            mesu.to_file()
+
+            utils.assert_folder_structure_equal(
+                self.after_to_file, Path(tmp_dir))
+
+    def test_get_measurement_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir, self.mesu_folder)
+            mesu = Measurement(
+                mo.get_request(), path / "mesu.info",
+                measurement_setting_file_name=self.mesu_name,
+                profile_name=self.profile_name, save_on_creation=False)
+            utils.disable_logging()
+            mesu.create_folder_structure(path)
+            mesu.to_file()
+
+            profile_file, mesu_file, tgt_file, det_file = \
+                Measurement.find_measurement_files(path)
+
+            self.assertEqual(
+                path / f"{self.profile_name}.profile", profile_file)
+            self.assertEqual(
+                path / f"{self.mesu_name}.measurement", mesu_file)
+
+            self.assertEqual(
+                path / f"Default.target", tgt_file)
+            self.assertEqual(
+                path / "Detector" / f"measurement.detector", det_file)
+

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -77,6 +77,8 @@ class TestInit(unittest.TestCase):
             request.to_file()
             utils.assert_folder_structure_equal(self.folder_structure, path)
 
+            utils.disable_logging()
+
 
 class TestSerialization(unittest.TestCase):
     def test_serialization(self):
@@ -104,6 +106,7 @@ class TestSerialization(unittest.TestCase):
                 request_from_file.default_target.description
             )
 
+            utils.disable_logging()
 
     def test_default_values_are_same(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -134,6 +137,7 @@ class TestSerialization(unittest.TestCase):
                 request.default_simulation,
                 request_from_file.default_simulation
             )
+            utils.disable_logging()
 
     @staticmethod
     def assert_request_values_are_same(request: Request):

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+"""
+Created on 06.06.2020
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2020 TODO
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = ""  # TODO
+__version__ = ""  # TODO
+
+import unittest
+import tempfile
+import os
+import tests.utils as utils
+import tests.mock_objects as mo
+
+from pathlib import Path
+
+from modules.request import Request
+
+
+class TestInit(unittest.TestCase):
+    def setUp(self):
+        # Expected folder structure when request is saved
+        self.folder_name = "foo"
+        self.folder_structure = {
+            "Default": {
+                "Detector": {
+                    "Efficiency_files": {},
+                    "Default.detector": None
+                },
+                "Default.measurement": None,
+                "default.log": None,
+                "Default.simulation": None,
+                "Default.mcsimu": None,
+                "Default.profile": None,
+                "4He-Default.rec": None,
+                "Default.target": None,
+                "Default_element.profile": None,
+                "Default.info": None,
+                "errors.log": None
+            },
+            "request.log": None,
+            f"{self.folder_name}.request": None
+        }
+
+    def test_folder_structure(self):
+        """Tests the folder structure when request is created"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir, self.folder_name)
+            Request(path, "bar", mo.get_global_settings(),
+                    save_on_creation=False, enable_logging=False)
+
+            self.assertEqual([], os.listdir(tmp_dir))
+
+            Request(path, "bar", mo.get_global_settings(),
+                    save_on_creation=True, enable_logging=False)
+
+            utils.assert_folder_structure_equal(self.folder_structure, path)

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -69,7 +69,91 @@ class TestInit(unittest.TestCase):
 
             self.assertEqual([], os.listdir(tmp_dir))
 
-            Request(path, "bar", mo.get_global_settings(),
-                    save_on_creation=True, enable_logging=False)
+            request = Request(path, "bar", mo.get_global_settings(),
+                              save_on_creation=True, enable_logging=False)
 
             utils.assert_folder_structure_equal(self.folder_structure, path)
+
+            request.to_file()
+            utils.assert_folder_structure_equal(self.folder_structure, path)
+
+
+class TestSerialization(unittest.TestCase):
+    def test_serialization(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir, "request")
+            request = Request(path, "foo", mo.get_global_settings(),
+                              save_on_creation=False, enable_logging=False)
+
+            request.default_run.charge = 1
+            request.default_run.fluence = 2
+            request.default_target.description = "foo"
+
+            request.to_file()
+
+            request_from_file = Request.from_file(
+                request.request_file, mo.get_global_settings())
+
+            self.assertEqual(
+                request.default_run.get_settings(),
+                request_from_file.default_run.get_settings()
+            )
+
+            self.assertEqual(
+                request.default_target.description,
+                request_from_file.default_target.description
+            )
+
+
+    def test_default_values_are_same(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir, "request")
+            request = Request(path, "foo", mo.get_global_settings(),
+                              save_on_creation=True, enable_logging=False)
+            self.assert_request_values_are_same(request)
+
+            request_from_file = Request.from_file(
+                request.request_file, mo.get_global_settings())
+            self.assert_request_values_are_same(request_from_file)
+
+            self.assertEqual(
+                request.request_file, request_from_file.request_file
+            )
+            self.assertEqual(
+                request.directory, request_from_file.directory
+            )
+
+            self.assertIsNot(
+                request, request_from_file
+            )
+            self.assertIsNot(
+                request.default_measurement,
+                request_from_file.default_measurement
+            )
+            self.assertIsNot(
+                request.default_simulation,
+                request_from_file.default_simulation
+            )
+
+    @staticmethod
+    def assert_request_values_are_same(request: Request):
+        utils.assert_are_same(
+            request,
+            request.default_measurement.request,
+            request.default_simulation.request
+        )
+        utils.assert_are_same(
+            request.default_detector,
+            request.default_measurement.detector,
+            request.default_simulation.detector
+        )
+        utils.assert_are_same(
+            request.default_run,
+            request.default_measurement.run,
+            request.default_simulation.run
+        )
+        utils.assert_are_same(
+            request.default_target,
+            request.default_measurement.target,
+            request.default_simulation.target
+        )

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -118,5 +118,3 @@ class TestSimulation(unittest.TestCase):
             self.assertEqual(sim.target.target_type, sim2.target.target_type)
 
             self.assertEqual(sim.run.fluence, sim2.run.fluence)
-
-            self.assertNotEqual(sim.modification_time, sim2.modification_time)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,6 +34,7 @@ import unittest
 import logging
 import platform
 import warnings
+import itertools
 
 from pathlib import Path
 from string import Template
@@ -262,3 +263,11 @@ def assert_folder_structure_equal(expected_structure: Dict, directory: Path):
                 f"Value should either be 'None' or a dictionary. {type(v)} "
                 f"given.")
 
+
+def assert_are_same(*args):
+    """Asserts that all given arguments are the same object. Raises
+    AssertionError if all objects are not the same.
+    """
+    for x, y in itertools.combinations(args, r=2):
+        if x is not y:
+            raise AssertionError(f"{x} is not {y}.")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -247,7 +247,7 @@ def assert_folder_structure_equal(expected_structure: Dict, directory: Path):
     if keys != fnames:
         raise AssertionError(
             f"Contents of the directory {directory} did not match expected "
-            f"values. Expected:\n{keys}\nGot:\n{fnames}")
+            f"values. Expected:\n{sorted(keys)}\nGot:\n{sorted(fnames)}")
     for k, v in expected_structure.items():
         p = directory / k
         if isinstance(v, dict):

--- a/ui_files/ui_new_measurement.ui
+++ b/ui_files/ui_new_measurement.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>375</width>
+    <width>434</width>
     <height>216</height>
    </rect>
   </property>
@@ -63,7 +63,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="simulationNameLabel">
        <property name="text">
-        <string>Measurement file:</string>
+        <string>Measurement file</string>
        </property>
       </widget>
      </item>
@@ -91,7 +91,7 @@
      <item row="1" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Measurement name:</string>
+        <string>Measurement name</string>
        </property>
       </widget>
      </item>
@@ -123,7 +123,7 @@
      <item row="2" column="0">
       <widget class="QLabel" name="SampleLabel">
        <property name="text">
-        <string>Place under sample:</string>
+        <string>Place under sample</string>
        </property>
       </widget>
      </item>
@@ -132,14 +132,14 @@
        <item>
         <widget class="QComboBox" name="samplesComboBox">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="minimumSize">
           <size>
-           <width>0</width>
+           <width>100</width>
            <height>0</height>
           </size>
          </property>

--- a/ui_files/ui_new_request.ui
+++ b/ui_files/ui_new_request.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>453</width>
-    <height>130</height>
+    <height>142</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -22,10 +22,13 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Request name:</string>
+        <string>Request name</string>
        </property>
       </widget>
      </item>
@@ -38,8 +41,14 @@
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_2">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string>Request directory:</string>
+        <string>Request directory</string>
        </property>
       </widget>
      </item>
@@ -91,6 +100,9 @@
       <widget class="QPushButton" name="pushOk">
        <property name="text">
         <string>Create</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/widgets/gui_utils.py
+++ b/widgets/gui_utils.py
@@ -400,10 +400,7 @@ def fill_cuts_treewidget(measurement, treewidget, use_elemloss=False,
         elem_root = QtWidgets.QTreeWidgetItem(["Elemental Losses"])
         for elemloss in cuts_elemloss:
             item = QtWidgets.QTreeWidgetItem([elemloss])
-            item.directory = Path(
-                measurement.directory,
-                measurement.directory_composition_changes,
-                "Changes")
+            item.directory = measurement.get_changes_dir()
             item.file_name = elemloss
             if item.file_name in checked_files:
                 item.setCheckState(0, QtCore.Qt.Checked)

--- a/widgets/matplotlib/measurement/tofe_histogram.py
+++ b/widgets/matplotlib/measurement/tofe_histogram.py
@@ -30,7 +30,9 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen \n " \
 __version__ = "2.0"
 
 import os
+from pathlib import Path
 import modules.math_functions as mf
+import modules.general_functions as gf
 
 import widgets.gui_utils as gutils
 
@@ -651,19 +653,13 @@ class MatplotlibHistogramWidget(MatplotlibWidget):
                     # Remove unnecessary tof_list and hist files
                     # TODO check that also no_foil.hist file is removed
                     cut_file_name = os.path.split(cut)[1].rsplit('.', 1)[0]
-                    removed_files = []
-                    for file in \
-                            os.listdir(
-                                self.measurement.directory_energy_spectra):
-                        if file == cut_file_name + ".hist" or file == \
-                                cut_file_name + ".tof_list":
-                            removed_files.append(file)
-                    for f in removed_files:
-                        os.remove(os.path.join(
-                            self.measurement.directory_energy_spectra, f))
+                    gf.remove_matching_files(
+                        self.measurement.get_energy_spectra_dir(),
+                        exts={".hist", ".tof_list"},
+                        filter_func=lambda f: f.name == cut_file_name)
             if delete_es:
                 save_file = os.path.join(
-                    self.measurement.directory_energy_spectra,
+                    self.measurement.get_energy_spectra_dir(),
                     es_widget.save_file)
                 if os.path.exists(save_file):
                     os.remove(save_file)
@@ -678,11 +674,10 @@ class MatplotlibHistogramWidget(MatplotlibWidget):
                     delete_depth = True
                     # TODO: Delete depth files
             if delete_depth:
-                save_file = os.path.join(
-                    self.measurement.directory_depth_profiles,
-                    depth_widget.save_file)
-                if os.path.exists(save_file):
-                    os.remove(save_file)
+                gf.remove_files(
+                    self.measurement.get_depth_profile_dir() /
+                    depth_widget.save_file
+                )
                 self.parent.tab.del_widget(depth_widget)
 
         # Update composition changes
@@ -693,11 +688,9 @@ class MatplotlibHistogramWidget(MatplotlibWidget):
                 if not os.path.exists(cut):
                     delete_comp = True
             if delete_comp:
-                save_file = os.path.join(
-                    self.measurement.directory_composition_changes,
+                gf.remove_files(
+                    self.measurement.get_composition_changes_dir() /
                     comp_widget.save_file)
-                if os.path.exists(save_file):
-                    os.remove(save_file)
                 self.parent.tab.del_widget(comp_widget)
 
         self.elementSelectDeleteButton.setEnabled(False)
@@ -724,42 +717,39 @@ class MatplotlibHistogramWidget(MatplotlibWidget):
 
             es_widget = self.parent.tab.energy_spectrum_widget
             if es_widget:
-                save_file = os.path.join(
-                    self.measurement.directory_energy_spectra,
+                save_file = Path(
+                    self.measurement.get_energy_spectra_dir(),
                     es_widget.save_file)
                 self.parent.tab.del_widget(es_widget)
             else:
-                save_file = os.path.join(
-                    self.measurement.directory_energy_spectra,
+                save_file = Path(
+                    self.measurement.get_energy_spectra_dir(),
                     EnergySpectrumWidget.save_file)
-            if os.path.exists(save_file):
-                os.remove(save_file)
+            gf.remove_files(save_file)
 
             comp_widget = self.parent.tab.elemental_losses_widget
             if comp_widget:
-                save_file = os.path.join(
-                    self.measurement.directory_composition_changes,
+                save_file = Path(
+                    self.measurement.get_composition_changes_dir(),
                     comp_widget.save_file)
                 self.parent.tab.del_widget(comp_widget)
             else:
-                save_file = os.path.join(
-                    self.measurement.directory_composition_changes,
+                save_file = Path(
+                    self.measurement.get_composition_changes_dir(),
                     ElementLossesWidget.save_file)
-            if os.path.exists(save_file):
-                os.remove(save_file)
+            gf.remove_files(save_file)
 
             depth_widget = self.parent.tab.depth_profile_widget
             if depth_widget:
-                save_file = os.path.join(
-                    self.measurement.directory_depth_profiles,
+                save_file = Path(
+                    self.measurement.get_depth_profile_dir(),
                     depth_widget.save_file)
                 self.parent.tab.del_widget(depth_widget)
             else:
-                save_file = os.path.join(
-                    self.measurement.directory_depth_profiles,
+                save_file = Path(
+                    self.measurement.get_depth_profile_dir(),
                     DepthProfileWidget.save_file)
-            if os.path.exists(save_file):
-                os.remove(save_file)
+            gf.remove_files(save_file)
 
             self.__on_draw_legend()
             self.canvas.draw_idle()

--- a/widgets/measurement/settings.py
+++ b/widgets/measurement/settings.py
@@ -37,7 +37,11 @@ import widgets.input_validation as iv
 import widgets.gui_utils as gutils
 
 from pathlib import Path
+from typing import Union
+from modules.enums import Profile
 from modules.element import Element
+from modules.simulation import Simulation
+from modules.measurement import Measurement
 from widgets.gui_utils import QtABCMeta
 from dialogs.element_selection import ElementSelectionDialog
 
@@ -115,9 +119,8 @@ class MeasurementSettingsWidget(QtWidgets.QWidget,
     target_theta = bnd.bind("targetThetaDoubleSpinBox", track_change=True)
     detector_theta = bnd.bind("detectorThetaDoubleSpinBox", track_change=True)
 
-    def __init__(self, obj):
-        """
-        Initializes the widget.
+    def __init__(self, obj: Union[Measurement, Simulation]):
+        """Initializes the widget.
 
         Args:
             obj: object that uses these settings, either a Measurement or a
@@ -152,10 +155,9 @@ class MeasurementSettingsWidget(QtWidgets.QWidget,
         self.targetFiiDoubleSpinBox.setLocale(locale)
 
         # Fii angles are currently not used so disable their spin boxes
-        # TODO find out how fii angles should be used in MCERD so these
-        #   can be enabled
         self.detectorFiiDoubleSpinBox.setEnabled(False)
         self.targetFiiDoubleSpinBox.setEnabled(False)
+        gutils.fill_combobox(self.profileComboBox, Profile)
 
         # Copy of measurement's/simulation's run or default run
         # TODO should default run also be copied?

--- a/widgets/measurement/settings.py
+++ b/widgets/measurement/settings.py
@@ -224,14 +224,8 @@ class MeasurementSettingsWidget(QtWidgets.QWidget,
         }
         self.set_properties(**run_params, **bean_params)
 
-        if self.obj.detector is None:
-            self.detector_theta = \
-                self.obj.request.default_detector.detector_theta
-            # TODO should there be a none check for target too?
-            self.target_theta = self.obj.request.default_target.target_theta
-        else:
-            self.detector_theta = self.obj.detector.detector_theta
-            self.target_theta = self.obj.target.target_theta
+        self.detector_theta = self.obj.detector.detector_theta
+        self.target_theta = self.obj.target.target_theta
 
     def check_angles(self):
         """

--- a/widgets/measurement/tab.py
+++ b/widgets/measurement/tab.py
@@ -353,7 +353,8 @@ class MeasurementTabWidget(QtWidgets.QWidget, BaseTab):
         """Opens depth profile dialog.
         """
         previous = self.depth_profile_widget
-        DepthProfileDialog(self, statusbar=self.statusbar)
+        DepthProfileDialog(self, self.obj, self.obj.request.global_settings,
+                           statusbar=self.statusbar)
         if self.depth_profile_widget != previous and \
                 type(self.depth_profile_widget) is not None:
             # TODO type(x) is not None???

--- a/widgets/profile_settings.py
+++ b/widgets/profile_settings.py
@@ -96,66 +96,31 @@ class ProfileSettingsWidget(QtWidgets.QWidget):
         """
         Show profile settings.
         """
-        if not self.measurement.use_default_profile_settings:
-            self.nameLineEdit.setText(
-                self.measurement.profile_name)
-            self.descriptionPlainTextEdit.setPlainText(
-                self.measurement.profile_description)
-            self.dateLabel.setText(time.strftime("%c %z %Z", time.localtime(
-                self.measurement.profile_modification_time)))
-            self.referenceDensityDoubleSpinBox.setValue(
-                self.measurement.reference_density)
-            self.numberOfDepthStepsSpinBox.setValue(
-                self.measurement.number_of_depth_steps)
-            self.depthStepForStoppingSpinBox.setValue(
-                self.measurement.depth_step_for_stopping)
-            self.depthStepForOutputSpinBox.setValue(
-                self.measurement.depth_step_for_output)
-            self.depthForConcentrationFromDoubleSpinBox.setValue(
-                self.measurement.depth_for_concentration_from)
-            self.depthForConcentrationToDoubleSpinBox.setValue(
-                self.measurement.depth_for_concentration_to)
-            self.channelWidthDoubleSpinBox.setValue(
-                self.measurement.channel_width)
-            self.numberOfSplitsSpinBox.setValue(
-                self.measurement.number_of_splits)
-            self.normalizationComboBox.setCurrentIndex(
-                self.normalizationComboBox.findText(
-                    self.measurement.normalization))
-        else:
-            self.nameLineEdit.setText(
-                self.measurement.request.default_measurement.profile_name)
-            self.dateLabel.setText(time.strftime("%c %z %Z", time.localtime(
-                self.measurement.request.default_measurement
-                    .profile_modification_time)))
-            self.descriptionPlainTextEdit.setPlainText(
-                self.measurement.request.default_measurement
-                    .profile_description)
-            self.referenceDensityDoubleSpinBox.setValue(
-                self.measurement.request.default_measurement
-                    .reference_density)
-            self.numberOfDepthStepsSpinBox.setValue(
-                self.measurement.request.default_measurement
-                    .number_of_depth_steps)
-            self.depthStepForStoppingSpinBox.setValue(
-                self.measurement.request.default_measurement
-                    .depth_step_for_stopping)
-            self.depthStepForOutputSpinBox.setValue(
-                self.measurement.request.default_measurement
-                    .depth_step_for_output)
-            self.depthForConcentrationFromDoubleSpinBox.setValue(
-                self.measurement.request.default_measurement
-                    .depth_for_concentration_from)
-            self.depthForConcentrationToDoubleSpinBox.setValue(
-                self.measurement.request.default_measurement
-                    .depth_for_concentration_to)
-            self.channelWidthDoubleSpinBox.setValue(
-                self.measurement.request.default_measurement.channel_width)
-            self.numberOfSplitsSpinBox.setValue(
-                self.measurement.request.default_measurement.number_of_splits)
-            self.normalizationComboBox.setCurrentIndex(
-                self.normalizationComboBox.findText(
-                    self.measurement.request.default_measurement.normalization))
+        self.nameLineEdit.setText(
+            self.measurement.profile_name)
+        self.descriptionPlainTextEdit.setPlainText(
+            self.measurement.profile_description)
+        self.dateLabel.setText(time.strftime("%c %z %Z", time.localtime(
+            self.measurement.profile_modification_time)))
+        self.referenceDensityDoubleSpinBox.setValue(
+            self.measurement.reference_density)
+        self.numberOfDepthStepsSpinBox.setValue(
+            self.measurement.number_of_depth_steps)
+        self.depthStepForStoppingSpinBox.setValue(
+            self.measurement.depth_step_for_stopping)
+        self.depthStepForOutputSpinBox.setValue(
+            self.measurement.depth_step_for_output)
+        self.depthForConcentrationFromDoubleSpinBox.setValue(
+            self.measurement.depth_for_concentration_from)
+        self.depthForConcentrationToDoubleSpinBox.setValue(
+            self.measurement.depth_for_concentration_to)
+        self.channelWidthDoubleSpinBox.setValue(
+            self.measurement.channel_width)
+        self.numberOfSplitsSpinBox.setValue(
+            self.measurement.number_of_splits)
+        self.normalizationComboBox.setCurrentIndex(
+            self.normalizationComboBox.findText(
+                self.measurement.normalization))
 
     def update_settings(self):
         """


### PR DESCRIPTION
This partially fixes #3. tof.in is written to `<request>/<sample>/<measurement>/tof_in` folder. However, the file still needs to be copied to bin dir as tof_list has to have it in its working directory and also tof_list has to be able to masses.dat file with a relative path.

This pull request also features lots of changes to how Meausurement objects are serialised and deserialised. .info file and other settings are no longer deleted when user ticks "Use request settings". The logic is now same as with Simulation objects.