### PR TITLE
energy_spectrum module uses subprocess_utils

### DIFF
--- a/modules/base.py
+++ b/modules/base.py
@@ -43,6 +43,9 @@ ElemSimList = List["ElementSimulation"]
 Range = Tuple[Union[float, int], Union[float, int]]
 StrTuple = Tuple[str, str]
 
+# Helper type hint for energy spectrum data
+Espe = List[Tuple[float, float]]
+
 
 class ElementSimulations(NamedTuple):
     running_simulations: ElemSimList

--- a/modules/energy_spectrum.py
+++ b/modules/energy_spectrum.py
@@ -49,10 +49,9 @@ from . import subprocess_utils as sutils
 from .parsing import ToFListParser
 from .measurement import Measurement
 from .element import Element
+from .base import Espe
 
 TofListData = List[Tuple[float, float, float, int, float, str, float, int]]
-# TODO there should be a class for energy spectrum data
-Espe = List[Tuple[float, float]]
 
 
 # TODO rename and refactor functions
@@ -234,13 +233,13 @@ class EnergySpectrum:
                 else:
                     tof_list_file = None
 
-                espe = sutils.process_output(
+                tof_list_data = sutils.process_output(
                     tof_list,
                     tof_parser.parse_str,
                     file=tof_list_file,
                     text_func=lambda x: f"{' '.join(str(col) for col in x)}\n"
                 )
-                return espe
+                return tof_list_data
         except Exception as e:
             msg = f"Error in tof_list: {e}"
             if logger_name is not None:

--- a/modules/energy_spectrum.py
+++ b/modules/energy_spectrum.py
@@ -31,18 +31,28 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen " \
 __version__ = "2.0"
 
 import logging
-import os
 import subprocess
 import platform
 
 import numpy as np
 
 from pathlib import Path
+from typing import List
+from typing import Tuple
+from typing import Optional
+from typing import Sequence
+from typing import Dict
 
+from .observing import ProgressReporter
 from . import general_functions as gf
+from . import subprocess_utils as sutils
 from .parsing import ToFListParser
 from .measurement import Measurement
 from .element import Element
+
+TofListData = List[Tuple[float, float, float, int, float, str, float, int]]
+# TODO there should be a class for energy spectrum data
+Espe = List[Tuple[float, float]]
 
 
 # TODO rename and refactor functions
@@ -50,8 +60,14 @@ from .element import Element
 class EnergySpectrum:
     """Class for energy spectrum.
     """
-    def __init__(self, measurement: Measurement, cut_files, spectrum_width,
-                 progress=None, no_foil=False):
+    def __init__(
+            self,
+            measurement: Measurement,
+            cut_files: Sequence[Path],
+            spectrum_width: float,
+            progress: Optional[ProgressReporter] = None,
+            no_foil: bool = False,
+            verbose: bool = True):
         """Inits energy spectrum
         
         Args:
@@ -61,22 +77,25 @@ class EnergySpectrum:
             spectrum_width: Float representing energy spectrum graph width.
             progress: ProgressReporter object.
             no_foil: whether foil thickness is set to 0 when running tof_list
+            verbose: whether tof_list's stderr is printed to console
         """
-        self.__measurement = measurement
-        self.__global_settings = self.__measurement.request.global_settings
-        self.__cut_files = cut_files
-        self.__spectrum_width = spectrum_width
-        self.__directory_es = measurement.get_energy_spectra_dir()
-        # TODO ATM tof_in is generated twice when calculating espes. This
-        #      should be refactored
-        tof_in_file = self.__measurement.generate_tof_in(no_foil=no_foil)
-        self.__tof_listed_files = self.__load_cuts(
-            no_foil=no_foil, progress=progress, tof_in_file=tof_in_file)
+        self._measurement = measurement
+        self._global_settings = self._measurement.request.global_settings
+        self._cut_files = cut_files
+        self._spectrum_width = spectrum_width
+        self._directory_es = measurement.get_energy_spectra_dir()
+        self._tof_listed_files = self._load_cuts(
+            no_foil=no_foil, progress=progress, verbose=verbose)
 
     @staticmethod
-    def calculate_measured_spectra(measurement: Measurement, cut_files,
-                                   spectrum_width, progress=None,
-                                   use_efficiency=False, no_foil=False):
+    def calculate_measured_spectra(
+            measurement: Measurement,
+            cut_files: Sequence[Path],
+            spectrum_width: float,
+            progress: Optional[ProgressReporter] = None,
+            use_efficiency: bool = False,
+            no_foil: bool = False,
+            verbose: bool = True) -> Dict[str, Espe]:
         """Calculates the measured energy spectra for the given .cut files.
 
         Args:
@@ -88,16 +107,21 @@ class EnergySpectrum:
             use_efficiency: whether efficiency is taken into account when
                 spectra is calculated
             no_foil: whether foil thickness is set to 0 when running tof_list
+            verbose: whether tof_list's stderr is printed to console
 
         Returns:
             energy spectra as a dictionary
         """
-        es = EnergySpectrum(measurement, cut_files, spectrum_width,
-                            progress=progress, no_foil=no_foil)
+        es = EnergySpectrum(
+            measurement, cut_files, spectrum_width, progress=progress,
+            no_foil=no_foil, verbose=verbose)
         return es.calculate_spectrum(
             use_efficiency=use_efficiency, no_foil=no_foil)
 
-    def calculate_spectrum(self, use_efficiency=False, no_foil=False):
+    def calculate_spectrum(
+            self,
+            use_efficiency: bool = False,
+            no_foil: bool = False) -> Dict[str, Espe]:
         """Calculate energy spectrum data from cut files.
 
         Args:
@@ -105,18 +129,19 @@ class EnergySpectrum:
                 spectra is calculated
             no_foil: whether foil thickness is set to 0 or original foil
                 thickness is used
-        
+
         Returns:
             energy spectra as a dictionary
         """
-        # First generate tof.in file to match the measurement whose energy
-        # spectra are drawn.
-        self.__measurement.generate_tof_in(no_foil=no_foil)
         return EnergySpectrum._calculate_spectrum(
-            self.__tof_listed_files, self.__spectrum_width, self.__measurement,
-            self.__directory_es, use_efficiency=use_efficiency, no_foil=no_foil)
+            self._tof_listed_files, self._spectrum_width, self._measurement,
+            self._directory_es, use_efficiency=use_efficiency, no_foil=no_foil)
 
-    def __load_cuts(self, no_foil=False, progress=None, tof_in_file=None):
+    def _load_cuts(
+            self,
+            no_foil: bool = False,
+            progress: Optional[ProgressReporter] = None,
+            verbose: bool = True) -> Dict[str, TofListData]:
         """Loads cut files through tof_list into list.
 
         Args:
@@ -126,44 +151,52 @@ class EnergySpectrum:
         Return:
             Returns list of cut files' tof_list results.
         """
+        tof_in = self._measurement.generate_tof_in(no_foil=no_foil)
         cut_dict = {}
         try:
-            save_output = self.__global_settings.is_es_output_saved()
-            count = len(self.__cut_files)
+            if self._global_settings.is_es_output_saved():
+                directory = self._directory_es
+            else:
+                directory = None
+
+            count = len(self._cut_files)
             
-            self.__directory_es.mkdir(exist_ok=True)
+            self._directory_es.mkdir(exist_ok=True)
             
-            for i, cut_file in enumerate(self.__cut_files):
-                filename_split = os.path.basename(cut_file).split('.')
+            for i, cut_file in enumerate(self._cut_files):
+                # TODO move cut file handling to cut_file module
+                filename_split = cut_file.name.split('.')
                 element = Element.from_string(filename_split[1])
 
-                if len(filename_split) == 5:  # Regular cut file
-                    # TODO name the split parts
-                    key = "{0}.{1}.{2}".format(
-                        element, filename_split[2], filename_split[3])
-                else:  # Elemental Losses cut file
-                    key = "{0}.{1}.{2}.{3}".format(
-                        element, filename_split[2], filename_split[3],
-                        filename_split[4])
+                if not (5 <= len(filename_split) <= 6):
+                    raise ValueError(
+                        f"Could not parse cut file name: {cut_file}")
+
+                key = ".".join([str(element), *filename_split[2:-1]])
 
                 cut_dict[key] = EnergySpectrum.tof_list(
-                    cut_file, self.__directory_es, save_output=save_output,
-                    no_foil=no_foil, logger_name=self.__measurement.name,
-                    tof_in_file=tof_in_file)
+                    cut_file, directory, no_foil=no_foil,
+                    logger_name=self._measurement.name,
+                    tof_in=tof_in, verbose=verbose)
 
                 if progress is not None:
                     progress.report(i / count * 90)
         except Exception as e:
             msg = f"Could not calculate Energy Spectrum: {e}."
-            logging.getLogger(self.__measurement.name).error(msg)
+            logging.getLogger(self._measurement.name).error(msg)
         finally:
             if progress is not None:
                 progress.report(100)
         return cut_dict
 
     @staticmethod
-    def tof_list(cut_file: Path, directory: Path = None, save_output=False,
-                 no_foil=False, logger_name=None, tof_in_file="tof.in"):
+    def tof_list(
+            cut_file: Path,
+            directory: Optional[Path] = None,
+            no_foil: bool = False,
+            logger_name: Optional[str] = None,
+            tof_in: Path = Path("tof.in"),
+            verbose: bool = True) -> TofListData:
         """ToF_list
 
         Arstila's tof_list executables interface for Python.
@@ -172,57 +205,42 @@ class EnergySpectrum:
             cut_file: A Path representing cut file to be ran through tof_list.
             directory: A Path representing measurement's energy spectrum
                 directory.
-            save_output: A boolean representing whether tof_list output is
-                saved.
             no_foil: whether foil thickness was used when .cut files were
                 generated. This affects the file path when saving output
             logger_name: name of a logging entity
+            tof_in: path to tof_in_file
+            verbose: whether tof_list's stderr is printed to console
 
         Returns:
             Returns cut file as list transformed through Arstila's tof_list
             program.
         """
-        bin_dir = gf.get_bin_dir()
-
         if not cut_file:
             return []
 
         tof_parser = ToFListParser()
+        cmd = EnergySpectrum.get_command(tof_in, cut_file)
+        stderr = None if verbose else subprocess.DEVNULL
 
         try:
-            if platform.system() == 'Windows':
-                executable = str(bin_dir / "tof_list.exe")
-            else:
-                executable = "./tof_list"
+            with subprocess.Popen(
+                    cmd, cwd=gf.get_bin_dir(), stdout=subprocess.PIPE,
+                    universal_newlines=True, stderr=stderr) as tof_list:
 
-            cmd = executable, str(tof_in_file), str(cut_file)
-            p = subprocess.Popen(
-                cmd, cwd=bin_dir, stdout=subprocess.PIPE,
-                universal_newlines=True)
-
-            raw_output = iter(p.stdout.readline, "")
-            parsed_output = tof_parser.parse_strs(
-                raw_output, method="row", ignore="w")
-
-            if save_output:
-                if directory is None:
-                    directory = Path.cwd() / "energy_spectrum_output"
-
-                directory.mkdir(exist_ok=True)
-
-                if no_foil:
-                    foil_txt = ".no_foil"
+                if directory is not None:
+                    directory.mkdir(exist_ok=True)
+                    tof_list_file = EnergySpectrum.get_tof_list_file_name(
+                        directory, cut_file, no_foil=no_foil)
                 else:
-                    foil_txt = ""
+                    tof_list_file = None
 
-                es_file = directory / f"{cut_file.stem}{foil_txt}.tof_list"
-                ls = []
-                with es_file.open("w") as file:
-                    for row in parsed_output:
-                        file.write(f"{' '.join(str(col) for col in row)}\n")
-                        ls.append(row)
-                return ls
-            return list(parsed_output)
+                espe = sutils.process_output(
+                    tof_list,
+                    tof_parser.parse_str,
+                    file=tof_list_file,
+                    text_func=lambda x: f"{' '.join(str(col) for col in x)}\n"
+                )
+                return espe
         except Exception as e:
             msg = f"Error in tof_list: {e}"
             if logger_name is not None:
@@ -232,9 +250,49 @@ class EnergySpectrum:
             return []
 
     @staticmethod
-    def _calculate_spectrum(tof_listed_files, spectrum_width: float,
-                            measurement: Measurement, directory_es: Path,
-                            use_efficiency=False, no_foil=False):
+    def get_command(tof_in: Path, cut_file: Path) -> Tuple[str, str, str]:
+        """Returns the command for running tof_list.
+        """
+        if platform.system() == 'Windows':
+            executable = str(gf.get_bin_dir() / "tof_list.exe")
+        else:
+            executable = "./tof_list"
+        return executable, str(tof_in), str(cut_file)
+
+    @staticmethod
+    def get_tof_list_file_name(
+            directory: Path, cut_file: Path, no_foil: bool = False) -> Path:
+        foil_txt = ".no_foil" if no_foil else ""
+        return directory / f"{cut_file.stem}{foil_txt}.tof_list"
+
+    @staticmethod
+    def get_hist_file_name(
+            directory: Path, measurement_name: str, key: str,
+            no_foil: bool = False) -> Path:
+        foil_txt = ".no_foil" if no_foil else ""
+        measurement_name = Path(measurement_name)
+
+        return Path(
+            directory,
+            f"{measurement_name.name}.{key}{foil_txt}.hist")
+
+    @staticmethod
+    def pad_with_zeroes(espe: Espe, spectrum_width: float) -> Espe:
+        """Returns energy spectrum data that has been padded with zeroes at
+        both ends.
+        """
+        first_val = espe[0][0] - spectrum_width, 0
+        last_val = espe[-1][0] + spectrum_width, 0
+        return [first_val, *espe, last_val]
+
+    @staticmethod
+    def _calculate_spectrum(
+            tof_listed_files,
+            spectrum_width: float,
+            measurement: Measurement,
+            directory_es: Path,
+            use_efficiency: bool = False,
+            no_foil: bool = False) -> Dict[str, Espe]:
         """Calculate energy spectrum data from .tof_list files and writes the
         results to .hist files.
 
@@ -246,50 +304,34 @@ class EnergySpectrum:
             directory_es: directory
             use_efficiency: whether efficiency is taken into account when
                 spectra is calculated
-            no_foil: whether foil thickeness was set to 0 or not. This also
+            no_foil: whether foil thickness was set to 0 or not. This also
                 affects the file name
 
         Returns:
             contents of .hist files as a dict
         """
-        histed_files = {}
-        keys = tof_listed_files.keys()
-        invalid_keys = set()
+        espes = {}
         if use_efficiency:
             y_col = 6
         else:
             y_col = None
 
-        for key in keys:
-            histed_files[key] = gf.hist(
-                tof_listed_files[key], col=2, weight_col=y_col,
+        for key, tof_list_data in tof_listed_files.items():
+            espe = gf.hist(
+                tof_list_data, col=2, weight_col=y_col,
                 width=spectrum_width)
-            if not histed_files[key]:
-                invalid_keys.add(key)
+
+            if not espe:
+                espes[key] = espe
                 continue
-            first_val = (histed_files[key][0][0] - spectrum_width, 0)
-            last_val = (histed_files[key][-1][0] + spectrum_width, 0)
-            histed_files[key].insert(0, first_val)
-            histed_files[key].append(last_val)
 
-        for key in keys:
-            if key in invalid_keys:
-                continue
-            file = measurement.name
-            histed = histed_files[key]
+            espes[key] = EnergySpectrum.pad_with_zeroes(espe, spectrum_width)
 
-            if no_foil:
-                foil_txt = ".no_foil"
-            else:
-                foil_txt = ""
+            filename = EnergySpectrum.get_hist_file_name(
+                directory_es, measurement.name, key, no_foil=no_foil)
 
-            filename = Path(directory_es,
-                            "{0}.{1}{2}.hist".format(os.path.splitext(file)[0],
-                                                     key,
-                                                     foil_txt))
-            numpy_array = np.array(histed,
-                                   dtype=[('float', float), ('int', int)])
-
+            numpy_array = np.array(
+                espe, dtype=[("float", float), ("int", int)])
             np.savetxt(filename, numpy_array, delimiter=" ", fmt="%5.5f %6d")
 
-        return histed_files
+        return espes

--- a/modules/get_espe.py
+++ b/modules/get_espe.py
@@ -35,7 +35,6 @@ from pathlib import Path
 from typing import Optional
 from typing import Iterable
 from typing import Tuple
-from typing import List
 
 from . import general_functions as gf
 from . import subprocess_utils as sutils
@@ -44,10 +43,7 @@ from .beam import Beam
 from .detector import Detector
 from .target import Target
 from .parsing import CSVParser
-
-# Helper type hint for energy spectrum data
-# TODO create an actual class for spectrum data
-Espe = List[Tuple[float, float]]
+from .base import Espe
 
 
 class GetEspe:

--- a/tests/mock_objects.py
+++ b/tests/mock_objects.py
@@ -167,14 +167,17 @@ def get_simulation(request=None) -> Simulation:
         enable_logging=False)
 
 
-def get_measurement(request=None) -> Measurement:
+def get_measurement(request=None, path=None,
+                    save_on_creation=False) -> Measurement:
     """Returns a Measurement object.
     """
     if request is None:
         request = get_request()
 
+    path = path or _TEMP_DIR / "mesu"
+
     return Measurement(
-        request, _TEMP_DIR / "mesu", save_on_creation=False,
+        request, path=path, save_on_creation=save_on_creation,
         enable_logging=False)
 
 

--- a/tests/resource/cuts.1H.ERD.0.cut
+++ b/tests/resource/cuts.1H.ERD.0.cut
@@ -1,0 +1,20 @@
+Count: 10
+Type: ERD
+Weight Factor: 1.0
+Energy: 0
+Detector Angle: 0
+Scatter Element: 
+Element losses: False
+Split count: 1
+
+ToF, Energy, Event number
+1078 639 764
+1065 634 3688
+1059 647 7581
+1068 621 18325
+1081 628 28211
+1057 637 41176
+1086 635 53683
+1083 637 57440
+1080 622 109997
+1071 643 113722

--- a/tests/resource/cuts.1H.ERD.1.cut
+++ b/tests/resource/cuts.1H.ERD.1.cut
@@ -1,0 +1,18 @@
+Count: 8
+Type: ERD
+Weight Factor: 1.0
+Energy: 0
+Detector Angle: 0
+Scatter Element: 
+Element losses: False
+Split count: 1
+
+ToF, Energy, Event number
+1571 271 3462
+1825 165 6699
+1102 583 21439
+1127 544 56607
+1139 522 65090
+1261 451 66716
+1243 457 73391
+1133 538 106390

--- a/tests/resource/cuts.35Cl.RBS_Mn.0.cut
+++ b/tests/resource/cuts.35Cl.RBS_Mn.0.cut
@@ -1,0 +1,19 @@
+Count: 12
+Type: RBS
+Weight Factor: 1.0
+Energy: 0
+Detector Angle: 0
+Scatter Element: Mn
+Element losses: False
+Split count: 1
+
+ToF, Energy, Event number
+2621 3661 17
+2698 3680 27
+2639 3617 39
+2696 3834 41
+2600 3652 43
+2500 3610 47
+2668 3624 52
+2715 3619 63
+2604 3621 69

--- a/tests/resource/cuts.7Li.0.0.0.cut
+++ b/tests/resource/cuts.7Li.0.0.0.cut
@@ -1,0 +1,20 @@
+Count: 10
+Type: ERD
+Weight Factor: 1.081
+Energy: 0
+Detector Angle: 0
+Scatter Element: 
+Element losses: True
+Split count: 1
+
+ToF, Energy, Event number
+1446 2469 606
+1424 2349 817
+1415 2396 1041
+1423 2409 1140
+1453 2329 2008
+1478 2404 2552
+1457 2486 2994
+1475 2421 4765
+1459 2458 6153
+1415 2426 8845

--- a/tests/unit/test_energy_spectrum.py
+++ b/tests/unit/test_energy_spectrum.py
@@ -1,0 +1,225 @@
+# coding=utf-8
+"""
+Created on 04.10.2020
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2020 Juhani Sundell
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = "Juhani Sundell"
+__version__ = "2.0"
+
+import unittest
+import tests.mock_objects as mo
+import tests.utils as utils
+import tempfile
+import os
+
+from pathlib import Path
+
+from modules.energy_spectrum import EnergySpectrum
+
+
+class TestCalculateMeasuredSpectra(unittest.TestCase):
+    def test_calculation_returns_expected_values_when_ch_equals_02(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            mesu = mo.get_measurement(
+                path=tmp_dir / "mesu.info", save_on_creation=True)
+            es = self.run_spectra_calculation(
+                mesu, tmp_dir, spectrum_width=0.2)
+            self.assertEqual(self.expected_02, es)
+
+    def test_calculation_returns_expected_values_when_ch_equals_05(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            mesu = mo.get_measurement(
+                path=tmp_dir / "mesu.info", save_on_creation=True)
+            es = self.run_spectra_calculation(
+                mesu, tmp_dir, spectrum_width=0.5)
+            self.assertEqual(self.expected_05, es)
+
+    def test_spectra_files_are_created(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            mesu = mo.get_measurement(
+                path=tmp_dir / "mesu.info", save_on_creation=True)
+            self.run_spectra_calculation(
+                mesu, tmp_dir, spectrum_width=0.5)
+
+            expected = sorted([
+                *self.expected_hist_files, *self.expected_tof_list_files
+            ])
+            spectra_files = sorted(os.listdir(mesu.get_energy_spectra_dir()))
+            self.assertEqual(expected, spectra_files)
+
+    def test_tof_list_file_contents_are_expected(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            mesu = mo.get_measurement(
+                path=tmp_dir / "mesu.info", save_on_creation=True)
+            self.run_spectra_calculation(
+                mesu, tmp_dir, spectrum_width=0.5)
+
+            tof_file = mesu.get_energy_spectra_dir() / "cuts.1H.ERD.0.tof_list"
+
+            with tof_file.open("r") as f:
+                self.assertEqual(
+                    self.expected_1h_0_tof_list_content, f.readlines()
+                )
+
+    @staticmethod
+    def run_spectra_calculation(mesu, tmp_dir: Path, **kwargs):
+        """Helper for running spectra calculations"""
+        det = mesu.get_detector_or_default()
+        det.update_directories(tmp_dir / "Detector")
+        resource_dir = utils.get_resource_dir()
+        cuts = [
+            resource_dir / "cuts.1H.ERD.0.cut",
+            resource_dir / "cuts.1H.ERD.1.cut",
+            resource_dir / "cuts.35Cl.RBS_Mn.0.cut",
+            resource_dir / "cuts.7Li.0.0.0.cut",
+        ]
+        es = EnergySpectrum.calculate_measured_spectra(
+            mesu, cuts, **kwargs, verbose=False
+        )
+        return es
+
+    @property
+    def expected_02(self):
+        return {
+            "1H.ERD.0": [
+                (0.10000000000000003, 0),
+                (0.30000000000000004, 0.0),
+                (0.5000000000000001, 10.0),
+                (0.7000000000000002, 0),
+            ],
+            "1H.ERD.1": [
+                (-0.30000000000000004, 0),
+                (-0.1, 0.0),
+                (0.1, 1.0),
+                (0.30000000000000004, 2.0),
+                (0.5000000000000001, 5.0),
+                (0.7000000000000002, 0),
+            ],
+            "35Cl.RBS_Mn.0": [
+                (2.5, 0),
+                (2.7, 0.0),
+                (2.9000000000000004, 3.0),
+                (3.1000000000000005, 5.0),
+                (3.3000000000000007, 0.0),
+                (3.500000000000001, 1.0),
+                (3.700000000000001, 0),
+            ],
+            "7Li.0.0.0": [
+                (1.5, 0),
+                (1.7, 0.0),
+                (1.9, 2.0),
+                (2.1, 8.0),
+                (2.3000000000000003, 0),
+            ]
+        }
+
+    @property
+    def expected_05(self):
+        return {
+            "1H.ERD.0": [
+                (-0.25, 0),
+                (0.25, 0.0),
+                (0.75, 10.0),
+                (1.25, 0),
+            ],
+            "1H.ERD.1": [
+                (-0.75, 0),
+                (-0.25, 0.0),
+                (0.25, 7.0),
+                (0.75, 1.0),
+                (1.25, 0),
+            ],
+            "35Cl.RBS_Mn.0": [
+                (1.75, 0),
+                (2.25, 0.0),
+                (2.75, 3.0),
+                (3.25, 6.0),
+                (3.75, 0),
+            ],
+            "7Li.0.0.0": [
+                (0.75, 0),
+                (1.25, 0.0),
+                (1.75, 2.0),
+                (2.25, 8.0),
+                (2.75, 0),
+            ]
+        }
+
+    @property
+    def expected_tof_list_files(self):
+        return [
+            "cuts.1H.ERD.0.tof_list",
+            "cuts.1H.ERD.1.tof_list",
+            "cuts.35Cl.RBS_Mn.0.tof_list",
+            "cuts.7Li.0.0.0.tof_list",
+        ]
+
+    @property
+    def expected_hist_files(self):
+        return [
+            "Default.1H.ERD.0.hist",
+            "Default.1H.ERD.1.hist",
+            "Default.35Cl.RBS_Mn.0.hist",
+            "Default.7Li.0.0.0.hist",
+        ]
+
+    @property
+    def expected_1h_0_tof_list_content(self):
+        return [
+            '0.0 0.0 0.53703 1 1.0078 ERD 1.0 764\n',
+            '0.0 0.0 0.54982 1 1.0078 ERD 1.0 3688\n',
+            '0.0 0.0 0.55655 1 1.0078 ERD 1.0 7581\n',
+            '0.0 0.0 0.54644 1 1.0078 ERD 1.0 18325\n',
+            '0.0 0.0 0.53343 1 1.0078 ERD 1.0 28211\n',
+            '0.0 0.0 0.55838 1 1.0078 ERD 1.0 41176\n',
+            '0.0 0.0 0.5287 1 1.0078 ERD 1.0 53683\n',
+            '0.0 0.0 0.53113 1 1.0078 ERD 1.0 57440\n',
+            '0.0 0.0 0.53419 1 1.0078 ERD 1.0 109997\n',
+            '0.0 0.0 0.5434 1 1.0078 ERD 1.0 113722\n'
+        ]
+
+
+class TestGetTofListFileName(unittest.TestCase):
+    def test_when_no_foil_is_false(self):
+        directory = Path("tmp", "espes")
+        cut_file = Path("tmp", "cuts", "cuts.1H.ERD.0.cut")
+        no_foil = False
+        self.assertEqual(
+            directory / "cuts.1H.ERD.0.tof_list",
+            EnergySpectrum.get_tof_list_file_name(directory, cut_file, no_foil)
+        )
+
+    def test_when_no_foil_is_true(self):
+        directory = Path("tmp", "espes")
+        cut_file = Path("tmp", "cuts", "cuts.1H.ERD.0.cut")
+        no_foil = True
+        self.assertEqual(
+            directory / "cuts.1H.ERD.0.no_foil.tof_list",
+            EnergySpectrum.get_tof_list_file_name(directory, cut_file, no_foil)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`energy_spectrum` module now uses `subprocess_utils.process_output` function to parse energy spectrum data. Also added type hints and refactored other parts of the module. Tests and some resource files also included.