### PR TITLE
Refactor logging, fixes #93

### DIFF
--- a/dialogs/energy_spectrum.py
+++ b/dialogs/energy_spectrum.py
@@ -342,7 +342,6 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
               f"Bin width: {self.bin_width} " \
               f"Used files: {', '.join(str(f) for f in self.result_files)}"
 
-        self.element_simulation.simulation.log(msg)
         self.simulation.log(msg)
         self.close()
 

--- a/dialogs/energy_spectrum.py
+++ b/dialogs/energy_spectrum.py
@@ -31,7 +31,6 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen " \
              "Juhani Sundell"
 __version__ = "2.0"
 
-import logging
 import os
 import shutil
 
@@ -339,12 +338,11 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
 
         sbh.reporter.report(100)
 
-        simulation_name = self.element_simulation.simulation.name
         msg = f"Created Energy Spectrum. " \
               f"Bin width: {self.bin_width} " \
               f"Used files: {', '.join(str(f) for f in self.result_files)}"
 
-        logging.getLogger("request").info(f"[{simulation_name}] {msg}")
+        self.element_simulation.simulation.log(msg)
         self.simulation.log(msg)
         self.close()
 
@@ -380,16 +378,11 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
                 self.parent.add_widget(self.parent.energy_spectrum_widget,
                                        icon=icon)
 
-                measurement_name = self.measurement.name
-                msg = "[{0}] Created Energy Spectrum. {1} {2}".format(
-                    measurement_name,
-                    "Bin width: {0}".format(width),
-                    "Cut files: {0}".format(", ".join(str(cut) for cut
-                                                      in selected_cuts)))
-                logging.getLogger("request").info(msg)
-                self.measurement.log(
-                    f"Created Energy Spectrum. Bin width: {width} Cut files: "
-                    f"{', '.join(str(cut) for cut in selected_cuts)}")
+                cuts = ", ".join(str(cut) for cut in selected_cuts)
+                msg = f"Created Energy Spectrum. " \
+                      f"Bin width: {width}. " \
+                      f"Cut files: {cuts}"
+                self.measurement.log(msg)
                 log_info = "Energy Spectrum graph points:\n"
                 data = self.parent.energy_spectrum_widget.energy_spectrum_data
                 splitinfo = "\n".join(["{0}: {1}".format(key, ", ".join(

--- a/dialogs/energy_spectrum.py
+++ b/dialogs/energy_spectrum.py
@@ -345,7 +345,7 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
               f"Used files: {', '.join(str(f) for f in self.result_files)}"
 
         logging.getLogger("request").info(f"[{simulation_name}] {msg}")
-        logging.getLogger(simulation_name).info(msg)
+        self.simulation.log(msg)
         self.close()
 
     @gutils.disable_widget
@@ -387,15 +387,15 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
                     "Cut files: {0}".format(", ".join(str(cut) for cut
                                                       in selected_cuts)))
                 logging.getLogger("request").info(msg)
-                logging.getLogger(measurement_name).info(
-                    "Created Energy Spectrum. Bin width: {0} Cut files: {1}".
-                    format(width, ", ".join(str(cut) for cut in selected_cuts)))
+                self.measurement.log(
+                    f"Created Energy Spectrum. Bin width: {width} Cut files: "
+                    f"{', '.join(str(cut) for cut in selected_cuts)}")
                 log_info = "Energy Spectrum graph points:\n"
                 data = self.parent.energy_spectrum_widget.energy_spectrum_data
                 splitinfo = "\n".join(["{0}: {1}".format(key, ", ".join(
                     "({0};{1})".format(round(v[0], 2), v[1])
                     for v in data[key])) for key in data.keys()])
-                logging.getLogger(measurement_name).info(log_info + splitinfo)
+                self.measurement.log(log_info + splitinfo)
             else:
                 QtWidgets.QMessageBox.critical(
                     self, "Error",
@@ -537,7 +537,7 @@ class EnergySpectrumWidget(QtWidgets.QWidget):
             # If the file path points to directory, this will either raise
             # PermissionError (Windows) or IsADirectoryError (Mac)
             msg = f"Could not create Energy Spectrum graph: {e}"
-            logging.getLogger(self.parent.obj.name).error(msg)
+            self.parent.obj.log_error(msg)
 
             if hasattr(self, "matplotlib"):
                 self.matplotlib.delete()

--- a/dialogs/measurement/depth_profile.py
+++ b/dialogs/measurement/depth_profile.py
@@ -29,8 +29,6 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen " \
              "Samuel Kaiponen \n Heta Rekilä \n Sinikka Siironen"
 __version__ = "2.0"
 
-import logging
-
 import dialogs.dialog_functions as df
 import widgets.gui_utils as gutils
 import widgets.binding as bnd
@@ -210,7 +208,7 @@ class DepthProfileDialog(QtWidgets.QDialog):
         except Exception as e:
             error_log = f"Exception occurred when trying to create depth " \
                         f"profiles: {e}"
-            logging.getLogger(self.measurement.name).error(error_log)
+            self.measurement.log_error(error_log)
         finally:
             sbh.reporter.report(100)
 
@@ -340,7 +338,7 @@ class DepthProfileWidget(QtWidgets.QWidget):
                 systematic_error=self._systematic_error, progress=sub_progress)
         except Exception as e:
             msg = f"Could not create Depth Profile graph: {e}"
-            logging.getLogger(self.measurement.name).error(msg)
+            self.measurement.log_error(msg)
             if hasattr(self, "matplotlib"):
                 self.matplotlib.delete()
         finally:

--- a/dialogs/measurement/element_losses.py
+++ b/dialogs/measurement/element_losses.py
@@ -29,7 +29,6 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen \n Samuli " \
              "Kaiponen \n Heta Rekilä \n Sinikka Siironen \n Juhani Sundell"
 __version__ = "2.0"
 
-import logging
 import os
 
 import dialogs.dialog_functions as df
@@ -154,12 +153,10 @@ class ElementLossesDialog(QtWidgets.QDialog):
             self.parent.add_widget(self.parent.elemental_losses_widget,
                                    icon=icon)
 
-            measurement_name = self.measurement.name
-            msg = "Created Element Losses. Splits: {0} {1} {2}" \
-                .format(split_count,
-                        "Reference cut: {0}".format(reference_cut),
-                        "List of cuts: {0}".format(used_cuts))
-            logging.getLogger(measurement_name).info(msg)
+            msg = f"Created Element Losses. Splits: {split_count} " \
+                  f"Reference cut: {reference_cut} " \
+                  f"List of cuts: {used_cuts}"
+            self.measurement.log(msg)
 
             log_info = "Elemental Losses split counts:\n"
 
@@ -168,7 +165,7 @@ class ElementLossesDialog(QtWidgets.QDialog):
                 ["{0}: {1}".format(
                     key, ", ".join(str(v) for v in split_counts[key]))
                     for key in split_counts])
-            logging.getLogger(measurement_name).info(log_info + splitinfo)
+            self.measurement.log(log_info + splitinfo)
 
             sbh.reporter.report(100)
             self.close()
@@ -245,7 +242,7 @@ class ElementLossesWidget(QtWidgets.QWidget):
                 rbs_list=rbs_list, reference_cut_file=reference_cut_file)
         except Exception as e:
             msg = f"Could not create Elemental Losses graph: {e}"
-            logging.getLogger(self.measurement.name).error(msg)
+            self.measurement.log_error(msg)
             if hasattr(self, "matplotlib"):
                 self.matplotlib.delete()
         finally:

--- a/dialogs/measurement/import_measurement.py
+++ b/dialogs/measurement/import_measurement.py
@@ -28,8 +28,6 @@ __author__ = "Timo Konu \n Severi Jääskeläinen \n Samuel Kaiponen \n Heta " \
              "Rekilä \n Sinikka Siironen \n Juhani Sundell \n Tuomas Pitkänen"
 __version__ = "2.0"
 
-import logging
-import os
 import re
 
 import dialogs.dialog_functions as df
@@ -194,17 +192,17 @@ class ImportMeasurementsDialog(QtWidgets.QDialog):
 
         filenames = ", ".join(filename_list)
         elapsed = timer() - start_time
-        log = "Imported measurements to request: {0}".format(filenames)
+        log = f"Imported measurements to request: {filenames}"
         log_var = "Variables used: {0} {1} {2} {3} {4}".format(
             "Skip lines: " + str(self.spin_skiplines.value()),
             "ADC trigger: " + str(self.spin_adctrigger.value()),
             "ADC count: " + str(self.spin_adccount.value()),
             "Timing: " + str(timing),
             "Event count: " + str(self.spin_eventcount.value()))
-        log_elapsed = "Importing finished {0} seconds".format(int(elapsed))
-        logging.getLogger("request").info(log)
-        logging.getLogger("request").info(log_var)
-        logging.getLogger("request").info(log_elapsed)
+        log_elapsed = f"Importing finished {elapsed} seconds"
+        self.request.log(log)
+        self.request.log(log_var)
+        self.request.log(log_elapsed)
 
         sbh.reporter.report(100)
         self.imported = True

--- a/dialogs/new_request.py
+++ b/dialogs/new_request.py
@@ -30,7 +30,6 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen \n " \
 __version__ = "2.0"
 
 import os
-import logging
 import platform
 
 import widgets.input_validation as iv
@@ -115,7 +114,6 @@ class RequestNewDialog(QtWidgets.QDialog):
             if not directory.exists():
                 os.makedirs(directory)
                 self.directory = directory
-                logging.getLogger("request").info("Created the request.")
                 self.__close = True
             else:
                 QtWidgets.QMessageBox.critical(self, "Already exists",

--- a/modules/calibration.py
+++ b/modules/calibration.py
@@ -29,18 +29,20 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen " \
 __version__ = "2.0"
 
 import collections
+from typing import Optional
+
+import numpy as np
 import scipy.optimize as optimize
-
-from . import general_functions as gf
-
-from numpy import array
-from numpy import linspace
-
 from scipy import cos
 from scipy import sin
 from scipy import sqrt
 from scipy import pi
 from scipy.special import erf
+
+from .run import Run
+from .detector import Detector
+from .ui_log_handlers import Logger
+from . import general_functions as gf
 
 
 class TOFCalibrationHistogram:
@@ -123,8 +125,8 @@ class TOFCalibrationHistogram:
         if len(x) < 2 or len(y) < 2:
             return None
 
-        x = array(x)  # Numpy array
-        y = array(y)
+        x = np.array(x)
+        y = np.array(y)
 
         Param = collections.namedtuple("Param", "x0 a k")
         p_guess = Param(x0=guess_x0, a=guess_a, k=guess_k)
@@ -207,9 +209,8 @@ class TOFCalibrationHistogram:
         Return:
             tuple(xp, pxp) of generated lists of axis data (x and y axis)
         """
-        x_values = linspace(self.histogram_x[0],
-                            self.histogram_x[-1],
-                            points_in_range)
+        x_values = np.linspace(
+            self.histogram_x[0], self.histogram_x[-1], points_in_range)
         y_values = self.error_function(x_values, params)
         return x_values, y_values
 
@@ -318,8 +319,8 @@ class TOFCalibration:
             self.offset = None
             return None, None
 
-        x = array(x)  # Numpy array
-        y = array(y)
+        x = np.array(x)
+        y = np.array(y)
 
         Param = collections.namedtuple('Param', 'a b')
         p_guess = Param(a=guess_a, b=guess_b)
@@ -352,7 +353,7 @@ class TOFCalibration:
             tuple(x_values, y_values) of generated lists of axis data (x and y
             axis).
         """
-        x_values = linspace(x_min, x_max, points_in_range)
+        x_values = np.linspace(x_min, x_max, points_in_range)
         y_values = self.linear_function(x_values, params)
         return x_values, y_values
 
@@ -369,7 +370,8 @@ class TOFCalibrationPoint:
     """ Class for the calculation of a theoretical time of flight.
     """
 
-    def __init__(self, time_of_flight, cut, detector, run):
+    def __init__(self, time_of_flight, cut, detector: Detector, run: Run,
+                 logger: Optional[Logger] = None):
         """ Inits the class.
 
         Args:
@@ -430,7 +432,8 @@ class TOFCalibrationPoint:
         except Exception as e:
             error_msg = f"Carbon stopping doesn't work: {e}. Continuing " \
                         f"without it. Carbon stopping energy set to 0."
-            # logging.getLogger("").error(error_msg) # TODO: Add to error logger
+            if logger is not None:
+                logger.log_error(error_msg)
             print(error_msg)
             carbon_energy_loss = 0
         self.energy_loss = carbon_energy_loss

--- a/modules/depth_files.py
+++ b/modules/depth_files.py
@@ -39,7 +39,6 @@ import math
 import os
 import platform
 import subprocess
-import logging
 import functools
 
 from pathlib import Path
@@ -49,6 +48,7 @@ from typing import List
 from . import math_functions as mf
 from . import comparison as comp
 from . import general_functions as gf
+from .ui_log_handlers import Logger
 from .element import Element
 from .parsing import CSVParser
 from .measurement import Measurement
@@ -518,7 +518,8 @@ class DepthProfileHandler:
             self,
             directory_path: Path,
             elements,
-            depth_units: DepthProfileUnit = DepthProfileUnit.NM):
+            depth_units: DepthProfileUnit = DepthProfileUnit.NM,
+            logger: Optional[Logger] = None) -> None:
         """Reads depth files from the given directory that match the given
         set of elements and stores them internally as DepthProfiles.
 
@@ -530,16 +531,18 @@ class DepthProfileHandler:
             elements: collection of elements that will be matched to
                       depth files
             depth_units: unit in which depths are measured
+            logger: optional Logger entity used for logging
         """
         file_paths = get_depth_files(elements, directory_path)
-        self.read_files(file_paths, elements, depth_units=depth_units)
+        self.read_files(
+            file_paths, elements, depth_units=depth_units, logger=logger)
 
     def read_files(
             self,
             file_paths,
             elements,
             depth_units: DepthProfileUnit = DepthProfileUnit.NM,
-            logger_name=None):
+            logger: Optional[Logger] = None) -> None:
         """Reads depth files from given list of file paths that
         match the given set of elements.
 
@@ -550,8 +553,7 @@ class DepthProfileHandler:
             elements: collection of elements that will be matched to
                       depth files
             depth_units: unit in which depths are measured
-            logger_name: name of a Logger entity that will be used to create a
-                         log message if something goes wrong when reading files
+            logger: optional Logger entity used for logging
         """
         # Clear currently stored profiles and cache for merging
         self.merge_profiles.cache_clear()
@@ -574,11 +576,10 @@ class DepthProfileHandler:
                     depth_units=depth_units)
 
                 self.__absolute_profiles[profile.get_profile_name()] = profile
-
             except Exception as e:
-                if logger_name is not None:
-                    logging.getLogger(logger_name).info(
-                        f"Could not create depth profiled .depth file: {e}")
+                if logger is not None:
+                    msg = f"Could not create depth profiled .depth file: {e}"
+                    logger.log_error(msg)
 
     def get_depth_range(self):
         """Returns the minimum and maximum depth values in the total depth

--- a/modules/element_simulation.py
+++ b/modules/element_simulation.py
@@ -28,7 +28,6 @@ __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä \n" \
 __version__ = "2.0"
 
 import json
-import logging
 import os
 import time
 import itertools
@@ -412,10 +411,9 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
                 "channel_width": prof["energy_spectra"]["channel_width"]
             }
         except (json.JSONDecodeError, OSError, KeyError, AttributeError) as e:
-            logging.getLogger("request").error(
-                f"Failed to read data from element simulation .profile file "
-                f"{profile_file}: {e}."
-            )
+            msg = f"Failed to read data from element simulation .profile " \
+                  f"file {profile_file}: {e}."
+            request.log_error(msg)
             kwargs = {}
 
         rec_type = mcsimu["simulation_type"].get_recoil_type()

--- a/modules/element_simulation.py
+++ b/modules/element_simulation.py
@@ -67,7 +67,6 @@ from .enums import SimulationMode
 from .run import Run
 from .detector import Detector
 from .element import Element
-from .profile import Profile
 
 
 # Mappings between the names of the MCERD parameters (keys) and
@@ -832,7 +831,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
             msg = f"Simulation finished. Element " \
                   f"{self.get_main_recoil().get_full_name()}, " \
                   f"observed atoms: {atom_count}."
-            logging.getLogger(self.simulation.name).info(msg)
+            self.simulation.log(msg)
 
         self.on_completed(self.get_current_status())
 

--- a/modules/energy_spectrum.py
+++ b/modules/energy_spectrum.py
@@ -30,7 +30,6 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen " \
              "Juhani Sundell"
 __version__ = "2.0"
 
-import logging
 import subprocess
 import platform
 
@@ -46,6 +45,7 @@ from typing import Dict
 from .observing import ProgressReporter
 from . import general_functions as gf
 from . import subprocess_utils as sutils
+from .ui_log_handlers import Logger
 from .parsing import ToFListParser
 from .measurement import Measurement
 from .element import Element
@@ -175,14 +175,14 @@ class EnergySpectrum:
 
                 cut_dict[key] = EnergySpectrum.tof_list(
                     cut_file, directory, no_foil=no_foil,
-                    logger_name=self._measurement.name,
+                    logger=self._measurement,
                     tof_in=tof_in, verbose=verbose)
 
                 if progress is not None:
                     progress.report(i / count * 90)
         except Exception as e:
             msg = f"Could not calculate Energy Spectrum: {e}."
-            logging.getLogger(self._measurement.name).error(msg)
+            self._measurement.log_error(msg)
         finally:
             if progress is not None:
                 progress.report(100)
@@ -193,7 +193,7 @@ class EnergySpectrum:
             cut_file: Path,
             directory: Optional[Path] = None,
             no_foil: bool = False,
-            logger_name: Optional[str] = None,
+            logger: Optional[Logger] = None,
             tof_in: Path = Path("tof.in"),
             verbose: bool = True) -> TofListData:
         """ToF_list
@@ -206,7 +206,7 @@ class EnergySpectrum:
                 directory.
             no_foil: whether foil thickness was used when .cut files were
                 generated. This affects the file path when saving output
-            logger_name: name of a logging entity
+            logger: optional Logger entity used for logging
             tof_in: path to tof_in_file
             verbose: whether tof_list's stderr is printed to console
 
@@ -242,8 +242,8 @@ class EnergySpectrum:
                 return tof_list_data
         except Exception as e:
             msg = f"Error in tof_list: {e}"
-            if logger_name is not None:
-                logging.getLogger(logger_name).error(msg)
+            if logger is not None:
+                logger.log_error(msg)
             else:
                 print(msg)
             return []

--- a/modules/general_functions.py
+++ b/modules/general_functions.py
@@ -606,8 +606,7 @@ def rename_entity(entity: Union["Measurement", "Simulation"], new_name):
             entity.serial_number + "-" + new_name
 
         # Close and remove logs
-        entity.remove_and_close_log(entity.defaultlog)
-        entity.remove_and_close_log(entity.errorlog)
+        entity.remove_and_close_log()
 
         new_dir = rename_file(entity.directory, new_folder)
         entity.name = new_name
@@ -639,7 +638,6 @@ def get_data_dir() -> Path:
 # to root folder is stored as the value of sys._MEIPASS attribute:
 # https://pyinstaller.readthedocs.io/en/stable/runtime-information.html?
 #   highlight=bundle
-# TODO is this only needed in macOS app?
 _ROOT_DIR = Path(
     getattr(sys, "_MEIPASS", Path(__file__).parent.parent)
 ).resolve()

--- a/modules/general_functions.py
+++ b/modules/general_functions.py
@@ -606,7 +606,7 @@ def rename_entity(entity: Union["Measurement", "Simulation"], new_name):
             entity.serial_number + "-" + new_name
 
         # Close and remove logs
-        entity.remove_and_close_log()
+        entity.close_log_files()
 
         new_dir = rename_file(entity.directory, new_folder)
         entity.name = new_name

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -52,7 +52,7 @@ from .detector import Detector
 from .profile import Profile
 from .run import Run
 from .target import Target
-from .ui_log_handlers import Logger
+from .ui_log_handlers import MeasurementLogger
 from .base import Serializable
 
 
@@ -247,7 +247,7 @@ class Measurements:
         self.measurements = remove_key(self.measurements, tab_id)
 
 
-class Measurement(Logger, Serializable):
+class Measurement(MeasurementLogger, Serializable):
     """Measurement class to handle one measurement data.
     """
 
@@ -276,8 +276,7 @@ class Measurement(Logger, Serializable):
             path: Full path to measurement's .info file.
         """
         # Run the base class initializer to establish logging
-        Logger.__init__(
-            self, name, "Measurement", enable_logging=enable_logging)
+        MeasurementLogger.__init__(self, enable_logging=enable_logging)
         # FIXME path should be to info file
         self.tab_id = tab_id
 
@@ -773,7 +772,7 @@ class Measurement(Logger, Serializable):
             #       3. user tries to open the imported data
             log_msg = "There was no old selection file to add to this " \
                       f"request."
-            logging.getLogger(self.name).info(log_msg)
+            self.log(log_msg)
 
     def add_point(self, point, canvas):
         """Add point into selection or create new selection if first or all
@@ -932,7 +931,7 @@ class Measurement(Logger, Serializable):
             progress.report(100)
 
         log_msg = f"Saving finished in {time.time() - starttime} seconds."
-        logging.getLogger(self.name).info(log_msg)
+        self.log(log_msg)
 
     def __remove_old_cut_files(self):
         """Remove old cut files.
@@ -1112,17 +1111,17 @@ class Measurement(Logger, Serializable):
                 shutil.copyfile(tof_in_file, new_file)
                 back_up_msg = "Backed up old tof.in file to {0}".format(
                     os.path.realpath(new_file))
-                logging.getLogger(self.name).info(back_up_msg)
+                self.log(back_up_msg)
             except Exception as e:
                 if not isinstance(e, FileNotFoundError):
                     error_msg = f"Error when generating tof.in: {e}"
-                    logging.getLogger(self.name).error(error_msg)
+                    self.log_error(error_msg)
             # Write new settings to the file.
             with tof_in_file.open("w") as fp:
                 fp.write(tof_in)
-            str_logmsg = "Generated tof.in with params> {0}". \
+            str_logmsg = f"Generated tof.in with params> {0}". \
                 format(tof_in.replace("\n", "; "))
-            logging.getLogger(self.name).info(str_logmsg)
+            self.log(str_logmsg)
 
         return tof_in_file
 

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -765,11 +765,6 @@ class Measurement(MeasurementLogger, Serializable):
             with selection_file.open("r"):
                 self.load_selection(selection_file, progress)
         except OSError:
-            # TODO: Is it necessary to inform user with this?
-            # FIXME crashes here when:
-            #       1. user deletes all measurements from a sample
-            #       2. user imports new .evnt file
-            #       3. user tries to open the imported data
             log_msg = "There was no old selection file to add to this " \
                       f"request."
             self.log(log_msg)

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -275,7 +275,8 @@ class Measurement(MeasurementLogger, Serializable):
             path: Full path to measurement's .info file.
         """
         # Run the base class initializer to establish logging
-        MeasurementLogger.__init__(self, enable_logging=enable_logging)
+        MeasurementLogger.__init__(
+            self, name, enable_logging=enable_logging, parent=request)
         # FIXME path should be to info file
         self.tab_id = tab_id
 
@@ -371,7 +372,7 @@ class Measurement(MeasurementLogger, Serializable):
                     self.measurement_file = path
                     break
 
-        self.set_loggers(self.directory, self.request.directory)
+        self.set_up_log_files(self.directory)
 
         element_colors = self.request.global_settings.get_element_colors()
         if selector_cls is not None:
@@ -390,7 +391,7 @@ class Measurement(MeasurementLogger, Serializable):
         if self.selector is not None:
             self.selector.update_references(self)
 
-        self.set_loggers(self.directory, self.request.directory)
+        self.set_up_log_files(self.directory)
 
     @staticmethod
     def find_measurement_files(directory: Path):
@@ -438,7 +439,8 @@ class Measurement(MeasurementLogger, Serializable):
             run: Optional[Run] = None,
             target: Optional[Target] = None,
             profile: Optional[Profile] = None,
-            sample: Optional["Sample"] = None) -> "Measurement":
+            sample: Optional["Sample"] = None,
+            enable_logging: bool = True) -> "Measurement":
         """Read Measurement information from file.
 
         Args:
@@ -450,6 +452,7 @@ class Measurement(MeasurementLogger, Serializable):
             target: Measurement's Target object.
             profile: Measurement's Profile object.
             sample: Sample under which this Measurement belongs to.
+            enable_logging: whether logging is enabled or not
 
         Return:
             Measurement object.
@@ -479,9 +482,9 @@ class Measurement(MeasurementLogger, Serializable):
             mesu_general = {}
 
         return cls(
-            request=request, path=info_file, run=run,
-            detector=detector, target=target, profile=profile,
-            **obj_info, **mesu_general, sample=sample)
+            request=request, path=info_file, run=run, detector=detector,
+            target=target, profile=profile, **obj_info, **mesu_general,
+            sample=sample, enable_logging=enable_logging)
 
     def get_data_dir(self) -> Path:
         """Returns path to Data directory.
@@ -629,7 +632,7 @@ class Measurement(MeasurementLogger, Serializable):
         self.__make_directories(self.get_energy_spectra_dir())
         self.__make_directories(self._get_tof_in_dir())
 
-        self.set_loggers(self.directory, self.request.directory)
+        self.set_up_log_files(self.directory)
 
         element_colors = self.request.global_settings.get_element_colors()
         if selector_cls is not None:

--- a/modules/profile.py
+++ b/modules/profile.py
@@ -28,13 +28,13 @@ __author__ = "Tuomas Pitkänen"
 __version__ = "2.0"
 
 import json
-import logging
 import time
 
 from pathlib import Path
-from typing import Set
+from typing import Set, Optional
 
 from .base import AdjustableSettings, Serializable
+from .ui_log_handlers import Logger
 
 
 # TODO: Create unit tests / copy unit tests from measurement
@@ -76,7 +76,10 @@ class Profile(AdjustableSettings, Serializable):
         self.normalization = normalization
 
     @classmethod
-    def from_file(cls, profile_file: Path) -> "Profile":
+    def from_file(
+            cls,
+            profile_file: Path,
+            logger: Optional[Logger] = None) -> "Profile":
         # TODO: Copy from measurement.from_file (lines 502 to 556)
         try:
             with profile_file.open("r") as prof_file:
@@ -93,12 +96,14 @@ class Profile(AdjustableSettings, Serializable):
             comp = profile["composition_changes"]
 
         except (OSError, KeyError, AttributeError, json.JSONDecodeError) as e:
-            logging.getLogger("request").error(
-                f"Failed to read settings from .profile file {profile_file}: {e}"
-            )
+            if logger is not None:
+                msg = f"Failed to read settings from .profile file " \
+                      f"{profile_file}: {e}"
+                logger.log_error(msg)
             # TODO: Initialize a request.default_profile elsewhere and
             #       use its values here, or just let it crash?
-            raise NotImplementedError("Error handling not implemented for .profile")
+            raise NotImplementedError(
+                "Error handling not implemented for .profile")
 
         return cls(channel_width=channel_width, **general, **depth, **comp)
 

--- a/modules/run.py
+++ b/modules/run.py
@@ -109,7 +109,7 @@ class Run(Serializable, AdjustableSettings):
             json.dump(obj, file, indent=4)
 
     @classmethod
-    def from_file(cls, measurement_file: Path):
+    def from_file(cls, measurement_file: Path) -> "Run":
         """
         Reads parameter sfrom file and makes a Run object from them.
         Args:

--- a/modules/selection.py
+++ b/modules/selection.py
@@ -33,7 +33,6 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen " \
 __version__ = "2.0"
 # TODO move this module under widgets.matplotlib
 
-import logging
 import os
 import itertools
 
@@ -339,7 +338,7 @@ class Selector:
         sel = self.selections[-1]  # Get last one
         if sel.count() < 3:  # Required point count
             message = "At least two points required to close selection"
-            logging.getLogger(self.measurement_name).error(message)
+            self.measurement.log_error(message)
             return 0
         elif not sel.is_closed:
             selection_is_ok = sel.end_selection(canvas)
@@ -480,14 +479,14 @@ class Selector:
                                     measurement=self.measurement)
                     self.selections.append(sel)
             message = f"Selection file {filename} was read successfully!"
-            logging.getLogger(self.measurement_name).info(message)
+            self.measurement.log(message)
         except OSError as e:
             message = f"Could not read selection file: {e}."
-            logging.getLogger(self.measurement_name).error(message)
+            self.measurement.log_error(message)
         except (ValueError, IndexError) as e:
             message = f"Could not read selection data from {filename}. " \
                       f"Reason: {e}. Check that the file contains valid data."
-            logging.getLogger(self.measurement_name).error(message)
+            self.measurement.log_error(message)
         self.update_axes_limits()
         self.draw()  # Draw all selections
         self.auto_save()

--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -244,7 +244,8 @@ class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
             enable_logging: whether logging is enabled
         """
         # Run the base class initializer to establish logging
-        SimulationLogger.__init__(self, enable_logging=enable_logging)
+        SimulationLogger.__init__(
+            self, name, enable_logging=enable_logging, parent=request)
 
         self.tab_id = tab_id
         self.path = Path(path)
@@ -298,7 +299,7 @@ class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
         if not self.directory.exists():
             self.directory.mkdir(exist_ok=True)
             self.request.log(f"Created a directory {self.directory}.")
-        self.set_loggers(self.directory, self.request.directory)
+        self.set_up_log_files(self.directory)
 
     def get_measurement_file(self) -> Path:
         """Returns the path to .measurement file that contains the settings
@@ -536,7 +537,7 @@ class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
         for elem_sim in self.element_simulations:
             elem_sim.directory = new_dir
 
-        self.set_loggers(self.directory, self.request.directory)
+        self.set_up_log_files(self.directory)
 
     def get_running_simulations(self) -> List[ElementSimulation]:
         """Returns a list of currently running simulations.

--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -31,7 +31,6 @@ __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä " \
 __version__ = "2.0"
 
 import json
-import logging
 import time
 
 from collections import namedtuple
@@ -172,7 +171,7 @@ class Simulations:
                     simulation
             except Exception as e:
                 log = f"Something went wrong while adding a new simulation: {e}"
-                logging.getLogger("request").critical(log)
+                self.request.log_error(log)
         if simulation is not None:
             sample.simulations.simulations[tab_id] = simulation
         return simulation
@@ -298,8 +297,7 @@ class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
         """
         if not self.directory.exists():
             self.directory.mkdir(exist_ok=True)
-            log = f"Created a directory {self.directory}."
-            logging.getLogger("request").info(log)
+            self.request.log(f"Created a directory {self.directory}.")
         self.set_loggers(self.directory, self.request.directory)
 
     def get_measurement_file(self) -> Path:

--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -50,7 +50,7 @@ from .detector import Detector
 from .element_simulation import ElementSimulation
 from .run import Run
 from .target import Target
-from .ui_log_handlers import Logger
+from .ui_log_handlers import SimulationLogger
 
 
 class Simulations:
@@ -199,7 +199,7 @@ class Simulations:
         self.simulations = remove_key(self.simulations, tab_id)
 
 
-class Simulation(Logger, ElementSimulationContainer, Serializable):
+class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
     """
     A Simulation class that handles information about one Simulation.
     """
@@ -245,7 +245,7 @@ class Simulation(Logger, ElementSimulationContainer, Serializable):
             enable_logging: whether logging is enabled
         """
         # Run the base class initializer to establish logging
-        Logger.__init__(self, name, "Simulation", enable_logging=enable_logging)
+        SimulationLogger.__init__(self, enable_logging=enable_logging)
 
         self.tab_id = tab_id
         self.path = Path(path)

--- a/modules/ui_log_handlers.py
+++ b/modules/ui_log_handlers.py
@@ -224,3 +224,17 @@ class SimulationLogger(_CategorizedLogger):
     @property
     def category(self) -> str:
         return "Simulation"
+
+
+class RequestLogger(Logger):
+    def set_loggers(self, request_directory: Path) -> None:
+        if not self.is_logging_enabled:
+            return
+        formatter = logging.Formatter(
+            "%(asctime)s - %(levelname)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S")
+        requestlog = logging.FileHandler(Path(request_directory, "request.log"))
+        requestlog.setLevel(logging.INFO)
+        requestlog.setFormatter(formatter)
+
+        self._logger.addHandler(requestlog)

--- a/modules/ui_log_handlers.py
+++ b/modules/ui_log_handlers.py
@@ -241,6 +241,25 @@ class _CategorizedLogger(Logger):
         return self._display_name
 
     @property
+    def info_log_file(self) -> Optional[Path]:
+        """Absolute path to the info log file of this Logger instance.
+        """
+        return self._path_to_log_file(0)
+
+    @property
+    def error_log_file(self) -> Optional[Path]:
+        """Absolute path to the error log file of this Logger instance.
+        """
+        return self._path_to_log_file(-1)
+
+    def _path_to_log_file(self, idx: int) -> Optional[Path]:
+        if not self._logger.handlers:
+            return None
+        handler = self._logger.handlers[idx]
+        if isinstance(handler, FileHandler):
+            return Path(handler.baseFilename).resolve()
+
+    @property
     def _kwargs_for_log(self) -> Mapping:
         return {
             "extra": {
@@ -255,7 +274,7 @@ class _CategorizedLogger(Logger):
         """
         default_log = FileHandler(directory / self.DEFAULT_LOG)
         default_log.setLevel(logging.INFO)
-        error_log = FileHandler(directory / "errors.log")
+        error_log = FileHandler(directory / self.ERROR_LOG)
         error_log.setLevel(logging.ERROR)
 
         default_log.setFormatter(self.default_formatter)

--- a/modules/ui_log_handlers.py
+++ b/modules/ui_log_handlers.py
@@ -134,8 +134,7 @@ class Logger:
 
 
 class _CategorizedLogger(Logger):
-    __slots__ = Logger.__slots__ + (
-        "datefmt", "defaultlog", "errorlog", "enable_logging")
+    __slots__ = Logger.__slots__ + ("datefmt", "defaultlog", "errorlog")
 
     def __init__(
             self,
@@ -193,14 +192,20 @@ class _CategorizedLogger(Logger):
         self._logger.addHandler(self.errorlog)
         self._logger.addHandler(requestlog)
 
-    def remove_and_close_log(self, log_filehandler):
+    def remove_and_close_log(self) -> None:
+        """Closes log files.
+        """
+        self._remove_and_close_log(self.defaultlog)
+        self._remove_and_close_log(self.errorlog)
+
+    def _remove_and_close_log(self, log_filehandler) -> None:
         """Closes the log file and removes it from the logger.
 
         Args:
             log_filehandler: Log's filehandler.
         """
-        self._logger.removeHandler(log_filehandler)
         if log_filehandler is not None:
+            self._logger.removeHandler(log_filehandler)
             log_filehandler.flush()
             log_filehandler.close()
 

--- a/potku.py
+++ b/potku.py
@@ -1166,6 +1166,7 @@ class Potku(QtWidgets.QMainWindow):
             # Clear the treewidget
             self.treeWidget.clear()
             self.tabs.clear()
+            self.request.close_log_files()
             self.request = None
             self.tab_widgets = {}
             self.tab_id = 0

--- a/potku.py
+++ b/potku.py
@@ -502,7 +502,7 @@ class Potku(QtWidgets.QMainWindow):
                 tab.tab_id)
             try:
                 # Close and remove logs
-                measurement.remove_and_close_log()
+                measurement.close_log_files()
 
                 # Remove measurement's directory tree
                 shutil.rmtree(measurement.directory)
@@ -515,8 +515,8 @@ class Potku(QtWidgets.QMainWindow):
                     QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.Ok)
                 # TODO check that this is the intented way of setting the
                 #  loggers in case something went wrong.
-                measurement.set_loggers(measurement.directory,
-                                        measurement.request.directory)
+                measurement.set_up_log_files(measurement.directory,
+                                             measurement.request.directory)
                 return
 
             self.request.samples.measurements.remove_by_tab_id(tab.tab_id)

--- a/potku.py
+++ b/potku.py
@@ -331,8 +331,7 @@ class Potku(QtWidgets.QMainWindow):
 
             # Remove object from Sample
             clicked_item.parent().obj.remove_obj(clicked_item.obj)
-            clicked_item.obj.defaultlog.close()
-            clicked_item.obj.errorlog.close()
+            clicked_item.obj.close_log_files()
 
             # Remove object directory
             shutil.rmtree(clicked_item.obj.directory)

--- a/potku.py
+++ b/potku.py
@@ -502,8 +502,7 @@ class Potku(QtWidgets.QMainWindow):
                 tab.tab_id)
             try:
                 # Close and remove logs
-                measurement.remove_and_close_log(measurement.defaultlog)
-                measurement.remove_and_close_log(measurement.errorlog)
+                measurement.remove_and_close_log()
 
                 # Remove measurement's directory tree
                 shutil.rmtree(measurement.directory)

--- a/potku.py
+++ b/potku.py
@@ -706,15 +706,16 @@ class Potku(QtWidgets.QMainWindow):
         # TODO: regex check for directory. I.E. do not allow asd/asd
         if dialog.directory:
             self.__close_request()
-            title = "{0} - Request: {1}".format(self.title, dialog.name)
+            title = f"{self.title} - Request: {dialog.name}"
             self.setWindowTitle(title)
 
-            self.treeWidget.setHeaderLabel("Request: {0}".format(dialog.name))
+            self.treeWidget.setHeaderLabel(f"Request: {dialog.name}")
             self.__initialize_tree_view()
 
-            self.request = Request(dialog.directory, dialog.name, self.settings,
-                                   self.tab_widgets)
+            self.request = Request(
+                dialog.directory, dialog.name, self.settings, self.tab_widgets)
             self.settings.set_request_directory_last_open(dialog.directory)
+            self.request.log("Request created.")
             # Request made, close introduction tab
             self.__remove_introduction_tab()
             self.__open_info_tab()

--- a/tests/integration/test_element_simulation.py
+++ b/tests/integration/test_element_simulation.py
@@ -27,7 +27,6 @@ __version__ = "2.0"
 import unittest
 import tempfile
 
-import tests.utils as utils
 import tests.mock_objects as mo
 
 from pathlib import Path
@@ -50,7 +49,7 @@ class TestElementSimulationSettings(unittest.TestCase):
     # TODO: This test doesn't make much sense after changing how default
     #       settings work with ElementSimulations. Convert this into a
     #       general integration test for ElementSimulation.
-    def test_elementsimulation_settings(self):
+    def test_element_simulation_settings(self):
         """This tests that ElementSimulation is run with the correct settings
         depending on how 'use_default_settings' and 'use_request_settings'
         have been set.
@@ -65,7 +64,8 @@ class TestElementSimulationSettings(unittest.TestCase):
 
             # Request
             request = Request(
-                req_dir, "test_req", GlobalSettings(config_dir=tmp_dir), {})
+                req_dir, "test_req", GlobalSettings(config_dir=tmp_dir), {},
+                enable_logging=False)
 
             self.assertEqual(req_dir, request.directory)
             self.assertEqual("test_req", request.request_name)
@@ -81,6 +81,10 @@ class TestElementSimulationSettings(unittest.TestCase):
             # Simulation
             sim = sample.simulations.add_simulation_file(
                 sample, simu_file, 0)
+            # Disable logging so the logging file handlers do not cause
+            # an exception when the tmp dir is removed
+            sim.close_log_files()
+
             self.assertIs(sim, sample.simulations.get_key_value(0))
             self.assertIsInstance(sim.detector, Detector)
             self.assertIsInstance(sim.run, Run)
@@ -97,10 +101,6 @@ class TestElementSimulationSettings(unittest.TestCase):
             elem_sim.number_of_ions = 3
             self.assertEqual(request, elem_sim.request)
             self.assertEqual("Fe-Default", elem_sim.get_full_name())
-
-            # Disable logging so the logging file handlers do not cause
-            # an exception when the tmp dir is removed
-            utils.disable_logging()
 
             # Some pre-simulation checks
             self.assertIsNot(sim.target, request.default_target)
@@ -131,8 +131,6 @@ class TestElementSimulationSettings(unittest.TestCase):
             # sim.use_request_settings = False
             # self.assert_expected_settings(elem_sim, request, sim)
 
-        self.assertFalse(tmp_dir.exists())
-
     @patch("modules.mcerd.MCERD.__init__", return_value=None)
     @patch("modules.mcerd.MCERD.run", return_value=mo.get_mcerd_stream())
     def assert_expected_settings(self, elem_sim: ElementSimulation,
@@ -146,11 +144,10 @@ class TestElementSimulationSettings(unittest.TestCase):
         seed, d = args[0], args[1]
         settings = {**d, "seed_number": seed}
         self.assertEqual(
-            get_expected_settings(elem_sim, request, sim), settings)
+            get_expected_settings(elem_sim, sim), settings)
 
 
-def get_expected_settings(elem_sim: ElementSimulation, request: Request,
-                          simulation: Simulation):
+def get_expected_settings(elem_sim: ElementSimulation, simulation: Simulation):
     detector = simulation.detector
     run = simulation.run
     expected_sim = elem_sim

--- a/tests/unit/test_element_simulation.py
+++ b/tests/unit/test_element_simulation.py
@@ -29,7 +29,6 @@ import unittest
 import tempfile
 import os
 import time
-import platform
 import threading
 import tests.utils as utils
 import tests.mock_objects as mo
@@ -42,7 +41,7 @@ from modules.element_simulation import ERDFileHandler
 from modules.element_simulation import ElementSimulation
 from modules.enums import OptimizationType
 
-from tests.utils import expected_failure_if
+from tests.utils import only_succeed_on
 
 from pathlib import Path
 from unittest.mock import patch
@@ -102,7 +101,7 @@ class TestErdFileHandler(unittest.TestCase):
     # Expect failure on *nix systems because they accept different file names
     # compared to Windows.
     # TODO correct behaviour should be specified in the future
-    @expected_failure_if(platform.system() != "Windows")
+    @only_succeed_on(utils.WINDOWS)
     def test_get_valid_erd_files(self):
         self.assertEqual([], list(fp.validate_erd_file_names(
             self.invalid_erd_files, self.elem_4he)))
@@ -330,7 +329,6 @@ class TestElementSimulation(unittest.TestCase):
             elem_sim2.get_settings())
         for key, value in self.kwargs.items():
             self.assertNotEqual(value, getattr(elem_sim2, key))
-
 
     def test_json_contents(self):
         self.elem_sim.use_default_settings = False

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -30,6 +30,7 @@ from logging import FileHandler
 from pathlib import Path
 from typing import Tuple
 
+import tests.utils as utils
 from modules.ui_log_handlers import (
     RequestLogger, MeasurementLogger, SimulationLogger, Logger
 )
@@ -54,6 +55,7 @@ class TestLogger(unittest.TestCase):
 
             logger.close_log_files()
 
+    @utils.only_run_on(utils.WINDOWS)
     def test_close_log_files_releases_resources(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
@@ -91,6 +93,7 @@ class TestLogger(unittest.TestCase):
             self.assertTrue(new_dir.exists())
             logger.close_log_files()
 
+    @utils.only_run_on(utils.WINDOWS)
     def test_previous_handlers_are_closed_when_set_loggers_is_called_again(
             self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,323 @@
+# coding=utf-8
+"""
+Created on 14.02.2021
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2021 Juhani Sundell
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = "Juhani Sundell"
+__version__ = "2.0"
+
+import unittest
+import tempfile
+from logging import FileHandler
+from pathlib import Path
+from typing import Tuple
+
+from modules.ui_log_handlers import (
+    RequestLogger, MeasurementLogger, SimulationLogger, Logger
+)
+
+
+class MockLogger(Logger):
+    FILE_NAME = "test.log"
+
+    def _get_handlers(self, directory: Path) -> Tuple[FileHandler, ...]:
+        return FileHandler(directory / self.FILE_NAME),
+
+
+class TestLogger(unittest.TestCase):
+    def test_log_file_is_created_after_set_loggers_is_called(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            log_file = tmp_dir / MockLogger.FILE_NAME
+
+            logger = MockLogger()
+            logger.set_up_log_files(tmp_dir)
+            self.assertTrue(log_file.exists())
+
+            logger.close_log_files()
+
+    def test_remove_and_close_log_releases_resources(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            log_file = tmp_dir / MockLogger.FILE_NAME
+
+            logger = MockLogger()
+            logger.set_up_log_files(tmp_dir)
+
+            # log file cannot be removed because logger is keeping its
+            # handle open
+            self.assertRaises(OSError, lambda: log_file.unlink())
+
+            # after calling remove_and_close, we can exit the context manager
+            # without exception
+            logger.close_log_files()
+
+    def test_log_file_is_not_created_if_logging_is_not_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            log_file = tmp_dir / MockLogger.FILE_NAME
+
+            logger = MockLogger(enable_logging=False)
+            logger.set_up_log_files(tmp_dir)
+
+            self.assertFalse(log_file.exists())
+
+    def test_directory_is_created_if_it_does_not_exist(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            new_dir = tmp_dir / "new"
+
+            logger = MockLogger()
+            logger.set_up_log_files(new_dir)
+
+            self.assertTrue(new_dir.exists())
+            logger.close_log_files()
+
+    def test_previous_handlers_are_closed_when_set_loggers_is_called_again(
+            self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            first_dir = Path(tmp_dir, "first")
+            first_file = first_dir / MockLogger.FILE_NAME
+
+            logger = MockLogger()
+            logger.set_up_log_files(first_dir)
+
+            second_dir = Path(tmp_dir, "second")
+            second_file = second_dir / MockLogger.FILE_NAME
+            logger.set_up_log_files(second_dir)
+
+            # first file can now be removed
+            first_file.unlink()
+            self.assertRaises(OSError, lambda: second_file.unlink())
+
+            logger.close_log_files()
+
+    def test_message_is_written_to_log_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            log_file = tmp_dir / MockLogger.FILE_NAME
+
+            logger = MockLogger()
+            logger.set_up_log_files(tmp_dir)
+            logger.log("foo")
+
+            expected = "foo\n"
+            actual = log_file.read_text()
+            self.assertEqual(expected, actual)
+
+            logger.close_log_files()
+
+    def test_error_is_written_to_log_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            log_file = tmp_dir / MockLogger.FILE_NAME
+
+            logger = MockLogger()
+            logger.set_up_log_files(tmp_dir)
+            logger.log_error("bar")
+
+            expected = "bar\n"
+            actual = log_file.read_text()
+            self.assertEqual(expected, actual)
+
+            logger.close_log_files()
+
+    def test_nothing_is_written_if_logging_is_not_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            log_file = tmp_dir / MockLogger.FILE_NAME
+
+            logger = MockLogger()
+            logger.set_up_log_files(tmp_dir)
+
+            logger.is_logging_enabled = False
+            logger.log("foo")
+            logger.log_error("bar")
+
+            expected = ""
+            actual = log_file.read_text()
+            self.assertEqual(expected, actual)
+
+            logger.close_log_files()
+
+    def test_message_is_not_written_if_log_file_is_closed(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            log_file = tmp_dir / MockLogger.FILE_NAME
+
+            logger = MockLogger()
+            logger.set_up_log_files(tmp_dir)
+            logger.close_log_files()
+            logger.log("foo")
+
+            expected = ""
+            actual = log_file.read_text()
+            self.assertEqual(expected, actual)
+
+    def test_child_logger_logs_to_parent_file_too(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            parent_file = tmp_dir / MockLogger.FILE_NAME
+
+            parent = MockLogger()
+            parent.set_up_log_files(tmp_dir)
+
+            child_dir = tmp_dir / "child"
+            child_file = child_dir / MockLogger.FILE_NAME
+            child = MockLogger(parent=parent)
+            child.set_up_log_files(child_dir)
+
+            child.log("foo")
+            child.log_error("bar")
+            parent.log("baz")
+
+            expected_parent = "foo\nbar\nbaz\n"
+            expected_child = "foo\nbar\n"
+            actual_parent = parent_file.read_text()
+            actual_child = child_file.read_text()
+            self.assertEqual(expected_parent, actual_parent)
+            self.assertEqual(expected_child, actual_child)
+
+            parent.close_log_files()
+            child.close_log_files()
+
+
+class TestRequestLogger(unittest.TestCase):
+    def test_log_file_is_created_after_set_loggers_is_called(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            folder = Path(tmp_dir)
+            log_file = folder / "request.log"
+
+            logger = RequestLogger()
+            logger.set_up_log_files(folder)
+
+            self.assertTrue(log_file.exists())
+
+            logger.close_log_files()
+
+    def test_message_is_written_to_log_file_with_timestamp(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            folder = Path(tmp_dir)
+            log_file = folder / "request.log"
+
+            logger = RequestLogger()
+            logger.set_up_log_files(folder)
+            logger.log("foo")
+
+            expected = r"\d\d\d\d\-\d\d-\d\d \d\d:\d\d:\d\d - INFO - foo\n"
+            actual = log_file.read_text()
+            self.assertRegex(actual, expected)
+
+            logger.close_log_files()
+
+    def test_error_message_is_written_to_log_file_with_timestamp(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            folder = Path(tmp_dir)
+            log_file = folder / "request.log"
+
+            logger = RequestLogger(enable_logging=True)
+            logger.set_up_log_files(folder)
+            logger.log_error("bar")
+
+            expected = r"\d\d\d\d\-\d\d-\d\d \d\d:\d\d:\d\d - ERROR - bar\n"
+            actual = log_file.read_text()
+            self.assertRegex(actual, expected)
+
+            logger.close_log_files()
+
+
+class TestCategorizedLoggers(unittest.TestCase):
+    def test_measurement_logger_creates_log_files(self):
+        logger = MeasurementLogger("mesu")
+        self.assert_logger_creates_log_files(logger)
+
+    def test_simulation_logger_creates_log_files(self):
+        logger = SimulationLogger("simu")
+        self.assert_logger_creates_log_files(logger)
+
+    def assert_logger_creates_log_files(self, logger: Logger):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            info_log = tmp_dir / "default.log"
+            error_log = tmp_dir / "errors.log"
+
+            logger.set_up_log_files(tmp_dir)
+
+            self.assertTrue(info_log.exists())
+            self.assertTrue(error_log.exists())
+
+            logger.close_log_files()
+
+    @unittest.expectedFailure
+    def test_measurement_logs_are_correctly_formatted(self):
+        request_logger = RequestLogger()
+        measurement_logger = MeasurementLogger("mesu", parent=request_logger)
+        self.assert_formatting_is_correct(
+            request_logger, measurement_logger, measurement_logger.category,
+            measurement_logger.display_name
+        )
+
+    @unittest.expectedFailure
+    def test_simulation_logs_are_correctly_formatted(self):
+        request_logger = RequestLogger()
+        measurement_logger = SimulationLogger("simu", parent=request_logger)
+        self.assert_formatting_is_correct(
+            request_logger, measurement_logger, measurement_logger.category,
+            measurement_logger.display_name
+        )
+
+    def assert_formatting_is_correct(
+            self, parent: Logger, child: Logger, category, display_name):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            parent_folder = Path(tmp_dir) / "parent"
+            child_folder = Path(tmp_dir) / "child"
+            request_log = parent_folder / "request.log"
+            info_log = child_folder / "default.log"
+            error_log = child_folder / "errors.log"
+
+            parent.set_up_log_files(parent_folder)
+            child.set_up_log_files(child_folder)
+            child.log("foo")
+            child.log_error("bar")
+
+            def_regex = r"\d\d\d\d\-\d\d-\d\d \d\d:\d\d:\d\d - INFO - foo\n" \
+                        r"\d\d\d\d\-\d\d-\d\d \d\d:\d\d:\d\d - ERROR - bar\n"
+            err_regex = r"\d\d\d\d\-\d\d-\d\d \d\d:\d\d:\d\d - ERROR - bar\n"
+            req_regex = r"\d\d\d\d\-\d\d-\d\d \d\d:\d\d:\d\d - INFO - " \
+                        fr"\[{category} : {display_name}\] - foo\n" \
+                        r"\d\d\d\d\-\d\d-\d\d \d\d:\d\d:\d\d - ERROR - " \
+                        fr"\[{category} : {display_name}\] - bar\n"
+
+            actual_mesu = info_log.read_text()
+            self.assertRegex(actual_mesu, def_regex)
+
+            actual_errors = error_log.read_text()
+            self.assertRegex(actual_errors, err_regex)
+
+            actual_request = request_log.read_text()
+            self.assertRegex(actual_request, req_regex)
+
+            parent.close_log_files()
+            child.close_log_files()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -319,6 +319,37 @@ class TestCategorizedLoggers(unittest.TestCase):
             parent.close_log_files()
             child.close_log_files()
 
+    def test_log_files_are_none_before_setting_log_files(self):
+        logger = MeasurementLogger("mesu")
+
+        self.assertIsNone(logger.info_log_file)
+        self.assertIsNone(logger.error_log_file)
+
+    def test_logger_returns_paths_to_log_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            info_log = tmp_dir / "default.log"
+            error_log = tmp_dir / "errors.log"
+
+            logger = MeasurementLogger("mesu")
+            logger.set_up_log_files(tmp_dir)
+
+            self.assertEqual(info_log, logger.info_log_file)
+            self.assertEqual(error_log, logger.error_log_file)
+
+            logger.close_log_files()
+
+    def test_log_files_are_none_after_closing_log_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+
+            logger = MeasurementLogger("mesu")
+            logger.set_up_log_files(tmp_dir)
+            logger.close_log_files()
+
+            self.assertIsNone(logger.info_log_file)
+            self.assertIsNone(logger.error_log_file)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -54,7 +54,7 @@ class TestLogger(unittest.TestCase):
 
             logger.close_log_files()
 
-    def test_remove_and_close_log_releases_resources(self):
+    def test_close_log_files_releases_resources(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             log_file = tmp_dir / MockLogger.FILE_NAME
@@ -66,7 +66,7 @@ class TestLogger(unittest.TestCase):
             # handle open
             self.assertRaises(OSError, lambda: log_file.unlink())
 
-            # after calling remove_and_close, we can exit the context manager
+            # after calling close_log_files, we can exit the context manager
             # without exception
             logger.close_log_files()
 
@@ -266,7 +266,6 @@ class TestCategorizedLoggers(unittest.TestCase):
 
             logger.close_log_files()
 
-    @unittest.expectedFailure
     def test_measurement_logs_are_correctly_formatted(self):
         request_logger = RequestLogger()
         measurement_logger = MeasurementLogger("mesu", parent=request_logger)
@@ -275,7 +274,6 @@ class TestCategorizedLoggers(unittest.TestCase):
             measurement_logger.display_name
         )
 
-    @unittest.expectedFailure
     def test_simulation_logs_are_correctly_formatted(self):
         request_logger = RequestLogger()
         measurement_logger = SimulationLogger("simu", parent=request_logger)

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from modules.request import Request
 
 
-class TestInit(unittest.TestCase):
+class TestFolderStructure(unittest.TestCase):
     def setUp(self):
         # Expected folder structure when request is saved
         self.folder_name = "foo"
@@ -57,7 +57,7 @@ class TestInit(unittest.TestCase):
             f"{self.folder_name}.request": None
         }
 
-    def test_folder_structure_when_logging_is_not_enabled(self):
+    def test_no_folders_are_created_if_save_on_creation_is_false(self):
         """Tests the folder structure when request is created"""
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir, self.folder_name)
@@ -66,13 +66,29 @@ class TestInit(unittest.TestCase):
 
             self.assertEqual([], os.listdir(tmp_dir))
 
-            request = Request(path, "bar", mo.get_global_settings(),
-                              save_on_creation=True, enable_logging=False)
+    def test_folder_structure_when_logging_is_not_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir, self.folder_name)
+            Request(
+                path, "bar", mo.get_global_settings(), save_on_creation=True,
+                enable_logging=False)
 
             utils.assert_folder_structure_equal(self.folder_structure, path)
 
-            request.to_file()
-            utils.assert_folder_structure_equal(self.folder_structure, path)
+    def test_folder_structure_when_logging_is_enabled(self):
+        """Tests the folder structure when request is created"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir, self.folder_name)
+            request = Request(
+                path, "bar", mo.get_global_settings(), save_on_creation=True,
+                enable_logging=True)
+
+            folder_structure = {
+                "request.log": None,
+                **self.folder_structure,
+            }
+            utils.assert_folder_structure_equal(folder_structure, path)
+            request.close_log_files()
 
 
 class TestSerialization(unittest.TestCase):

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -46,7 +46,6 @@ class TestInit(unittest.TestCase):
                     "Default.detector": None
                 },
                 "Default.measurement": None,
-                "default.log": None,
                 "Default.simulation": None,
                 "Default.mcsimu": None,
                 "Default.profile": None,
@@ -54,13 +53,11 @@ class TestInit(unittest.TestCase):
                 "Default.target": None,
                 "Default_element.profile": None,
                 "Default.info": None,
-                "errors.log": None
             },
-            "request.log": None,
             f"{self.folder_name}.request": None
         }
 
-    def test_folder_structure(self):
+    def test_folder_structure_when_logging_is_not_enabled(self):
         """Tests the folder structure when request is created"""
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir, self.folder_name)
@@ -77,15 +74,14 @@ class TestInit(unittest.TestCase):
             request.to_file()
             utils.assert_folder_structure_equal(self.folder_structure, path)
 
-            utils.disable_logging()
-
 
 class TestSerialization(unittest.TestCase):
     def test_serialization(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir, "request")
-            request = Request(path, "foo", mo.get_global_settings(),
-                              save_on_creation=False, enable_logging=False)
+            request = Request(
+                path, "foo", mo.get_global_settings(),
+                save_on_creation=False, enable_logging=False)
 
             request.default_run.charge = 1
             request.default_run.fluence = 2
@@ -94,7 +90,8 @@ class TestSerialization(unittest.TestCase):
             request.to_file()
 
             request_from_file = Request.from_file(
-                request.request_file, mo.get_global_settings())
+                request.request_file, mo.get_global_settings(),
+                enable_logging=False)
 
             self.assertEqual(
                 request.default_run.get_settings(),
@@ -106,8 +103,6 @@ class TestSerialization(unittest.TestCase):
                 request_from_file.default_target.description
             )
 
-            utils.disable_logging()
-
     def test_default_values_are_same(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir, "request")
@@ -116,7 +111,8 @@ class TestSerialization(unittest.TestCase):
             self.assert_request_values_are_same(request)
 
             request_from_file = Request.from_file(
-                request.request_file, mo.get_global_settings())
+                request.request_file, mo.get_global_settings(),
+                enable_logging=False)
             self.assert_request_values_are_same(request_from_file)
 
             self.assertEqual(
@@ -137,7 +133,6 @@ class TestSerialization(unittest.TestCase):
                 request.default_simulation,
                 request_from_file.default_simulation
             )
-            utils.disable_logging()
 
     @staticmethod
     def assert_request_values_are_same(request: Request):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,7 +30,6 @@ __version__ = "2.0"
 import os
 import hashlib
 import unittest
-import logging
 import platform
 import warnings
 import itertools
@@ -131,18 +130,8 @@ def verify_files(file_paths, checksum, msg=None):
     if b:
         return lambda func: func
     if msg is not None:
-        return unittest.skip("{0}: {1}.".format(msg, reason))
+        return unittest.skip(f"{msg}: {reason}.")
     return unittest.skip(reason)
-
-
-def disable_logging():
-    """Disables loggers and removes their file handles"""
-    loggers = [logging.getLogger(name) for name in
-               logging.root.manager.loggerDict]
-    for logger in loggers:
-        logger.disabled = True
-        for handler in logger.handlers:
-            handler.close()
 
 
 class PlatformSwitcher:

--- a/widgets/base_tab.py
+++ b/widgets/base_tab.py
@@ -95,14 +95,12 @@ class BaseTab(abc.ABC, metaclass=QtABCMeta):
         log_widget specifies which ui element will handle the logging. That
         should be the one which is added to this tab.
         """
-        logger = logging.getLogger(self.obj.name)
         defaultformat = logging.Formatter(
             '%(asctime)s - %(levelname)s - %(message)s',
             datefmt='%Y-%m-%d %H:%M:%S')
-        widgetlogger_default = CustomLogHandler(logging.INFO,
-                                                defaultformat,
-                                                log_widget)
-        logger.addHandler(widgetlogger_default)
+        widgetlogger_default = CustomLogHandler(
+            logging.INFO, defaultformat, log_widget)
+        self.obj.logger.addHandler(widgetlogger_default)
 
     def del_widget(self, widget):
         """Delete a widget from current tab.


### PR DESCRIPTION
Major changes in this PR:
- Adds a unified `Logger` interface for Requests, Measurements and Simulations. From now on, logging should be done via this interface rather than invoking Python's logging module.
- Makes sure that each `Logger` uses its own log files. Previously all Requests that were opened during the runtime of the program would end up writing to the same file. This was also the case for Measurements and Simulations that had the same name. This fixes #93.
- Uses uuid module to create unique names for each `Logger`. Also uses period separated names to establish a parent - child hierarchy between Requests and Measurements/Simulations.