### PR TITLE
#61 spec file updates

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 numpy = "*"
 scipy = "*"
-matplotlib = "*"
+matplotlib = "==3.2.2"
 PyQt5 = "==5.14.2"
 Shapely = "*"
 wheel = "*"

--- a/README.md
+++ b/README.md
@@ -161,19 +161,6 @@ or
 $ pipenv run ./create_bundle.sh
 `````
 
-### Missing binaries
-
-Currently, the packaging process does not include all necessary binary files. The
-following files are not copied:
-
-- awk (manually placed, see section External dependencies)
-- coinc
-- jibal_bootstrap
-- jibaltool
-
-A manual workaround is to copy the files from `potku/external/bin` to 
-`potku/dist/potku/external/bin/`.
-
 ## Licence
 
 Potku is licensed under GNU General Public License. See [LICENSE](LICENSE) for details.

--- a/potku.spec
+++ b/potku.spec
@@ -35,7 +35,7 @@ elif system == "Windows":
     icon = "ui_icons/potku/potku_logo_icons/potku_icon.ico"
     console = True
 else:
-    extras = []
+    extras = [("external/lib/*.so*", ".")]
     icon = "ui_icons/potku/potku_logo_icons/potku_icon.ico"
     console = True
 

--- a/potku.spec
+++ b/potku.spec
@@ -41,12 +41,16 @@ else:
 
 block_cipher = None
 
+bins = [
+    (f"external/bin/{file.name}", "external/bin/")
+    for file in os.scandir("external/bin")
+    if file.name != "jibal.conf"
+]
+
 a = Analysis(
     ["potku.py"],
      pathex=[],
-     binaries=[
-        ("external/bin/[!jibal.conf]*", "external/bin/")
-     ],
+     binaries=bins,
      datas=[
         ("external/bin/jibal.conf", "external/bin/"),
         ("external/share", "external/share"),


### PR DESCRIPTION
No more missing binaries when creating the bundle (except for libgsl which still needs to be installed separately for non-Windows versions).

Not tested on macOS which is usually the most finicky OS when it comes to running pyinstaller, so stuff may break.

Closes #61.