### PR TITLE
Make reference density setting work for measurement's that use request settings

### DIFF
--- a/modules/depth_files.py
+++ b/modules/depth_files.py
@@ -53,6 +53,7 @@ from .element import Element
 from .parsing import CSVParser
 from .measurement import Measurement
 from .observing import ProgressReporter
+from .enums import DepthProfileUnit
 
 
 class DepthFileGenerator:
@@ -253,7 +254,11 @@ class DepthProfile:
         return len(self.depths)
 
     @classmethod
-    def from_file(cls, file_path, element=None, depth_units="nm"):
+    def from_file(
+            cls,
+            file_path: Path,
+            element: Optional[Element] = None,
+            depth_units: DepthProfileUnit = DepthProfileUnit.NM) -> "DepthProfile":
         """Reads a depth profile from a file and returns it.
 
         Args:
@@ -266,7 +271,7 @@ class DepthProfile:
         Return:
             DepthProfile object
         """
-        if depth_units == "nm":
+        if depth_units == DepthProfileUnit.NM:
             x_column = 2
         else:
             x_column = 0
@@ -509,7 +514,11 @@ class DepthProfileHandler:
         self.__absolute_profiles = {}
         self.__relative_profiles = {}
 
-    def read_directory(self, directory_path, elements, depth_units="nm"):
+    def read_directory(
+            self,
+            directory_path: Path,
+            elements,
+            depth_units: DepthProfileUnit = DepthProfileUnit.NM):
         """Reads depth files from the given directory that match the given
         set of elements and stores them internally as DepthProfiles.
 
@@ -525,8 +534,12 @@ class DepthProfileHandler:
         file_paths = get_depth_files(elements, directory_path)
         self.read_files(file_paths, elements, depth_units=depth_units)
 
-    def read_files(self, file_paths, elements, depth_units="nm",
-                   logger_name=None):
+    def read_files(
+            self,
+            file_paths,
+            elements,
+            depth_units: DepthProfileUnit = DepthProfileUnit.NM,
+            logger_name=None):
         """Reads depth files from given list of file paths that
         match the given set of elements.
 

--- a/modules/enums.py
+++ b/modules/enums.py
@@ -218,3 +218,14 @@ class Profile(str, Enum):
 
     def __str__(self):
         return self.value.capitalize()
+
+
+@enum.unique
+class DepthProfileUnit(str, Enum):
+    """X axis unit used for depth profiles.
+    """
+    ATOMS_PER_SQUARE_CM = "1e15 at./cm²"
+    NM = "nm"
+
+    def __str__(self):
+        return self.value

--- a/modules/general_functions.py
+++ b/modules/general_functions.py
@@ -424,20 +424,25 @@ def md5_for_file(f, block_size=2 ** 20):
     return md5.digest()
 
 
-def to_superscript(string):
-    """TODO"""
-    sups = {"0": "\u2070",
-            "1": "\xb9",
-            "2": "\xb2",
-            "3": "\xb3",
-            "4": "\u2074",
-            "5": "\u2075",
-            "6": "\u2076",
-            "7": "\u2077",
-            "8": "\u2078",
-            "9": "\u2079"}
+_SUPERSCRIPTED_DIGITS = {
+    "0": "\u2070",
+    "1": "\xb9",
+    "2": "\xb2",
+    "3": "\xb3",
+    "4": "\u2074",
+    "5": "\u2075",
+    "6": "\u2076",
+    "7": "\u2077",
+    "8": "\u2078",
+    "9": "\u2079",
+}
 
-    return "".join(sups.get(char, char) for char in string)
+
+def digits_to_superscript(string: str) -> str:
+    """Changes all digits in given string to superscript,
+    i.e. 'cm3' => 'cm³'.
+    """
+    return "".join(_SUPERSCRIPTED_DIGITS.get(char, char) for char in string)
 
 
 def lower_case_first(s: str) -> str:

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -166,9 +166,8 @@ class Measurements:
             # Create Measurement from file
             if file_path.exists() and file_path.suffix == ".info":
                 measurement = Measurement.from_file(
-                    file_path, mesu_file, profile_file,
-                    self.request, sample=sample, target=target,
-                    detector=detector, run=run, profile=profile)
+                    file_path, mesu_file, self.request, sample=sample,
+                    target=target, detector=detector, run=run, profile=profile)
 
                 measurement_folder_name = file_directory.name
                 serial_number = int(measurement_folder_name[
@@ -432,16 +431,21 @@ class Measurement(Logger, Serializable):
             profile_file, measurement_file, target_file, detector_file)
 
     @classmethod
-    def from_file(cls, info_file: Path, measurement_file: Path,
-                  profile_file: Path, request: "Request", detector=None,
-                  run=None, target=None, profile=None,
-                  sample=None) -> "Measurement":
+    def from_file(
+            cls,
+            info_file: Path,
+            measurement_file: Path,
+            request: "Request",
+            detector: Optional[Detector] = None,
+            run: Optional[Run] = None,
+            target: Optional[Target] = None,
+            profile: Optional[Profile] = None,
+            sample: Optional["Sample"] = None) -> "Measurement":
         """Read Measurement information from file.
 
         Args:
             info_file: Path to .info file.
             measurement_file: Path to .measurement file.
-            profile_file: Path to .profile file.
             request: Request that the Measurement belongs to.
             detector: Measurement's Detector object.
             run: Measurement's Run object.

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -350,7 +350,7 @@ class Measurement(Logger, Serializable):
         Return:
             A Detector.
         """
-        detector, *_ = self._get_used_settings()
+        detector, *_ = self.get_used_settings()
         return detector
 
     def get_measurement_file(self) -> Path:
@@ -965,7 +965,8 @@ class Measurement(Logger, Serializable):
         """
         self.selector.load(filename, progress=progress)
 
-    def _get_used_settings(self):
+    def get_used_settings(
+            self) -> Tuple[Detector, Run, Target, Profile, "Measurement"]:
         if self.use_request_settings:
             detector = self.request.default_detector
             run = self.request.default_run
@@ -1004,7 +1005,7 @@ class Measurement(Logger, Serializable):
         tof_in_file.parent.mkdir(exist_ok=True)
 
         # Get settings
-        detector, run, target, profile, measurement = self._get_used_settings()
+        detector, run, target, profile, measurement = self.get_used_settings()
         global_settings = self.request.global_settings
 
         reference_density = profile.reference_density

--- a/modules/request.py
+++ b/modules/request.py
@@ -214,6 +214,12 @@ class Request(ElementSimulationContainer):
                 Path(self.default_folder, "Default.measurement"),
                 Path(self.default_folder, "Default.profile"),
                 self, **kwargs)
+
+            # Ensure that use_request_settings flag is False. Otherwise
+            # measurement settings would not be saved when calling
+            # measurement.to_file (this was change was introduced in commit
+            # fc68f07)
+            measurement.use_request_settings = False
         else:
             # Create default measurement for request
             measurement = Measurement(

--- a/modules/request.py
+++ b/modules/request.py
@@ -209,11 +209,9 @@ class Request(ElementSimulationContainer):
         info_path = Path(self.default_folder, "Default.info")
         if info_path.exists():
             # Read measurement from file
+            measurement_file = Path(self.default_folder, "Default.measurement")
             measurement = Measurement.from_file(
-                info_path,
-                Path(self.default_folder, "Default.measurement"),
-                Path(self.default_folder, "Default.profile"),
-                self, **kwargs)
+                info_path, measurement_file, self, **kwargs)
 
             # Ensure that use_request_settings flag is False. Otherwise
             # measurement settings would not be saved when calling

--- a/tests/gui/test_depth_profile.py
+++ b/tests/gui/test_depth_profile.py
@@ -41,10 +41,10 @@ class TestDepthProfile(unittest.TestCase):
         parent.measurement = mo.get_measurement()
         parent.measurement.selector = Selector(
             parent.measurement, mo.get_global_settings().get_default_colors())
-        parent.icon_manager = Mock()
+        icon_manager = Mock()
         depth_dir, all_elems, _ = mo.get_sample_depth_files_and_elements()
         w = MatplotlibDepthProfileWidget(
-            parent, depth_dir, all_elems, {})
+            parent, depth_dir, all_elems, {}, icon_manager, {})
 
         w.close()
 

--- a/tests/gui/test_depth_profile_dialog.py
+++ b/tests/gui/test_depth_profile_dialog.py
@@ -1,0 +1,136 @@
+# coding=utf-8
+"""
+Created on 06.02.2021
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2021 Juhani Sundell
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = "Juhani Sundell"
+__version__ = "2.0"
+
+import unittest
+import tests.gui
+import tests.mock_objects as mo
+
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from modules.enums import CrossSection
+from dialogs.measurement.depth_profile import DepthProfileDialog
+
+
+class TestDialogInitialization(unittest.TestCase):
+    """Tests initialization conditions that various Dialogs must have.
+    """
+    def setUp(self) -> None:
+        self.measurement = mo.get_measurement()
+        self.global_settings = mo.get_global_settings()
+        self.parent_widget = Mock()
+
+    @patch("PyQt5.QtWidgets.QDialog.exec_")
+    def test_dialog_is_opened(self, mock_exec):
+        dialog = DepthProfileDialog(
+            self.parent_widget,
+            self.measurement,
+            self.global_settings)
+        dialog.close()
+        mock_exec.assert_called_once()
+
+    @patch("PyQt5.QtWidgets.QDialog.exec_")
+    def test_dialog_shows_correct_cross_section_model(self, _):
+        cross_section = CrossSection.LECUYER
+        self.global_settings.set_cross_sections(cross_section)
+        dialog = DepthProfileDialog(
+            self.parent_widget,
+            self.measurement,
+            self.global_settings)
+
+        self.assertEqual(
+            dialog.label_cross.text(),
+            str(cross_section))
+        dialog.close()
+
+    @patch("PyQt5.QtWidgets.QDialog.exec_")
+    def test_dialog_shows_correct_measurement_settings(self, _):
+        dialog = DepthProfileDialog(
+            self.parent_widget,
+            self.measurement,
+            self.global_settings)
+
+        self.assertEqual(
+            dialog.label_calibslope.text(),
+            str(self.measurement.detector.tof_slope))
+        self.assertEqual(
+            dialog.label_caliboffset.text(),
+            str(self.measurement.detector.tof_offset))
+        self.assertEqual(
+            dialog.label_depthstop.text(),
+            str(self.measurement.profile.depth_step_for_stopping))
+        self.assertEqual(
+            dialog.label_depthnumber.text(),
+            str(self.measurement.profile.number_of_depth_steps))
+        self.assertEqual(
+            dialog.label_depthbin.text(),
+            str(self.measurement.profile.depth_step_for_output))
+        self.assertEqual(
+            dialog.label_depthscale.text(),
+            f"{self.measurement.profile.depth_for_concentration_from} - "
+            f"{self.measurement.profile.depth_for_concentration_to}")
+
+        dialog.close()
+
+    @patch("PyQt5.QtWidgets.QDialog.exec_")
+    def test_dialog_shows_efficiency_files_are_correctly_shown(self, _):
+        dialog = DepthProfileDialog(
+            self.parent_widget,
+            self.measurement,
+            self.global_settings)
+
+        expected = "No efficiency files."
+
+        self.assertEqual(
+            dialog.label_efficiency_files.text(),
+            expected
+        )
+        dialog.close()
+
+    @patch("PyQt5.QtWidgets.QDialog.exec_")
+    def test_dialog_shows_correct_other_settings(self, _):
+        dialog = DepthProfileDialog(
+            self.parent_widget,
+            self.measurement,
+            self.global_settings)
+
+        self.assertEqual(
+            dialog.check_0line.isChecked(),
+            DepthProfileDialog.line_zero
+        )
+        self.assertEqual(
+            dialog.check_scaleline.isChecked(),
+            DepthProfileDialog.line_scale
+        )
+        self.assertEqual(
+            dialog.spin_systerr.value(),
+            DepthProfileDialog.systerr
+        )
+        dialog.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/gui/test_dialog_initialization.py
+++ b/tests/gui/test_dialog_initialization.py
@@ -32,7 +32,6 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 from dialogs.measurement.element_losses import ElementLossesDialog
-from dialogs.measurement.depth_profile import DepthProfileDialog
 from dialogs.energy_spectrum import EnergySpectrumParamsDialog
 from dialogs.measurement.calibration import CalibrationDialog
 from dialogs.simulation.optimization import OptimizationDialog
@@ -48,10 +47,6 @@ class TestDialogInitialization(unittest.TestCase):
         """
         e = ElementLossesDialog(Mock(), mo.get_measurement())
         e.close()
-
-        d = DepthProfileDialog(
-            Mock(), mo.get_measurement(), mo.get_global_settings())
-        d.close()
 
         c = CalibrationDialog(
             [mo.get_measurement()], mo.get_detector(), mo.get_run())
@@ -69,7 +64,7 @@ class TestDialogInitialization(unittest.TestCase):
         self.assertFalse(o.pushButton_OK.isEnabled())
         o.close()
 
-        assert mock_exec.call_count == 4
+        assert mock_exec.call_count == 3
 
     @patch("PyQt5.QtWidgets.QDialog.exec_")
     def test_espe_params(self, mock_exec):

--- a/tests/integration/test_depth_profile_handling.py
+++ b/tests/integration/test_depth_profile_handling.py
@@ -31,6 +31,7 @@ import math
 import tests.mock_objects as mo
 
 from modules.depth_files import DepthProfileHandler
+from modules.enums import DepthProfileUnit
 from timeit import default_timer as timer
 
 
@@ -103,12 +104,14 @@ class TestDepthProfileHandling(unittest.TestCase):
         """Tests depth ranges with different depth units"""
         # First read files while using depth units other than nanometers
         self.handler.read_directory(
-            self.depth_dir, self.some_elements, depth_units="")
+            self.depth_dir, self.some_elements,
+            depth_units=DepthProfileUnit.ATOMS_PER_SQUARE_CM)
         fst_range = self.handler.get_depth_range()
 
         # Then read files using nanometers
         self.handler.read_directory(
-            self.depth_dir, self.some_elements, depth_units="nm")
+            self.depth_dir, self.some_elements,
+            depth_units=DepthProfileUnit.NM)
         snd_range = self.handler.get_depth_range()
 
         # First and second ranges are different and both are not
@@ -152,8 +155,7 @@ class TestDepthProfileHandling(unittest.TestCase):
         self.assertEqual(inf.currsize, 0)
         self.assertEqual(inf.maxsize, max_cache)
 
-        self.handler.read_directory(
-            self.depth_dir, self.all_elements, depth_units="nm")
+        self.handler.read_directory(self.depth_dir, self.all_elements)
         a, b = self.handler.get_depth_range()
 
         # First merge is called with same parameters for n times
@@ -208,8 +210,7 @@ class TestDepthProfileHandling(unittest.TestCase):
         # Caching means that same object is returned
         # This needs to be taken into consideration if caller needs to modify
         # the results
-        self.handler.read_directory(
-            self.depth_dir, self.some_elements, depth_units="nm")
+        self.handler.read_directory(self.depth_dir, self.some_elements)
 
         # Set initial ranges that fall within handlers depth range
         a, b = self.handler.get_depth_range()
@@ -233,8 +234,7 @@ class TestDepthProfileHandling(unittest.TestCase):
 
         # When a new ProfileHandler is created, new cache is also established
         new_dp = DepthProfileHandler()
-        new_dp.read_directory(
-            self.depth_dir, self.some_elements, depth_units="nm")
+        new_dp.read_directory(self.depth_dir, self.some_elements)
 
         m5 = new_dp.merge_profiles(a, b, method="abs_rel_abs")
         self.assertIsNot(m1, m5)

--- a/tests/mock_objects.py
+++ b/tests/mock_objects.py
@@ -236,7 +236,7 @@ def get_selection() -> "MockSelection":
     return MockSelection()
 
 
-class TestObserver(Observer):
+class MockObserver(Observer):
     """Observer that appends messages it receives to its collections.
     """
     def __init__(self):

--- a/tests/unit/test_general_functions.py
+++ b/tests/unit/test_general_functions.py
@@ -122,7 +122,7 @@ class TestMatchingFunctions(unittest.TestCase):
         self.assertRaises(
             TypeError, lambda: comp.find_match_in_dicts(1, [[1]]))
         self.assertRaises(
-            TypeError, lambda: comp.find_match_in_dicts(1, [set(1, 2)]))
+            TypeError, lambda: comp.find_match_in_dicts(1, [{1, 2}]))
         self.assertRaises(
             TypeError, lambda: comp.find_match_in_dicts([], [{[]: []}]))
 
@@ -324,11 +324,11 @@ class TestFileIO(unittest.TestCase):
 
             self.assertRaises(
                 TypeError, lambda: gf.remove_matching_files(tmp_dir))
-            gf.remove_matching_files(tmp_dir, exts=[])
+            gf.remove_matching_files(tmp_dir, exts=set())
 
             self.assertTrue(no_ext.exists())
 
-            gf.remove_matching_files(tmp_dir, exts=[""])
+            gf.remove_matching_files(tmp_dir, exts={""})
             self.assertFalse(no_ext.exists())
 
     def test_file_name_conditions(self):
@@ -475,10 +475,9 @@ class TestCoinc(unittest.TestCase):
             self.assertEqual([], gf.coinc(**params))
 
     def test_coinc_returns_empty_list_if_no_timings(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            params = dict(self.params)
-            params["timing"] = {}
-            self.assertEqual([], gf.coinc(**params))
+        params = dict(self.params)
+        params["timing"] = {}
+        self.assertEqual([], gf.coinc(**params))
 
     def test_coinc_returns_expected_output_if_parameters_are_ok(self):
         with tempfile.TemporaryDirectory():
@@ -505,3 +504,22 @@ class TestCoinc(unittest.TestCase):
             params["timing"] = {}
             gf.coinc(output_file=output_file, **params)
             self.assertFalse(output_file.exists())
+
+
+class TestDigitsToSuperscript(unittest.TestCase):
+    def test_string_containing_no_digits_is_unchanged(self):
+        original = "one two three"
+        actual = gf.digits_to_superscript(original)
+        self.assertEqual(original, actual)
+
+    def test_string_containing_digit_is_changed(self):
+        original = "cm3"
+        actual = gf.digits_to_superscript(original)
+        expected = "cm³"
+        self.assertEqual(expected, actual)
+
+    def test_all_digits_in_string_are_superscripted(self):
+        original = "1234567890"
+        actual = gf.digits_to_superscript(original)
+        expected = "¹²³⁴⁵⁶⁷⁸⁹⁰"
+        self.assertEqual(expected, actual)

--- a/tests/unit/test_mcerd.py
+++ b/tests/unit/test_mcerd.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from modules.concurrency import CancellationToken
 import modules.mcerd as mcerd
 
-from tests.mock_objects import TestObserver
+from tests.mock_objects import MockObserver
 
 
 class TestParseOutput(unittest.TestCase):
@@ -101,7 +101,7 @@ class TestParseOutput(unittest.TestCase):
             "bar"
         ]
 
-        obs = TestObserver()
+        obs = MockObserver()
         rx.from_iterable(iter(output)).pipe(
             mcerd.MCERD.get_pipeline(100, "foo"),
         ).subscribe(obs)
@@ -185,7 +185,7 @@ class TestTimeoutCheck(unittest.TestCase):
         with subprocess.Popen(["sleep", "1"]) as proc:
             res = mcerd.MCERD.timeout_check(proc, 0.01, ct)
 
-            obs = TestObserver()
+            obs = MockObserver()
             res.subscribe(obs)
             time.sleep(DEFAULT_SLEEP_TIME)
 
@@ -202,7 +202,7 @@ class TestTimeoutCheck(unittest.TestCase):
         with subprocess.Popen(["sleep", "1"]) as proc:
             res = mcerd.MCERD.timeout_check(proc, 0.01, ct)
 
-            obs = TestObserver()
+            obs = MockObserver()
             res.subscribe(obs)
             time.sleep(DEFAULT_SLEEP_TIME)
 
@@ -214,7 +214,7 @@ class TestTimeoutCheck(unittest.TestCase):
                 ["echo", "hello"], stdout=subprocess.DEVNULL) as proc:
             res = mcerd.MCERD.timeout_check(proc, 0.01, ct)
 
-        obs = TestObserver()
+        obs = MockObserver()
         res.subscribe(obs)
         time.sleep(DEFAULT_SLEEP_TIME)
 
@@ -231,7 +231,7 @@ class TestTimeoutCheck(unittest.TestCase):
         with subprocess.Popen(["sleep", "1"]) as proc:
             res = mcerd.MCERD.timeout_check(proc, 0.1, ct)
 
-            obs = TestObserver()
+            obs = MockObserver()
             res.subscribe(obs)
 
             self.assertIsNone(proc.poll(), msg=FAILURE_MSG)
@@ -245,7 +245,7 @@ class TestCancellationCheck(unittest.TestCase):
         with subprocess.Popen(["sleep", "1"]) as proc:
             res = mcerd.MCERD.cancellation_check(proc, 0.01, ct)
 
-            obs = TestObserver()
+            obs = MockObserver()
             res.subscribe(obs)
             ct.request_cancellation()
 
@@ -262,7 +262,7 @@ class TestCancellationCheck(unittest.TestCase):
         with subprocess.Popen(["sleep", "0.1"]) as proc:
             res = mcerd.MCERD.cancellation_check(proc, 0.01, ct)
 
-            obs = TestObserver()
+            obs = MockObserver()
             res.subscribe(obs)
 
             time.sleep(0.2)
@@ -274,7 +274,7 @@ class TestCancellationCheck(unittest.TestCase):
         with subprocess.Popen(["sleep", "1"]) as proc:
             res = mcerd.MCERD.cancellation_check(proc, 0.01, ct)
 
-            obs = TestObserver()
+            obs = MockObserver()
             res.subscribe(obs)
 
             time.sleep(0.25)
@@ -290,7 +290,7 @@ class TestCancellationCheck(unittest.TestCase):
                 proc:
             res = mcerd.MCERD.cancellation_check(proc, 0.01, ct)
 
-        obs = TestObserver()
+        obs = MockObserver()
         res.subscribe(obs)
         ct.request_cancellation()
 
@@ -307,7 +307,7 @@ class TestCancellationCheck(unittest.TestCase):
         with subprocess.Popen(["sleep", "1"]) as proc:
             res = mcerd.MCERD.cancellation_check(proc, 0.05, ct)
 
-            obs = TestObserver()
+            obs = MockObserver()
             res.subscribe(obs)
             ct.request_cancellation()
 
@@ -319,7 +319,7 @@ class TestRunningCheck(unittest.TestCase):
     def test_running_check_produces_dicts_with_running_status(self):
         with subprocess.Popen(["sleep", "0.1"]) as proc:
             res = mcerd.MCERD.running_check(proc, 0.01, 0.01)
-            obs = TestObserver()
+            obs = MockObserver()
             res.subscribe(obs)
 
         time.sleep(0.05)

--- a/tests/unit/test_observing.py
+++ b/tests/unit/test_observing.py
@@ -33,7 +33,7 @@ import modules.observing as observing
 from modules.observing import Observable
 from modules.observing import Observer
 from modules.observing import ProgressReporter
-from tests.mock_objects import TestObserver
+from tests.mock_objects import MockObserver
 
 
 # Mock observable and observer
@@ -50,7 +50,7 @@ class TestObserving(unittest.TestCase):
 
         self.assertEqual(0, pub.get_observer_count())
 
-        sub = TestObserver()
+        sub = MockObserver()
         self.assertIsInstance(sub, Observer)
 
         pub.subscribe(sub)
@@ -81,7 +81,7 @@ class TestObserving(unittest.TestCase):
         """Tests that the publisher uses the correct callbacks to publish
         messages."""
         pub = Pub()
-        sub = TestObserver()
+        sub = MockObserver()
 
         pub.subscribe(sub)
 
@@ -106,8 +106,8 @@ class TestObserving(unittest.TestCase):
         pub1 = Pub()
         pub2 = Pub()
 
-        sub1 = TestObserver()
-        sub2 = TestObserver()
+        sub1 = MockObserver()
+        sub2 = MockObserver()
 
         # Subscriber can receive messages from multiple observables and
         # publisher can send messages to multiple subscribers
@@ -133,7 +133,7 @@ class TestObserving(unittest.TestCase):
         """Observers are weakly referenced so they should be removed when
         they no longer exist"""
         pub = Pub()
-        sub = TestObserver()
+        sub = MockObserver()
 
         pub.subscribe(sub)
         self.assertEqual(1, pub.get_observer_count())
@@ -151,7 +151,7 @@ class TestObserving(unittest.TestCase):
 
         # Also if the Sub is only initialized in the context of the subscribe
         # function, observer count stays at 0
-        pub.subscribe(TestObserver())
+        pub.subscribe(MockObserver())
         self.assertEqual(0, pub.get_observer_count())
 
     def test_unreferenceable(self):
@@ -319,7 +319,7 @@ class TestRxOps(unittest.TestCase):
 
     def assert_observed_data_ok(self, data, reduce_func, start_cond, end_cond,
                                 exp_nexts, exp_errs, exp_compl):
-        obs = TestObserver()
+        obs = MockObserver()
 
         stream = rx.from_iterable(data)
         stream.pipe(

--- a/ui_files/ui_depth_profile_params.ui
+++ b/ui_files/ui_depth_profile_params.ui
@@ -251,7 +251,7 @@
             <item>
              <widget class="QLabel" name="label_10">
               <property name="text">
-               <string>Number of depth steps:</string>
+               <string>Number of depth steps: </string>
               </property>
              </widget>
             </item>
@@ -329,7 +329,7 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>X axis units:</string>
+        <string>X axis units</string>
        </property>
       </widget>
      </item>
@@ -350,6 +350,23 @@
        </property>
        <property name="checked">
         <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_reference_density">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reference density [g/cm&lt;span style=&quot; vertical-align:super;&quot;&gt;3&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="sbox_reference_density">
+       <property name="minimum">
+        <double>0.010000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>9999.000000000000000</double>
        </property>
       </widget>
      </item>

--- a/ui_files/ui_depth_profile_params.ui
+++ b/ui_files/ui_depth_profile_params.ui
@@ -341,6 +341,9 @@
        <property name="checked">
         <bool>true</bool>
        </property>
+       <attribute name="buttonGroup">
+        <string notr="true">group_x_axis_units</string>
+       </attribute>
       </widget>
      </item>
      <item>
@@ -351,6 +354,9 @@
        <property name="checked">
         <bool>false</bool>
        </property>
+       <attribute name="buttonGroup">
+        <string notr="true">group_x_axis_units</string>
+       </attribute>
       </widget>
      </item>
      <item>
@@ -481,4 +487,7 @@
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="group_x_axis_units"/>
+ </buttongroups>
 </ui>

--- a/widgets/matplotlib/measurement/depth_profile.py
+++ b/widgets/matplotlib/measurement/depth_profile.py
@@ -52,6 +52,7 @@ from modules.depth_files import DepthProfileHandler
 from modules.depth_files import DepthProfile
 from modules.element import Element
 from modules.base import Range
+from modules.enums import DepthProfileUnit
 
 from PyQt5 import QtWidgets
 
@@ -61,8 +62,9 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
     """
 
     def __init__(self, parent, depth_dir: Path, elements: List[Element],
-                 rbs_list, x_units="nm", depth_scale: Optional[Range] = None,
-                 add_legend=True, add_line_zero=False, systematic_error=3.0,
+                 rbs_list, x_units: DepthProfileUnit = DepthProfileUnit.NM,
+                 depth_scale: Optional[Range] = None, add_legend=True,
+                 add_line_zero=False, systematic_error=3.0,
                  progress=None):
         """Inits depth profile widget.
 
@@ -85,13 +87,12 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
         self.canvas.manager.set_title("Depth Profile")
         self.axes.fmt_xdata = lambda x: "{0:1.2f}".format(x)
         self.axes.fmt_ydata = lambda y: "{0:1.2f}".format(y)
-        self.x_units = x_units
         self.elements = elements
         self.__systerr = systematic_error
 
         self.profile_handler = DepthProfileHandler()
         self.profile_handler.read_directory(
-            depth_dir, self.elements, depth_units=self.x_units)
+            depth_dir, self.elements, depth_units=x_units)
         if progress is not None:
             progress.report(50)
 
@@ -118,7 +119,7 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
         self.__rbs_list = rbs_list
         self.__fork_toolbar_buttons()
 
-        self.axes.set_xlabel(f"Depth ({self.x_units})")
+        self.axes.set_xlabel(f"Depth ({x_units})")
         self.axes.set_ylabel('Concentration (at.%)')
 
         self.limit = AlternatingLimits(

--- a/widgets/matplotlib/measurement/depth_profile.py
+++ b/widgets/matplotlib/measurement/depth_profile.py
@@ -35,9 +35,7 @@ __version__ = "2.0"
 
 import modules.math_functions as mf
 
-from typing import List
-from typing import Optional
-from typing import Dict
+from typing import List, Dict, Optional, Set
 
 from pathlib import Path
 
@@ -47,12 +45,14 @@ from widgets.matplotlib.base import MatplotlibWidget
 from widgets.matplotlib import mpl_utils
 from widgets.matplotlib.mpl_utils import AlternatingLimits
 from widgets.matplotlib.mpl_utils import LineChart
+from widgets.icon_manager import IconManager
 
 from modules.depth_files import DepthProfileHandler
 from modules.depth_files import DepthProfile
 from modules.element import Element
 from modules.base import Range
 from modules.enums import DepthProfileUnit
+from modules.observing import ProgressReporter
 
 from PyQt5 import QtWidgets
 
@@ -61,11 +61,13 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
     """Depth profile widget that handles drawing depth profiles.
     """
 
-    def __init__(self, parent, depth_dir: Path, elements: List[Element],
-                 rbs_list, x_units: DepthProfileUnit = DepthProfileUnit.NM,
-                 depth_scale: Optional[Range] = None, add_legend=True,
-                 add_line_zero=False, systematic_error=3.0,
-                 progress=None):
+    def __init__(self, parent: QtWidgets.QWidget, depth_dir: Path,
+                 elements: List[Element], rbs_list: Dict[str, Element],
+                 icon_manager: IconManager, selection_colors: Dict[str, str],
+                 x_units: DepthProfileUnit = DepthProfileUnit.NM,
+                 depth_scale: Optional[Range] = None,
+                 add_line_zero: bool = False, systematic_error: float = 3.0,
+                 progress: Optional[ProgressReporter] = None):
         """Inits depth profile widget.
 
         Args:
@@ -76,7 +78,6 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
                 scatter elements.
             depth_scale: A tuple of depth scaling values.
             x_units: An unit to be used as x axis.
-            add_legend: A boolean of whether to show the legend.
             add_line_zero: A boolean representing if vertical line is drawn at
                 zero.
             systematic_error: A double representing systematic error.
@@ -85,67 +86,56 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
         super().__init__(parent)
 
         self.canvas.manager.set_title("Depth Profile")
-        self.axes.fmt_xdata = lambda x: "{0:1.2f}".format(x)
-        self.axes.fmt_ydata = lambda y: "{0:1.2f}".format(y)
-        self.elements = elements
-        self.__systerr = systematic_error
+        self.axes.fmt_xdata = lambda x: f"{x:1.2f}"
+        self.axes.fmt_ydata = lambda y: f"{y:1.2f}"
+        self.axes.set_xlabel(f"Depth ({x_units})")
+        self.axes.set_ylabel("Concentration (at.%)")
 
-        self.profile_handler = DepthProfileHandler()
-        self.profile_handler.read_directory(
-            depth_dir, self.elements, depth_units=x_units)
+        self._elements = elements
+        self._ignore_from_graph: Set[Element] = set()
+        self._ignore_from_ratio: Set[Element] = set()
+        self._systematic_error = systematic_error
+
+        self._profile_handler = DepthProfileHandler()
+        self._profile_handler.read_directory(
+            depth_dir, self._elements, depth_units=x_units)
+
         if progress is not None:
             progress.report(50)
 
-        self.__ignore_from_graph = set()
-        self.__ignore_from_ratio = set()
+        self._selection_colors = selection_colors
+        self._icon_manager = icon_manager
 
-        # TODO get selection colors and icon manager as parameters, not from
-        #      parent
-        self.selection_colors = parent.measurement.selector.get_colors()
-        self.icon_manager = parent.icon_manager
-
-        self.lim_icons = {
+        self._lim_icons = {
             "a": "depth_profile_lim_all.svg",
             "b": "depth_profile_lim_in.svg",
             "c": "depth_profile_lim_ex.svg"
         }
-        self.lim_mode = "a"
+        self._lim_mode = "a"
 
         self.canvas.mpl_connect("button_press_event", self.onclick)
 
-        self.__position_set = False
-        self.__rel_graph = False
-        self.__absolute_values = False
-        self.__rbs_list = rbs_list
-        self.__fork_toolbar_buttons()
+        self._position_set = False
+        self._relative_graph = False
+        self._absolute_values = False
+        self._rbs_list = rbs_list
+        self._fork_toolbar_buttons()
 
-        self.axes.set_xlabel(f"Depth ({x_units})")
-        self.axes.set_ylabel('Concentration (at.%)')
-
-        self.limit = AlternatingLimits(
-            self.canvas, self.axes, xs=self.profile_handler.get_depth_range(),
+        self._limit_lines = AlternatingLimits(
+            self.canvas, self.axes, xs=self._profile_handler.get_depth_range(),
             colors=("blue", "red"))
-        self._line_chart = None
-        self.depth_plots = {}
-        self._update_depth_plots(self.get_profiles_to_use())
+        self._line_chart = self._create_depth_profile_chart()
         self.axes.set_ylim(bottom=0.0)
-
-        self.add_legend = add_legend
-        if self.add_legend:
-            self.__make_legend_box()
+        self._make_legend_box()
 
         self.axes.axhline(y=0, color="#000000")
         if add_line_zero:
-            self._line_zero = self.axes.axvline(
+            self.axes.axvline(
                 x=0, linestyle="-", linewidth=3, color="#C0C0C0", alpha=0.75)
-        else:
-            self._line_zero = None
 
         if depth_scale:
-            self._vspan = self.axes.axvspan(
+            self.axes.axvspan(
                 *depth_scale, color="#C0C0C0", alpha=0.20, edgecolor=None)
-        else:
-            self._vspan = None
 
         self.remove_axes_ticks()
 
@@ -159,287 +149,262 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
             event: A click event on the graph
         """
         if event.button == 1 and self.limButton.isChecked():
-            self.limit.update_graph(event.xdata)
-            if self.add_legend:
-                self.__make_legend_box()
+            self._limit_lines.update_graph(event.xdata)
+            self._make_legend_box()
 
     def get_profiles_to_use(self) -> Dict[str, DepthProfile]:
         """Determines what files to use for plotting. Either relative, absolute
         or a merger of the two.
         """
-        if not self.__rel_graph:
-            return self.profile_handler.get_absolute_profiles()
-        elif self.lim_mode == "a":
-            return self.profile_handler.get_relative_profiles()
+        lim_a, lim_b = self._limit_lines.get_range()
 
-        lim_a, lim_b = self.limit.get_range()
-        if self.lim_mode == "b":
-            return self.profile_handler.merge_profiles(
-                lim_a, lim_b, method="abs_rel_abs"
-            )
-
-        return self.profile_handler.merge_profiles(
-            lim_a, lim_b, method="rel_abs_rel"
-        )
-
-    def _update_depth_plots(self, profiles: Dict[str, DepthProfile]):
-        profiles_to_use = {
+        if not self._relative_graph:
+            profiles = self._profile_handler.get_absolute_profiles()
+        elif self._lim_mode == "a":
+            profiles = self._profile_handler.get_relative_profiles()
+        elif self._lim_mode == "b":
+            profiles = self._profile_handler.merge_profiles(
+                lim_a, lim_b, method="abs_rel_abs")
+        else:
+            profiles = self._profile_handler.merge_profiles(
+                lim_a, lim_b, method="rel_abs_rel")
+        return {
             k: v for k, v in profiles.items() if k != "total"
         }
-        if self._line_chart is None:
-            lineargs = []
-            for key, profile in sorted(
-                    profiles_to_use.items(), key=lambda tpl: tpl[1].element):
 
-                # Check RBS selection
-                element = profile.element
-                if key in self.__rbs_list.values():
-                    color_key = f"RBS_{element}0"
-                else:
-                    color_key = f"{element}0"
+    def _create_depth_profile_chart(self) -> LineChart:
+        profiles_to_use = self.get_profiles_to_use()
+        lineargs = []
+        for key, profile in sorted(
+                profiles_to_use.items(), key=lambda tpl: tpl[1].element):
 
-                lineargs.append(LineChart.get_line_args(
-                    element, profile.depths, profile.concentrations,
-                    color=self.selection_colors.get(color_key, "red")))
+            # Check RBS selection
+            element = profile.element
+            if key in self._rbs_list.values():
+                color_key = f"RBS_{element}0"
+            else:
+                color_key = f"{element}0"
 
-            self._line_chart = LineChart(self.canvas, self.axes, lineargs)
-        else:
-            lineargs = ({
-                "key": v.element,
-                "ys": v.concentrations
-            } for v in profiles_to_use.values())
-            self._line_chart.update_graph(lineargs)
+            lineargs.append(LineChart.get_line_args(
+                element, profile.depths, profile.concentrations,
+                color=self._selection_colors.get(color_key, "red")))
+
+        return LineChart(self.canvas, self.axes, lineargs)
+
+    def _update_depth_profile_chart(self) -> None:
+        profiles_to_use = self.get_profiles_to_use()
+        lineargs = ({
+            "key": v.element,
+            "ys": v.concentrations
+        } for v in profiles_to_use.values())
+        self._line_chart.update_graph(lineargs)
 
     @mpl_utils.draw_and_flush
-    def __make_legend_box(self):
+    def _make_legend_box(self) -> None:
         """Make legend box for the graph.
         """
         box = self.axes.get_position()
-        if not self.__position_set:
+        if not self._position_set:
             self.axes.set_position(
                 [box.x0, box.y0, box.width * 0.8, box.height])
-            self.__position_set = True
+            self._position_set = True
         handles, labels = self.axes.get_legend_handles_labels()
 
         # Calculate values to be displayed in the legend box
         # TODO make profile_handler use Element objects as keys so
         #   there is no need to do this conversion
-        ignored_str = set(str(elem) for elem in self.__ignore_from_ratio)
-        lim_a, lim_b = self.limit.get_range()
-        if self.__absolute_values:
-            concentrations = self.profile_handler.integrate_concentrations(
+        ignored_str = set(str(elem) for elem in self._ignore_from_ratio)
+        lim_a, lim_b = self._limit_lines.get_range()
+        if self._absolute_values:
+            concentrations = self._profile_handler.integrate_concentrations(
                 lim_a, lim_b)
-            percentages, moe = {}, {}
+            percentages, moes = {}, {}
         else:
-            percentages, moe = self.profile_handler.calculate_ratios(
-                ignored_str, lim_a, lim_b, self.__systerr)
+            percentages, moes = self._profile_handler.calculate_ratios(
+                ignored_str, lim_a, lim_b, self._systematic_error)
             concentrations = {}
 
         # Fix labels to proper format, with MoE
         labels_w_percentages = []
-        for i in range(0, len(labels)):
-            element = Element.from_string(labels[i])
-            element_str = labels[i]
-            element_isotope = str(element.isotope)
-
-            if element_isotope == "None":
+        rbs_values = {elem.symbol for elem in self._rbs_list.values()}
+        for element_str in labels:
+            element = Element.from_string(element_str)
+            if element.isotope is None:
                 element_isotope = ""
-
-            element_name = element.symbol
-            for elem in self.__rbs_list.values():
-                if element_str == elem.symbol:
-                    element_name += "*"
-            str_element = "{0:>3}{1:<3}".format(element_isotope, element_name)
-            # str_element = labels[i]
-            # percentages[element_str] can be 0 which results false
-            # None when element is ignored from ratio calculation.
-            if not self.__absolute_values and percentages[element_str] is not \
-                    None:
-                rounding = mf.get_rounding_decimals(moe[element_str])
-                if rounding:
-                    str_ratio = "{0}%".format(round(percentages[element_str],
-                                                    rounding))
-                    str_err = "± {0}%".format(round(moe[element_str], rounding))
-                else:
-                    str_ratio = "{0}%".format(int(percentages[element_str]))
-                    str_err = "± {0}%".format(int(moe[element_str]))
-                lbl_str = "{0} {1:<6} {2}".format(r"$^{" + element_isotope +
-                                                  "}$" +
-                                                  element_name,
-                                                  str_ratio, str_err)
             else:
-                lbl_str = '{0}'.format(str_element)
+                element_isotope = str(element.isotope)
+
+            rbs_asterisk = "*" if element_str in rbs_values else ""
+            element_name = f"{element.symbol}{rbs_asterisk}"
+            elem_lbl = f"$^{{{element_isotope}}}${element_name}"
+
+            if not self._absolute_values and percentages[element_str] is not \
+                    None:
+                percentage = percentages[element_str]
+                moe = moes[element_str]
+                rounding = mf.get_rounding_decimals(moe)
+                if rounding:
+                    str_ratio = f"{round(percentage, rounding)}%"
+                    str_err = f"± {round(moe, rounding)}%"
+                else:
+                    str_ratio = f"{int(percentage)}%"
+                    str_err = f"± {int(moe)}%"
+                lbl_str = f"{elem_lbl} {str_ratio:<6} {str_err}"
+            else:
+                lbl_str = f"{element_isotope:>3}{element_name:<3}"
 
             # Use absolute values for the elements instead of percentages.
-            if self.__absolute_values:
-                lbl_str = "{0} {1:<7} at./1e15 at./cm²"\
-                    .format(r"$^{" + element_isotope + "}$" + element.symbol,
-                            round(concentrations[element_str], 3))
+            if self._absolute_values:
+                conc = concentrations[element_str]
+                lbl_str = f"{elem_lbl} {round(conc, 3):<7} at./1e15 at./cm²"
             labels_w_percentages.append(lbl_str)
 
-        leg = self.axes.legend(handles, labels_w_percentages,
-                               loc=3, bbox_to_anchor=(1, 0),
-                               borderaxespad=0, prop={'size': 11,
-                                                      'family': "monospace"})
+        leg = self.axes.legend(
+            handles, labels_w_percentages, loc=3, bbox_to_anchor=(1, 0),
+            borderaxespad=0, prop={"size": 11, "family": "monospace"})
+
         for handle in leg.legendHandles:
             handle.set_linewidth(3.0)
 
-    def __fork_toolbar_buttons(self):
+    def _fork_toolbar_buttons(self):
         """Custom toolbar buttons be here.
         """
         # But first, let's play around with the existing MatPlotLib buttons.
-        _, self.__button_drag, self.__button_zoom = \
+        _, self._button_drag, self._button_zoom = \
             mpl_utils.get_toolbar_elements(
-                self.mpl_toolbar, drag_callback=self.__uncheck_custom_buttons,
-                zoom_callback=self.__uncheck_custom_buttons)
+                self.mpl_toolbar, drag_callback=self._uncheck_custom_buttons,
+                zoom_callback=self._uncheck_custom_buttons)
 
         self.limButton = QtWidgets.QToolButton(self)
-        self.limButton.clicked.connect(self.__toggle_lim_lines)
+        self.limButton.clicked.connect(self._toggle_lim_lines)
         self.limButton.setCheckable(True)
         self.limButton.setToolTip(
             "Toggle the view of the limit lines on and off")
-        self.icon_manager.set_icon(self.limButton, "amarok_edit.svg")
+        self._icon_manager.set_icon(self.limButton, "amarok_edit.svg")
         self.mpl_toolbar.addWidget(self.limButton)
 
         self.modeButton = QtWidgets.QToolButton(self)
-        self.modeButton.clicked.connect(self.__toggle_lim_mode)
+        self.modeButton.clicked.connect(self._toggle_lim_mode)
         self.modeButton.setToolTip(
             "Toggles between selecting the entire " +
             "histogram, area included in the limits and " +
             "areas included of the limits")
-        self.icon_manager.set_icon(self.modeButton, "depth_profile_lim_all.svg")
+        self._icon_manager.set_icon(
+            self.modeButton, "depth_profile_lim_all.svg")
         self.mpl_toolbar.addWidget(self.modeButton)
 
         self.viewButton = QtWidgets.QToolButton(self)
-        self.viewButton.clicked.connect(self.__toggle_rel)
-        # self.viewButton.setCheckable(True)
+        self.viewButton.clicked.connect(self._toggle_rel)
         self.viewButton.setToolTip("Switch between relative and absolute view")
-        self.icon_manager.set_icon(self.viewButton, "depth_profile_abs.svg")
+        self._icon_manager.set_icon(self.viewButton, "depth_profile_abs.svg")
         self.mpl_toolbar.addWidget(self.viewButton)
 
         # Log scale & ignore elements button
         self.mpl_toolbar.addSeparator()
-        self.__button_toggle_log = QtWidgets.QToolButton(self)
-        self.__button_toggle_log.clicked.connect(self.__toggle_log_scale)
-        self.__button_toggle_log.setCheckable(True)
-        self.__button_toggle_log.setToolTip(
+        self._button_toggle_log = QtWidgets.QToolButton(self)
+        self._button_toggle_log.clicked.connect(self._toggle_log_scale)
+        self._button_toggle_log.setCheckable(True)
+        self._button_toggle_log.setToolTip(
             "Toggle logarithmic Y axis scaling.")
-        self.icon_manager.set_icon(self.__button_toggle_log,
-                                   "monitoring_section.svg")
-        self.mpl_toolbar.addWidget(self.__button_toggle_log)
+        self._icon_manager.set_icon(
+            self._button_toggle_log, "monitoring_section.svg")
+        self.mpl_toolbar.addWidget(self._button_toggle_log)
 
-        self.__button_toggle_absolute = QtWidgets.QToolButton(self)
-        self.__button_toggle_absolute.clicked.connect(
-            self.__toggle_absolute_values)
-        self.__button_toggle_absolute.setCheckable(True)
-        self.__button_toggle_absolute.setToolTip(
+        self._button_toggle_absolute = QtWidgets.QToolButton(self)
+        self._button_toggle_absolute.clicked.connect(
+            self._toggle_absolute_values)
+        self._button_toggle_absolute.setCheckable(True)
+        self._button_toggle_absolute.setToolTip(
             "Toggle absolute values for elements.")
-        self.icon_manager.set_icon(self.__button_toggle_absolute, "color.svg")
-        self.mpl_toolbar.addWidget(self.__button_toggle_absolute)
+        self._icon_manager.set_icon(self._button_toggle_absolute, "color.svg")
+        self.mpl_toolbar.addWidget(self._button_toggle_absolute)
 
-        self.__button_ignores = QtWidgets.QToolButton(self)
-        self.__button_ignores.clicked.connect(self.__ignore_elements_dialog)
-        self.__button_ignores.setToolTip(
+        self._button_ignores = QtWidgets.QToolButton(self)
+        self._button_ignores.clicked.connect(self._ignore_elements_dialog)
+        self._button_ignores.setToolTip(
             "Select elements which are included in "
             "ratio calculation.")
-        self.icon_manager.set_icon(self.__button_ignores, "gear.svg")
-        self.mpl_toolbar.addWidget(self.__button_ignores)
+        self._icon_manager.set_icon(self._button_ignores, "gear.svg")
+        self.mpl_toolbar.addWidget(self._button_ignores)
 
-    def __uncheck_custom_buttons(self):
+    def _uncheck_custom_buttons(self) -> None:
         """Uncheck custom buttons.
         """
         self.limButton.setChecked(False)
 
-    def __uncheck_built_in_buttons(self):
-        """Uncheck built.in buttons.
-        """
-        self.__button_drag.setChecked(False)
-        self.__button_zoom.setChecked(False)
-
-    def __toggle_lim_mode(self, *_):
-        """Toggle lim mode.
-
-        Args:
-            *_: unused event args
-        """
-        self.__switch_lim_mode()
-
-    def __switch_lim_mode(self, mode=""):
+    def _toggle_lim_mode(self, *_) -> None:
         """Switch between the three modes:
         a = enable relative view throughout the histogram
         b = enable relative view only within limits
         c = enable relative view only outside limits
-        """
-        if mode != "":
-            self.lim_mode = mode
-        elif self.lim_mode == "a":
-            self.lim_mode = "b"
-        elif self.lim_mode == "b":
-            self.lim_mode = "c"
-        else:
-            self.lim_mode = "a"
-        self.icon_manager.set_icon(
-            self.modeButton, self.lim_icons[self.lim_mode])
-        self._update_depth_plots(self.get_profiles_to_use())
 
-    def __toggle_lim_lines(self):
+        Args:
+            *_: unused event args
+        """
+        if self._lim_mode == "a":
+            self._lim_mode = "b"
+        elif self._lim_mode == "b":
+            self._lim_mode = "c"
+        else:
+            self._lim_mode = "a"
+        self._icon_manager.set_icon(
+            self.modeButton, self._lim_icons[self._lim_mode])
+        self._update_depth_profile_chart()
+
+    def _toggle_lim_lines(self) -> None:
         """Toggles the usage of limit lines.
         """
-        self.__toggle_drag_zoom()
+        self._toggle_drag_zoom()
         self.mpl_toolbar.mode = "limit setting tool"
 
-    def __toggle_rel(self):
+    def _toggle_rel(self) -> None:
         """Toggles between the absolute and relative views.
         """
-        self.__rel_graph = not self.__rel_graph
-        if self.__rel_graph:
-            self.icon_manager.set_icon(self.viewButton, "depth_profile_rel.svg")
+        self._relative_graph = not self._relative_graph
+        if self._relative_graph:
+            self._icon_manager.set_icon(
+                self.viewButton, "depth_profile_rel.svg")
         else:
-            self.icon_manager.set_icon(self.viewButton, "depth_profile_abs.svg")
+            self._icon_manager.set_icon(
+                self.viewButton, "depth_profile_abs.svg")
 
-        self._update_depth_plots(self.get_profiles_to_use())
+        self._update_depth_profile_chart()
 
-    def __toggle_drag_zoom(self):
+    def _toggle_drag_zoom(self) -> None:
         """Toggles drag zoom.
         """
-        if self.__button_drag.isChecked():
+        if self._button_drag.isChecked():
             self.mpl_toolbar.pan()
-        if self.__button_zoom.isChecked():
+        if self._button_zoom.isChecked():
             self.mpl_toolbar.zoom()
 
-        self.__button_drag.setChecked(False)
-        self.__button_zoom.setChecked(False)
+        self._button_drag.setChecked(False)
+        self._button_zoom.setChecked(False)
 
-    def __ignore_elements_dialog(self, *_):
+    def _ignore_elements_dialog(self, *_) -> None:
         """Ignore elements from elements ratio calculation.
         """
         dialog = DepthProfileIgnoreElements(
-            self.elements, self.__ignore_from_graph, self.__ignore_from_ratio)
+            self._elements, self._ignore_from_graph, self._ignore_from_ratio)
 
         if not dialog.exec_():
             return
 
-        self._update_ignored(
-            dialog.ignored_from_graph, dialog.ignored_from_ratio)
+        self._ignore_from_graph = set(dialog.ignored_from_graph)
+        self._ignore_from_ratio = set(dialog.ignored_from_ratio)
+        self._line_chart.hide_lines(self._ignore_from_graph)
+        self._make_legend_box()
 
-    def _update_ignored(self, ignored_graph, ignored_ratio):
-        self.__ignore_from_graph = set(ignored_graph)
-        self.__ignore_from_ratio = set(ignored_ratio)
-        self._line_chart.hide_lines(self.__ignore_from_graph)
-        if self.add_legend:
-            self.__make_legend_box()
-
-    def __toggle_absolute_values(self):
+    def _toggle_absolute_values(self) -> None:
         """Toggle absolute values for the elements in the graph.
         """
-        self.__absolute_values = self.__button_toggle_absolute.isChecked()
-        if self.add_legend:
-            self.__make_legend_box()
+        self._absolute_values = self._button_toggle_absolute.isChecked()
+        self._make_legend_box()
 
-    def __toggle_log_scale(self, *_):
+    def _toggle_log_scale(self, *_) -> None:
         """Toggle log scaling for Y axis in depth profile graph.
         """
-        if self.__button_toggle_log.isChecked():
+        if self._button_toggle_log.isChecked():
             self._line_chart.set_yscale("symlog")
         else:
             self._line_chart.set_yscale("linear")

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -90,7 +90,8 @@ class ElementWidget(QtWidgets.QWidget):
         self.radio_button = QtWidgets.QRadioButton()
 
         if element.isotope:
-            isotope_superscript = general.to_superscript(str(element.isotope))
+            isotope_superscript = general.digits_to_superscript(
+                str(element.isotope))
             button_text = isotope_superscript + " " + element.symbol
         else:
             button_text = element.symbol

--- a/widgets/measurement/tab.py
+++ b/widgets/measurement/tab.py
@@ -46,6 +46,7 @@ from dialogs.measurement.settings import MeasurementSettingsDialog
 
 from modules.element import Element
 from modules.measurement import Measurement
+from modules.enums import DepthProfileUnit
 
 from PyQt5 import QtCore
 from PyQt5 import QtWidgets
@@ -230,9 +231,13 @@ class MeasurementTabWidget(QtWidgets.QWidget, BaseTab):
             elements_string = lines[1].strip().split("\t")
             elements = [Element.from_string(element)
                         for element in elements_string]
-            x_unit = lines[3].strip()
+            try:
+                x_unit = DepthProfileUnit(lines[3].strip())
+            except ValueError:
+                x_unit = DepthProfileUnit.ATOMS_PER_SQUARE_CM
             line_zero = False
             line_scale = False
+            systerr = 0.0
             if len(lines) == 7:  # "Backwards compatibility"
                 line_zero = lines[4].strip() == "True"
                 line_scale = lines[5].strip() == "True"


### PR DESCRIPTION
Fixes #119.

Other changes:
- binding module used extensively to bind GUI values to Python properties in DepthProfileDialog
- depth profile x axis units are now an enum
- adds a small backwards compatibility fix for requests made with older versions of Potku (97755ae)