### PR TITLE
Elem sim settings copy

### DIFF
--- a/modules/element_simulation.py
+++ b/modules/element_simulation.py
@@ -920,16 +920,9 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
     def get_mcerd_params(self) -> Tuple[Dict, Run, Detector]:
         """Returns the parameters for MCERD simulations.
         """
-        # TODO: The settings part could probably be simplified to just
-        #       `settings = self.get_settings()`
-        #       now that clone_request_settings has been added.
-        if self.use_default_settings:
-            settings = self.request.default_element_simulation.get_settings()
-        else:
-            settings = self.get_settings()
-
-        run = self.simulation.get_used_run()
-        detector = self.simulation.get_used_detector()
+        settings = self.get_settings()
+        run = self.simulation.run
+        detector = self.simulation.detector
 
         return settings, run, detector
 

--- a/modules/element_simulation.py
+++ b/modules/element_simulation.py
@@ -124,7 +124,9 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
                  seed_number=101, minimum_energy=1.0, channel_width=0.025,
                  use_default_settings=True, optimization_recoils=None,
                  optimized_fluence=None, save_on_creation=True):
-        """Initializes ElementSimulation.
+        """Initializes ElementSimulation. Most arguments are ignored if
+        use_default_settings is True.
+
         Args:
             directory: Folder of simulation that contains the ElementSimulation.
             request: Request object reference.
@@ -172,20 +174,38 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
 
         self.recoil_elements = recoil_elements
 
-        self.simulation_type = SimulationType(simulation_type.upper())
-        self.simulation_mode = SimulationMode(simulation_mode.lower())
-
-        self.number_of_ions = number_of_ions
-        self.number_of_preions = number_of_preions
-        self.number_of_scaling_ions = number_of_scaling_ions
-        self.number_of_recoils = number_of_recoils
-        self.minimum_scattering_angle = minimum_scattering_angle
-        self.minimum_main_scattering_angle = minimum_main_scattering_angle
-        self.minimum_energy = minimum_energy
-        self.seed_number = seed_number
-        self.channel_width = channel_width
-
+        # TODO: Rename to use_request_settings
         self.use_default_settings = use_default_settings
+        if self.use_default_settings:
+            # Initialize fields to prevent KeyErrors during
+            # self.clone_request_settings()
+            self.simulation_type = None
+            self.simulation_mode = None
+
+            self.number_of_ions = None
+            self.number_of_preions = None
+            self.number_of_scaling_ions = None
+            self.number_of_recoils = None
+            self.minimum_scattering_angle = None
+            self.minimum_main_scattering_angle = None
+            self.minimum_energy = None
+            self.seed_number = None
+            self.channel_width = None
+
+            self.clone_request_settings()
+        else:
+            self.simulation_type = SimulationType(simulation_type.upper())
+            self.simulation_mode = SimulationMode(simulation_mode.lower())
+
+            self.number_of_ions = number_of_ions
+            self.number_of_preions = number_of_preions
+            self.number_of_scaling_ions = number_of_scaling_ions
+            self.number_of_recoils = number_of_recoils
+            self.minimum_scattering_angle = minimum_scattering_angle
+            self.minimum_main_scattering_angle = minimum_main_scattering_angle
+            self.minimum_energy = minimum_energy
+            self.seed_number = seed_number
+            self.channel_width = channel_width
 
         if self.name_prefix != "":
             name = self.name_prefix + "-" + self.name
@@ -917,6 +937,9 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
         """Clone settings from request."""
         settings = self.request.default_element_simulation.get_settings()
         self.set_settings(**settings)
+
+        self.channel_width = \
+            self.request.default_element_simulation.channel_width
 
     def optimization_results_to_file(self, cut_file: Optional[Path] = None):
         """Saves optimizations results to file if they exist.

--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -302,21 +302,6 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
             logging.getLogger("request").info(log)
         self.set_loggers(self.directory, self.request.directory)
 
-    def get_used_detector(self) -> Detector:
-        """Returns the Detector object that is currently used by this
-        Simulation.
-        """
-        if self.use_request_settings:
-            return self.request.default_detector
-        return self.detector
-
-    def get_used_run(self) -> Run:
-        """Returns the Run object that is currently used by this Simulation.
-        """
-        if self.use_request_settings:
-            return self.request.default_run
-        return self.run
-
     def get_measurement_file(self) -> Path:
         """Returns the path to .measurement file that contains the settings
         of this Simulation.

--- a/tests/integration/test_element_simulation.py
+++ b/tests/integration/test_element_simulation.py
@@ -6,7 +6,7 @@ Potku is a graphical user interface for analyzation and
 visualization of measurement data collected from a ToF-ERD
 telescope. For physics calculations Potku uses external
 analyzation components.
-Copyright (C) 2020 Juhani Sundell
+Copyright (C) 2020 Juhani Sundell, Tuomas Pitkänen
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -21,7 +21,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program (file named 'LICENCE').
 """
-__author__ = "Juhani Sundell"
+__author__ = "Juhani Sundell \n Tuomas Pitkänen"
 __version__ = "2.0"
 
 import unittest
@@ -47,6 +47,9 @@ from modules.sample import Sample
 
 
 class TestElementSimulationSettings(unittest.TestCase):
+    # TODO: This test doesn't make much sense after changing how default
+    #       settings work with ElementSimulations. Convert this into a
+    #       general integration test for ElementSimulation.
     def test_elementsimulation_settings(self):
         """This tests that ElementSimulation is run with the correct settings
         depending on how 'use_default_settings' and 'use_request_settings'
@@ -109,22 +112,24 @@ class TestElementSimulationSettings(unittest.TestCase):
                 elem_sim.number_of_ions,
                 request.default_element_simulation.number_of_ions)
 
-            # Test with all setting combinations
-            elem_sim.use_default_settings = True
-            sim.use_request_settings = True
             self.assert_expected_settings(elem_sim, request, sim)
 
-            elem_sim.use_default_settings = True
-            sim.use_request_settings = False
-            self.assert_expected_settings(elem_sim, request, sim)
-
-            elem_sim.use_default_settings = False
-            sim.use_request_settings = True
-            self.assert_expected_settings(elem_sim, request, sim)
-
-            elem_sim.use_default_settings = False
-            sim.use_request_settings = False
-            self.assert_expected_settings(elem_sim, request, sim)
+            # # Test with all setting combinations
+            # elem_sim.use_default_settings = True
+            # sim.use_request_settings = True
+            # self.assert_expected_settings(elem_sim, request, sim)
+            #
+            # elem_sim.use_default_settings = True
+            # sim.use_request_settings = False
+            # self.assert_expected_settings(elem_sim, request, sim)
+            #
+            # elem_sim.use_default_settings = False
+            # sim.use_request_settings = True
+            # self.assert_expected_settings(elem_sim, request, sim)
+            #
+            # elem_sim.use_default_settings = False
+            # sim.use_request_settings = False
+            # self.assert_expected_settings(elem_sim, request, sim)
 
         self.assertFalse(tmp_dir.exists())
 
@@ -146,17 +151,9 @@ class TestElementSimulationSettings(unittest.TestCase):
 
 def get_expected_settings(elem_sim: ElementSimulation, request: Request,
                           simulation: Simulation):
-    if simulation.use_request_settings:
-        detector = request.default_detector
-        run = request.default_run
-    else:
-        detector = simulation.detector
-        run = simulation.run
-
-    if elem_sim.use_default_settings:
-        expected_sim = request.default_element_simulation
-    else:
-        expected_sim = elem_sim
+    detector = simulation.detector
+    run = simulation.run
+    expected_sim = elem_sim
 
     return {
         "simulation_type": elem_sim.simulation_type,

--- a/tests/unit/test_element_simulation.py
+++ b/tests/unit/test_element_simulation.py
@@ -309,7 +309,7 @@ class TestElementSimulation(unittest.TestCase):
         }
         self.elem_sim = ElementSimulation(
             tempfile.gettempdir(), mo.get_request(), [self.main_rec],
-            save_on_creation=False, **self.kwargs)
+            save_on_creation=False, use_default_settings=False, **self.kwargs)
 
     def test_get_full_name(self):
         self.assertEqual("Default", self.elem_sim.get_full_name())
@@ -317,6 +317,20 @@ class TestElementSimulation(unittest.TestCase):
         self.assertEqual("foo", self.elem_sim.get_full_name())
         self.elem_sim.name_prefix = "bar"
         self.assertEqual("bar-foo", self.elem_sim.get_full_name())
+
+    def test_use_default_settings(self):
+        """Tests that use_default_settings overrides kwargs"""
+        elem_sim2 = ElementSimulation(
+            tempfile.gettempdir(), self.elem_sim.request,
+            [mo.get_recoil_element()], save_on_creation=False,
+            use_default_settings=True, **self.kwargs)
+
+        self.assertEqual(
+            self.elem_sim.request.default_element_simulation.get_settings(),
+            elem_sim2.get_settings())
+        for key, value in self.kwargs.items():
+            self.assertNotEqual(value, getattr(elem_sim2, key))
+
 
     def test_json_contents(self):
         self.elem_sim.use_default_settings = False
@@ -331,7 +345,8 @@ class TestElementSimulation(unittest.TestCase):
             "seed_number": 101,
             "number_of_recoils": 10,
             "number_of_scaling_ions": 5,
-            "main_recoil": self.main_rec.name
+            "main_recoil": self.main_rec.name,
+            "use_default_settings": "False"
         }
         expected.update(self.kwargs)
         result = self.elem_sim.get_json_content()
@@ -344,7 +359,6 @@ class TestElementSimulation(unittest.TestCase):
                                    "is running particularly slow. Run the "
                                    "test again to confirm results."
                                )
-        self.assertEqual("False", result.pop("use_default_settings"))
         self.assertEqual(expected, result)
 
     def test_simulation_settings(self):


### PR DESCRIPTION
- fix ElementSimulation not copying request settings on creation (continuation to #80)
- update get_mcerd_params and remove unused methods