### PR TITLE
Fix AttributeError when selecting x axis unit (#114)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 /Sample-data
 /.idea
 /.settings
+.vscode
 /__pycache__
 /venv
 *.bak
@@ -52,6 +53,8 @@ Pipfile.lock
 /build
 
 # Directories used for bundling Mac version
-# (TODO remove these once Mac bundling is sorted out)
 /tk
 /tcl
+
+# Ignore hypothesis folder (in case it will be used in the future)
+.hypothesis

--- a/dialogs/measurement/depth_profile.py
+++ b/dialogs/measurement/depth_profile.py
@@ -178,9 +178,11 @@ class DepthProfileDialog(QtWidgets.QDialog):
 
                 # If reference density changed, update value to measurement
                 if self.__reference_density_spinbox is not None:
-                    if self.measurement.reference_density != \
+                    # FIXME selected reference density has no effect if
+                    #   measurement uses request settings
+                    if self.measurement.profile.reference_density != \
                             self.__reference_density_spinbox.value():
-                        self.measurement.reference_density = \
+                        self.measurement.profile.reference_density = \
                             self.__reference_density_spinbox.value()
                         self.measurement.to_file()
                 
@@ -225,7 +227,8 @@ class DepthProfileDialog(QtWidgets.QDialog):
         ref_density_spin_box.setEnabled(True)
         ref_density_spin_box.setLocale(self.locale)
 
-        ref_density_spin_box.setValue(self.measurement.reference_density)
+        ref_density_spin_box.setValue(
+            self.measurement.profile.reference_density)
 
         layout.insertWidget(3, ref_density_label)
         layout.insertWidget(4, ref_density_spin_box)

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -252,9 +252,14 @@ class Measurement(Logger, Serializable):
     """Measurement class to handle one measurement data.
     """
 
-    # __slots__ = "request", "tab_id", "name", "description",\
-    #             "modification_time", "run", "detector", "target", \
-    #             "profile"
+    __slots__ = "request", "tab_id", "name", "description",\
+                "modification_time", "run", "detector", "target", \
+                "profile", "path", "sample", "measurement_setting_file_name", \
+                "measurement_setting_file_description", "serial_number", \
+                "measurement_setting_modification_time", "data", \
+                "measurement_file", "directory", "use_request_settings", \
+                "selector"
+
     DIRECTORY_PREFIX = "Measurement_"
 
     def __init__(self, request, path, tab_id=-1, name="Default",

--- a/tests/unit/test_element_simulation.py
+++ b/tests/unit/test_element_simulation.py
@@ -308,7 +308,7 @@ class TestElementSimulation(unittest.TestCase):
             "number_of_preions": 3
         }
         self.elem_sim = ElementSimulation(
-            tempfile.gettempdir(), mo.get_request(), [self.main_rec],
+            Path(tempfile.gettempdir()), mo.get_request(), [self.main_rec],
             save_on_creation=False, use_default_settings=False, **self.kwargs)
 
     def test_get_full_name(self):
@@ -321,7 +321,7 @@ class TestElementSimulation(unittest.TestCase):
     def test_use_default_settings(self):
         """Tests that use_default_settings overrides kwargs"""
         elem_sim2 = ElementSimulation(
-            tempfile.gettempdir(), self.elem_sim.request,
+            Path(tempfile.gettempdir()), self.elem_sim.request,
             [mo.get_recoil_element()], save_on_creation=False,
             use_default_settings=True, **self.kwargs)
 
@@ -397,11 +397,10 @@ class TestElementSimulation(unittest.TestCase):
             number_of_ions_in_presimu="i dunno, two maybe?")
         self.assertEqual("i dunno, two maybe?", self.elem_sim.number_of_preions)
 
-    def test_slots(self):
+    def test_element_simulation_has_slots(self):
         """Tests that __slots__ declaration works.
         """
-        self.assertRaises(AttributeError,
-                          lambda: utils.slots_test(self.elem_sim))
+        utils.assert_has_slots(self.elem_sim)
 
     @patch("modules.get_espe.GetEspe.__init__", return_value=None)
     @patch("modules.get_espe.GetEspe.run", return_value=None)

--- a/tests/unit/test_foil.py
+++ b/tests/unit/test_foil.py
@@ -101,12 +101,10 @@ class TestFoil(unittest.TestCase):
                                foil.get_solid_angle(units="sr"),
                                places=places)
 
-    def test_slots(self):
+    def test_foils_have_slots(self):
         """Tests that __slots__ work properly for Foils"""
-        self.assertRaises(AttributeError,
-                          lambda: utils.slots_test(RectangularFoil()))
-        self.assertRaises(AttributeError,
-                          lambda: utils.slots_test(CircularFoil()))
+        utils.assert_has_slots(RectangularFoil())
+        utils.assert_has_slots(CircularFoil())
 
     def test_get_mcerd_params(self):
         unit_rec = RectangularFoil(size_x=1.0, size_y=1.0, distance=1.0)

--- a/tests/unit/test_measurement.py
+++ b/tests/unit/test_measurement.py
@@ -197,3 +197,9 @@ def get_extected_folder_structure(root, name):
             "tof_in": {}
         }
     }
+
+
+class TestMeasurement(unittest.TestCase):
+    def test_measurement_has_slots(self):
+        m = mo.get_measurement()
+        utils.assert_has_slots(m)

--- a/tests/unit/test_parsing.py
+++ b/tests/unit/test_parsing.py
@@ -241,13 +241,11 @@ class TestParsing(unittest.TestCase):
                                                  method="row",
                                                  separator="\t")))
 
-    def test_slots(self):
+    def test_parsers_have_slots(self):
         """Tests that __slots__ work in CSVParser.
         """
-        self.assertRaises(AttributeError,
-                          lambda: utils.slots_test(CSVParser()))
-        self.assertRaises(AttributeError,
-                          lambda: utils.slots_test(ToFListParser()))
+        utils.assert_has_slots(CSVParser())
+        utils.assert_has_slots(ToFListParser())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -27,7 +27,6 @@ __version__ = "2.0"
 
 import unittest
 import tempfile
-import os
 
 import tests.mock_objects as mo
 import tests.utils as utils
@@ -39,21 +38,10 @@ from modules.enums import OptimizationType
 
 
 class TestSimulation(unittest.TestCase):
-    def test_slots(self):
+    def test_simulation_has_slots(self):
         """Tests that __slots__ work correctly for Simulation."""
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            req = mo.get_request()
-            sim = Simulation(Path(temp_dir, "test.simu"), req)
-
-            # Logging needs to be disabled, otherwise loggers retain file
-            # handlers that prevent removing the temp_dir
-            utils.disable_logging()
-
-            self.assertRaises(AttributeError, lambda: utils.slots_test(sim))
-
-        # Just in case make sure that the temp_dir got deleted
-        self.assertFalse(os.path.exists(temp_dir))
+        sim = mo.get_simulation()
+        utils.assert_has_slots(sim)
 
     @patch("modules.mcerd.MCERD.run", return_value=mo.get_mcerd_stream())
     def test_get_active_simulation(self, mock_run):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,7 +39,10 @@ import modules.general_functions as gf
 
 from pathlib import Path
 from string import Template
-from typing import Dict
+from typing import (
+    Dict,
+    Any
+)
 
 
 def get_sample_data_dir() -> Path:
@@ -210,17 +213,22 @@ def run_without_warnings(func):
         return func()
 
 
-def slots_test(obj):
-    """Checks whether the given object has a working __slots__ declaration,
-    this function raises an AttributeError
+def assert_has_slots(obj: Any):
+    """Asserts that the given object has a __slots__ declaration. If not,
+    raises AssertionError.
     """
     if not hasattr(obj, "__slots__"):
-        return
+        raise AssertionError("Object does not have __slots__.")
     for i in range(1000):
         attr = f"xyz{i}"
         if not hasattr(obj, attr) and attr not in getattr(obj, "__slots__"):
-            setattr(obj, attr, "foo")
-            break
+            try:
+                setattr(obj, attr, "foo")
+                raise AssertionError(
+                    "__slots__ declaration not working as intended, perhaps "
+                    "due to inheritance.")
+            except AttributeError:
+                return
 
 
 def assert_folder_structure_equal(expected_structure: Dict, directory: Path):


### PR DESCRIPTION
Closes #114 

There is another bug though; when measurement uses request settings, the reference density set in the Depth Profile dialog has no effect. The value defined in Request Settings dialog is used instead.