### PR TITLE
Bugfixes

### DIFF
--- a/dialogs/measurement/settings.py
+++ b/dialogs/measurement/settings.py
@@ -32,6 +32,7 @@ __version__ = "2.0"
 import time
 
 import dialogs.dialog_functions as df
+import widgets.binding as bnd
 import modules.general_functions as gf
 import widgets.gui_utils as gutils
 
@@ -50,6 +51,7 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
     """
     Dialog class for handling the measurement parameter input.
     """
+    use_request_settings = bnd.bind("defaultSettingsCheckBox")
 
     def __init__(self, measurement: Measurement, icon_manager):
         """
@@ -94,8 +96,8 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
 
         self.tabs.addTab(self.detector_settings_widget, "Detector")
 
-        self.defaultSettingsCheckBox.setChecked(
-            self.measurement.use_request_settings)
+        self.use_request_settings = self.measurement.use_request_settings
+
         # TODO these should be set in the widget, not here
         self.measurement_settings_widget.nameLineEdit.setText(
             self.measurement.measurement_setting_file_name)
@@ -143,7 +145,7 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
 
         # Copy request settings without checking their validity. They
         # have been checked once in request settings anyway.
-        if self.defaultSettingsCheckBox.isChecked():
+        if self.use_request_settings:
             self.measurement.use_request_settings = True
 
             # Remove measurement-specific efficiency files
@@ -182,12 +184,14 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
                 self._remove_extra_files()
                 self.measurement.to_file()
                 return True
+
             except TypeError:
                 QtWidgets.QMessageBox.question(
                     self, "Warning",
                     "Some of the setting values have not been set.\n"
                     "Please input setting values to save them.",
                     QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
+
         return False
 
     def _save_settings_and_close(self):

--- a/dialogs/measurement/settings.py
+++ b/dialogs/measurement/settings.py
@@ -160,7 +160,7 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
             return True
 
         # Check the target and detector angles
-        if self.measurement_settings_widget.check_angles():
+        if not self.measurement_settings_widget.check_angles():
             return False
 
         if not self.tabs.currentWidget().fields_are_valid:

--- a/dialogs/measurement/settings.py
+++ b/dialogs/measurement/settings.py
@@ -161,36 +161,38 @@ class MeasurementSettingsDialog(QtWidgets.QDialog):
 
         # Check the target and detector angles
         if self.measurement_settings_widget.check_angles():
-            if not self.tabs.currentWidget().fields_are_valid:
-                QtWidgets.QMessageBox.critical(
-                    self, "Warning",
-                    "Some of the setting values have not been set.\n"
-                    "Please input values in fields indicated in red.",
-                    QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
-                return False
+            return False
 
-            # Use Measurement specific settings
-            try:
-                self.measurement.use_request_settings = False
+        if not self.tabs.currentWidget().fields_are_valid:
+            QtWidgets.QMessageBox.critical(
+                self, "Warning",
+                "Some of the setting values have not been set.\n"
+                "Please input values in fields indicated in red.",
+                QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
+            return False
 
-                # Set Detector object to settings widget
-                self.detector_settings_widget.obj = self.measurement.detector
+        # Use Measurement specific settings
+        try:
+            self.measurement.use_request_settings = False
 
-                # Update settings
-                self.measurement_settings_widget.update_settings()
-                self.detector_settings_widget.update_settings()
-                self.profile_settings_widget.update_settings()
+            # Set Detector object to settings widget
+            self.detector_settings_widget.obj = self.measurement.detector
 
-                self._remove_extra_files()
-                self.measurement.to_file()
-                return True
+            # Update settings
+            self.measurement_settings_widget.update_settings()
+            self.detector_settings_widget.update_settings()
+            self.profile_settings_widget.update_settings()
 
-            except TypeError:
-                QtWidgets.QMessageBox.question(
-                    self, "Warning",
-                    "Some of the setting values have not been set.\n"
-                    "Please input setting values to save them.",
-                    QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
+            self._remove_extra_files()
+            self.measurement.to_file()
+            return True
+
+        except TypeError:
+            QtWidgets.QMessageBox.question(
+                self, "Warning",
+                "Some of the setting values have not been set.\n"
+                "Please input setting values to save them.",
+                QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
 
         return False
 

--- a/dialogs/simulation/element_simulation_settings.py
+++ b/dialogs/simulation/element_simulation_settings.py
@@ -116,6 +116,13 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
             self.settings_updated.emit()
             self.close()
 
+    def use_request_settings_toggled(self) -> bool:
+        """Check if "use request settings" has been toggled."""
+        return self.use_default_settings != \
+            self.element_simulation.use_default_settings
+
+    # TODO: Make this function more similar to measurement and
+    #       simulation settings dialogs
     def update_settings(self):
         """Updates ElementSimulation settings and saves them into a file.
 
@@ -134,7 +141,10 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
 
         # TODO could compare default element simulation and this element
         #  simulation to see if reset is actually needed
-        if self.sim_widget.are_values_changed() or self.are_values_changed():
+        settings_changed = \
+            not self.use_default_settings \
+            and (self.sim_widget.are_values_changed() or self.are_values_changed())
+        if self.use_request_settings_toggled() or settings_changed:
             simulation = self.element_simulation.simulation
 
             if self.use_default_settings:
@@ -153,12 +163,16 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
             ):
                 return False
 
+        self.element_simulation.use_default_settings = self.use_default_settings
+        if self.use_default_settings:
+            self.element_simulation.clone_request_settings()
+        else:
+            self.sim_widget.update_settings()
+
         if self.element_simulation.name != self.sim_widget.name:
             # Remove current simu file if name has been changed
             self.element_simulation.remove_files()
 
-        self.element_simulation.use_default_settings = self.use_default_settings
-        self.sim_widget.update_settings()
         # TODO remove files with old name, if name has changed
 
         self.element_simulation.to_file()

--- a/dialogs/simulation/settings.py
+++ b/dialogs/simulation/settings.py
@@ -137,6 +137,18 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
             exts={".detector"}
         )
 
+    def use_request_settings_toggled(self) -> bool:
+        """Check if "use request settings" has been toggled."""
+        return self.use_request_settings != self.simulation.use_request_settings
+
+    def values_changed(self) -> bool:
+        """Check if measurement or detector settings have changed."""
+        if self.measurement_settings_widget.are_values_changed():
+            return True
+        if self.detector_settings_widget.values_changed():
+            return True
+        return False
+
     def _update_parameters(self):
         """
          Update Simulation's Run, Detector and Target objects. If simulation
@@ -163,7 +175,7 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
                 QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
             return False
 
-        if (self.use_request_settings != self.simulation.use_request_settings) \
+        if self.use_request_settings_toggled() \
                 or (not self.use_request_settings and self.values_changed()):
             # User has switched from simulation settings to request settings,
             # or vice versa. Confirm if the user wants to delete old simulations
@@ -222,18 +234,3 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
         """
         if self._update_parameters():
             self.close()
-
-    def values_changed(self):
-        """
-        Check if measurement or detector settings have
-        changed.
-
-        Return:
-
-            True or False.
-        """
-        if self.measurement_settings_widget.are_values_changed():
-            return True
-        if self.detector_settings_widget.values_changed():
-            return True
-        return False

--- a/dialogs/simulation/settings.py
+++ b/dialogs/simulation/settings.py
@@ -9,7 +9,7 @@ telescope. For physics calculations Potku uses external
 analyzation components.
 Copyright (C) 2013-2018 Jarkko Aalto, Severi Jääskeläinen, Samuel Kaiponen,
 Timo Konu, Samuli Kärkkäinen, Samuli Rahkonen, Miika Raunio, Heta Rekilä and
-Sinikka Siironen, 2020 Juhani Sundell
+Sinikka Siironen, 2020 Juhani Sundell, Tuomas Pitkänen
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -25,17 +25,13 @@ You should have received a copy of the GNU General Public License
 along with this program (file named 'LICENCE').
 """
 __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä " \
-             "\n Sinikka Siironen \n Juhani Sundell"
+             "\n Sinikka Siironen \n Juhani Sundell \n Tuomas Pitkänen"
 __version__ = "2.0"
-
-import time
 
 import dialogs.dialog_functions as df
 import widgets.binding as bnd
 import modules.general_functions as gf
 import widgets.gui_utils as gutils
-
-from pathlib import Path
 
 from modules.simulation import Simulation
 
@@ -76,9 +72,9 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
         self.resize(int(self.geometry().width() * 1.2),
                     int(screen_geometry.size().height() * 0.8))
         self.defaultSettingsCheckBox.stateChanged.connect(
-            self.__change_used_settings)
-        self.OKButton.clicked.connect(self.__save_settings_and_close)
-        self.applyButton.clicked.connect(self.__update_parameters)
+            self._change_used_settings)
+        self.OKButton.clicked.connect(self._save_settings_and_close)
+        self.applyButton.clicked.connect(self._update_parameters)
         self.cancelButton.clicked.connect(self.close)
 
         preset_folder = gutils.get_preset_dir(
@@ -122,7 +118,7 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
 
         self.exec()
 
-    def __change_used_settings(self):
+    def _change_used_settings(self):
         """Set specific settings enabled or disabled based on the "Use
         request settings" checkbox.
         """
@@ -132,7 +128,16 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
         else:
             self.tabs.setEnabled(True)
 
-    def __update_parameters(self):
+    def _remove_extra_files(self):
+        gf.remove_matching_files(
+            self.simulation.directory,
+            exts={".measurement", ".target"})
+        gf.remove_matching_files(
+            self.simulation.directory / "Detector",
+            exts={".detector"}
+        )
+
+    def _update_parameters(self):
         """
          Update Simulation's Run, Detector and Target objects. If simulation
          specific parameters are in use, save them into a file.
@@ -171,18 +176,25 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
                     msg="simulation settings"):
                 return False
 
-        try:
-            # Update simulation settings
-            self.simulation.use_request_settings = \
-                self.use_request_settings
+        # Copy request settings without checking their validity. They
+        # have been checked once in request settings anyway.
+        if self.use_request_settings:
+            self.simulation.use_request_settings = True
 
-            # Remove measurement-specific efficiency files
-            if self.simulation.use_request_settings and \
-                    self.simulation.detector is not \
+            # Remove simulation-specific efficiency files
+            if self.simulation.detector is not \
                     self.simulation.request.default_detector:
                 self.simulation.detector.remove_efficiency_files()
 
-            det_folder_path = Path(self.simulation.directory, "Detector")
+            self.simulation.clone_request_settings()
+
+            self._remove_extra_files()
+            self.simulation.to_file()
+            return True
+
+        try:
+            # Update simulation settings
+            self.simulation.use_request_settings = False
 
             # Set Detector object to settings widget
             self.detector_settings_widget.obj = self.simulation.detector
@@ -190,15 +202,8 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
             # Update settings
             self.measurement_settings_widget.update_settings()
             self.detector_settings_widget.update_settings()
-            self.simulation.detector.path = Path(
-                det_folder_path, f"{self.simulation.detector.name}.detector")
 
-            # Delete possible extra files
-            gf.remove_matching_files(self.simulation.directory,
-                                     exts={".measurement", ".target"})
-            gf.remove_matching_files(
-                det_folder_path, exts={".detector"}
-            )
+            self._remove_extra_files()
             self.simulation.to_file()
             return True
 
@@ -211,11 +216,11 @@ class SimulationSettingsDialog(QtWidgets.QDialog):
 
         return False
 
-    def __save_settings_and_close(self):
+    def _save_settings_and_close(self):
         """Saves settings and closes the dialog if __update_parameters returns
         True.
         """
-        if self.__update_parameters():
+        if self._update_parameters():
             self.close()
 
     def values_changed(self):

--- a/modules/detector.py
+++ b/modules/detector.py
@@ -374,7 +374,7 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         (i.e. 1H-example.eff becomes 1H.eff).
         """
         destination = self.get_used_efficiencies_dir()
-        destination.mkdir(exist_ok=True)
+        destination.mkdir(exist_ok=True, parents=True)
         # Remove previous files
         gf.remove_matching_files(destination, {".eff"})
 

--- a/modules/request.py
+++ b/modules/request.py
@@ -190,7 +190,7 @@ class Request(ElementSimulationContainer):
             # Create default detector for request
             detector = Detector(
                 Path(self.default_detector_folder, "Default.detector"),
-                name="Default-detector",
+                name="Default",
                 description="These are default detector settings.",
                 save_on_creation=save_on_creation)
 

--- a/ui_files/ui_request_detector_settings.ui
+++ b/ui_files/ui_request_detector_settings.ui
@@ -632,7 +632,7 @@ T</string>
                   </sizepolicy>
                  </property>
                  <property name="text">
-                  <string>Execute...</string>
+                  <string>Execute... (please re-save cuts first if you have made changes to beam settings)</string>
                  </property>
                 </widget>
                </item>

--- a/widgets/detector_settings.py
+++ b/widgets/detector_settings.py
@@ -121,6 +121,7 @@ class DetectorSettingsWidget(QtWidgets.QWidget, bnd.PropertyTrackingWidget,
         self._enable_remove_btn()
 
         # Calibration settings
+        # TODO: Require saving affected cuts if beam setting has been changed
         self.executeCalibrationButton.clicked.connect(
             self.__open_calibration_dialog)
         self.executeCalibrationButton.setEnabled(


### PR DESCRIPTION
- Fix efficiency file copying causing a crash on measurements that don't use request settings. This made energy spectra and depth profiles unusable.
- Fix being able to edit setting that use request settings by disabling the setting, changing values and re-enabling default settings
- Improve element simulation setting copying
- Remind user to re-save cuts before doing calibration with modified beam settings. Workaround for #98