### PR TITLE
Fix a crash when loading detector settings + type hints and stuff

### DIFF
--- a/dialogs/dialog_functions.py
+++ b/dialogs/dialog_functions.py
@@ -171,25 +171,16 @@ def delete_recoil_espe(tab: "SimulationTabWidget", recoil_name: str):
                     break
 
 
-def add_imported_files_to_tree(qdialog, files):
-    """
-
-    Args:
-        qdialog: import dialog
-        files: list of files
-    """
-    if not files:
-        return
+def add_imported_files_to_tree(
+        qdialog: QtWidgets.QDialog, files: Iterable[Path]) -> None:
     for file in files:
         if file in qdialog.files_added:
             continue
-        directory, filename = os.path.split(file)
-        name, unused_ext = os.path.splitext(filename)
-        item = QtWidgets.QTreeWidgetItem([name])
+        item = QtWidgets.QTreeWidgetItem([file.stem])
         item.file = file
-        item.name = name
-        item.filename = filename
-        item.directory = directory
+        item.name = file.stem
+        item.filename = file.name
+        item.directory = file.parent
         qdialog.files_added[file] = file
         qdialog.treeWidget.addTopLevelItem(item)
 

--- a/dialogs/energy_spectrum.py
+++ b/dialogs/energy_spectrum.py
@@ -411,10 +411,9 @@ class EnergySpectrumParamsDialog(QtWidgets.QDialog):
         file_path = fdialogs.open_file_dialog(
             self, self.element_simulation.request.directory,
             "Select a file to import", "")
-        if not file_path:
+        if file_path is None:
             return
 
-        file_path = Path(file_path)
         name = file_path.name
 
         new_file_name = \

--- a/dialogs/file_dialogs.py
+++ b/dialogs/file_dialogs.py
@@ -85,7 +85,7 @@ def open_files_dialog(
     Returns:
         A full paths to the selected filenames if a file is selected.
     """
-    selected_files, = QtWidgets.QFileDialog.getOpenFileNames(
+    selected_files, *_ = QtWidgets.QFileDialog.getOpenFileNames(
         parent, title, str(default_folder), parent.tr(allowed_files))
     return [Path(file) for file in selected_files]
 

--- a/dialogs/file_dialogs.py
+++ b/dialogs/file_dialogs.py
@@ -30,11 +30,18 @@ __author__ = "Jarkko Aalto \n Timo Konu \n Samuli Kärkkäinen \n Samuli " \
              "\n Sinikka Siironen \n Juhani Sundell"
 __version__ = "2.0"
 
+from pathlib import Path
+from typing import Optional, List
+
 from PyQt5 import QtWidgets
 
 
-def open_file_dialog(parent, default_folder, title, files):
-    """Opens open file dialog
+def open_file_dialog(
+        parent: QtWidgets.QWidget,
+        default_folder: Path,
+        title: str,
+        allowed_files: str) -> Optional[Path]:
+    """Opens open file dialog for single file.
 
     Opens dialog to select file to be opened and returns full file path to
     selected file if one is selected. If no file is selected returns None.
@@ -44,50 +51,53 @@ def open_file_dialog(parent, default_folder, title, files):
         default_folder: String or Path representing which folder is shown when
             dialog opens.
         title: String representing open file dialog title.
-        files: String representing what type of file can be opened.
+        allowed_files: String representing what type of file can be opened.
 
     Returns:
-        A full path to the selected filename if a file is selected. For
-        example:
-
-        "C:/Transfer/FinlandiaData/esimerkkidata.zip"
+        A full path to the selected filename if a file is selected.
     """
     # Convert the folder parameter to string to avoid TypeError when the
     # default_folder is a Path object
-    filename = QtWidgets.QFileDialog.getOpenFileName(
-        parent, title, str(default_folder), parent.tr(files))
-    return filename[0]
+    selected_file, *_ = QtWidgets.QFileDialog.getOpenFileName(
+        parent, title, str(default_folder), parent.tr(allowed_files))
+    if selected_file:
+        return Path(selected_file)
+    return None
 
 
-def open_files_dialog(parent, default_folder, title, files):
-    """Opens open file dialog for multiple files
+def open_files_dialog(
+        parent: QtWidgets.QWidget,
+        default_folder: Path,
+        title: str,
+        allowed_files: str) -> List[Path]:
+    """Opens open file dialog for multiple files.
 
-    Opens dialog to select files to be opened and returns full file path to
-    selected file if one or more is selected.
-    If no file is selected returns None.
+    Opens dialog to select files to be opened and returns full file paths to
+    selected files if one or more is selected.
 
     Args:
         parent: Parent object which opens the open file dialog.
         default_folder: String or Path representing which folder is shown when
             dialog opens.
         title: String representing open file dialog title.
-        files: String representing what type of file can be opened.
+        allowed_files: String representing what type of file can be opened.
 
     Returns:
-        A full path to the selected filename if a file is selected. For
-        example:
-
-        "C:/Transfer/FinlandiaData/esimerkkidata.zip"
+        A full paths to the selected filenames if a file is selected.
     """
-    filenames = QtWidgets.QFileDialog.getOpenFileNames(
-        parent, title, str(default_folder), parent.tr(files))
-    return filenames[0]
+    selected_files, = QtWidgets.QFileDialog.getOpenFileNames(
+        parent, title, str(default_folder), parent.tr(allowed_files))
+    return [Path(file) for file in selected_files]
 
 
-def save_file_dialog(parent, default_folder, title, files):
-    """Opens save file dialog
+def save_file_dialog(
+        parent: QtWidgets.QWidget,
+        default_folder: Path,
+        title: str,
+        allowed_files: str) -> Optional[Path]:
+    """Opens save file dialog.
 
-    Opens dialog to select savefile name and returns full file path to
+    Opens dialog to select a save file name and returns full file path to
     selected file if one is selected. If no file is selected returns None.
 
     Args:
@@ -95,14 +105,13 @@ def save_file_dialog(parent, default_folder, title, files):
         default_folder: String or Path representing which folder is shown when
             dialog opens.
         title: String representing open file dialog title.
-        files: String representing what type of file can be opened.
+        allowed_files: String representing what type of file can be opened.
 
     Returns:
-        A full path to the selected filename if a file is selected. For
-        example:
-
-        "C:/Transfer/FinlandiaData/esimerkkidata.zip"
+        A full path to the selected filename if a file is selected.
     """
     filename = QtWidgets.QFileDialog.getSaveFileName(
-        parent, title, str(default_folder), parent.tr(files))[0]
-    return filename
+        parent, title, str(default_folder), parent.tr(allowed_files))[0]
+    if filename:
+        return Path(filename)
+    return None

--- a/dialogs/measurement/import_measurement.py
+++ b/dialogs/measurement/import_measurement.py
@@ -39,7 +39,7 @@ from pathlib import Path
 
 from widgets.gui_utils import StatusBarHandler
 from dialogs.measurement.import_timing_graph import ImportTimingGraphDialog
-from dialogs.file_dialogs import open_files_dialog
+import dialogs.file_dialogs as fdialogs
 
 from modules.request import Request
 from widgets.icon_manager import IconManager
@@ -103,7 +103,7 @@ class ImportMeasurementsDialog(QtWidgets.QDialog):
     def __add_file(self):
         """Add a file to list of files to be imported.
         """
-        files = open_files_dialog(
+        files = fdialogs.open_files_dialog(
             self, self.request.directory,
             "Select an event collection to be imported",
             "Event collection (*.evnt)")

--- a/dialogs/measurement/load_measurement.py
+++ b/dialogs/measurement/load_measurement.py
@@ -129,7 +129,7 @@ class LoadMeasurementDialog(QtWidgets.QDialog):
         self.filename = fdialogs.open_file_dialog(
             self, self.directory, "Select a measurement to load",
             "Raw Measurement (*.asc)")
-        self.pathLineEdit.setText(self.filename)
+        self.pathLineEdit.setText(str(self.filename))
 
     def __find_existing_sample(self):
         """

--- a/modules/detector.py
+++ b/modules/detector.py
@@ -233,7 +233,11 @@ class Detector(MCERDParameterContainer, Serializable, AdjustableSettings):
         gf.remove_matching_files(self.get_used_efficiencies_dir(), {".eff"})
 
     @classmethod
-    def from_file(cls, detector_file: Path, request, save_on_creation=True):
+    def from_file(
+            cls,
+            detector_file: Path,
+            request: "Request",
+            save_on_creation: bool = True) -> "Detector":
         """Initialize Detector from a JSON file.
 
         Args:

--- a/widgets/detector_settings.py
+++ b/widgets/detector_settings.py
@@ -179,7 +179,7 @@ class DetectorSettingsWidget(QtWidgets.QWidget, bnd.PropertyTrackingWidget,
         file = fdialogs.open_file_dialog(
             self, self.request.default_folder, "Select detector file",
             "Detector File (*.detector)")
-        if not file:
+        if file is None:
             return
 
         temp_detector = Detector.from_file(file, self.request, False)
@@ -209,11 +209,10 @@ class DetectorSettingsWidget(QtWidgets.QWidget, bnd.PropertyTrackingWidget,
         file = fdialogs.save_file_dialog(
             self, self.request.default_folder, "Save detector file",
             "Detector File (*.detector)")
-        if not file:
+        if file is None:
             return
-        file = Path(file)
-        if file.suffix != ".detector":
-            file = Path(file.parent, f"{file.name}.detector")
+
+        file = file.with_suffix(".detector")
         if not self.some_values_changed():
             self.obj.to_file(file)
         else:
@@ -502,12 +501,11 @@ class DetectorSettingsWidget(QtWidgets.QWidget, bnd.PropertyTrackingWidget,
         }
 
         for eff_file in new_eff_files:
-            new_eff_file = Path(eff_file)
-            used_eff_file = Detector.get_used_efficiency_file_name(new_eff_file)
+            used_eff_file = Detector.get_used_efficiency_file_name(eff_file)
 
             if used_eff_file not in used_eff_files:
                 try:
-                    self.obj.add_efficiency_file(new_eff_file)
+                    self.obj.add_efficiency_file(eff_file)
                     used_eff_files.add(used_eff_file)
                 except OSError as e:
                     QtWidgets.QMessageBox.critical(
@@ -525,7 +523,7 @@ class DetectorSettingsWidget(QtWidgets.QWidget, bnd.PropertyTrackingWidget,
         # Store the folder where we previously fetched an eff-file
         gutils.set_potku_setting(
             DetectorSettingsWidget.EFF_FILE_FOLDER_KEY,
-            str(new_eff_file.parent))
+            str(eff_file.parent))
 
     def __remove_efficiency(self):
         """Removes efficiency files from detector's efficiency directory and

--- a/widgets/matplotlib/measurement/tofe_histogram.py
+++ b/widgets/matplotlib/measurement/tofe_histogram.py
@@ -43,7 +43,7 @@ from dialogs.graph_settings import TofeGraphSettingsWidget
 from dialogs.measurement.depth_profile import DepthProfileWidget
 from dialogs.measurement.element_losses import ElementLossesWidget
 from dialogs.measurement.selection import SelectionSettingsDialog
-from dialogs.file_dialogs import open_file_dialog
+import dialogs.file_dialogs as fdialogs
 
 from matplotlib import cm
 from matplotlib.colors import LogNorm
@@ -548,10 +548,10 @@ class MatplotlibHistogramWidget(MatplotlibWidget):
     def load_selections(self):
         """Show dialog to load selections.
         """
-        filename = open_file_dialog(self, self.measurement.directory,
-                                    "Load Element Selection",
-                                    "Selection file (*.selections)")
-        if filename:
+        filename = fdialogs.open_file_dialog(
+            self, self.measurement.directory, "Load Element Selection",
+            "Selection file (*.selections)")
+        if filename is not None:
             sbh = StatusBarHandler(self.statusbar)
             sbh.reporter.report(40)
 


### PR DESCRIPTION
Functions in `dialogs.file_dialogs` now return Path objects as expected by the backend code. Loading detector settings from file no longer cause a crash (#132).

Changing the return types also affected other parts of the code so there are quite a few changes beside the bug fix.

Type hints have been added and docstrings have been updated.
