### PR TITLE
Revert color scheme serialization back to the original way (#79)

### DIFF
--- a/modules/global_settings.py
+++ b/modules/global_settings.py
@@ -379,7 +379,7 @@ class GlobalSettings:
         Args:
             value: a ToFEColorScheme value.
         """
-        self._config[self._TOFE]["color_scheme"] = value.value
+        self._config[self._TOFE]["color_scheme"] = str(value)
 
     @handle_exceptions(return_value=0)
     def get_tofe_bin_range_mode(self) -> int:


### PR DESCRIPTION
Effects of this PR:
- Older (before d0fe3a7) versions of Potku no longer crash when trying to use .ini files that were produced by newer (1b5f398 and after) versions of Potku.
- Versions between d0fe3a7 and 1b5f398 cannot read color schemes from .ini files made by older or newer versions of Potku, but will revert to default value without crashing.

Closes #79.