### PR TITLE
Save target and element simulations automatically when user makes changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Pipfile.lock
 
 # Ignore hypothesis folder (in case it will be used in the future)
 .hypothesis
+
+# Visual Studio
+.vs

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -1770,6 +1770,8 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
     def update_plot(self):
         """Updates marker and line data and redraws the plot.
         """
+        if hasattr(self.parent, 'recoil_distribution_widget'):
+            self.parent._save_target_and_recoils(True)
         if self.current_element_simulation is None:
             self.markers.set_visible(False)
             self.lines.set_visible(False)

--- a/widgets/simulation/target.py
+++ b/widgets/simulation/target.py
@@ -132,7 +132,7 @@ class TargetWidget(QtWidgets.QWidget):
         self.targetRadioButton.setChecked(True)
         self.stackedWidget.setCurrentIndex(0)
 
-        self.saveButton.clicked.connect(self.__save_target_and_recoils)
+        self.saveButton.clicked.connect(self._save_target_and_recoils)
 
         self.del_points = None
 
@@ -200,10 +200,10 @@ class TargetWidget(QtWidgets.QWidget):
             if self.stop_saving:
                 break
             if self.target:
-                self.__save_target_and_recoils(True)
+                self._save_target_and_recoils(True)
             time.sleep(60)
 
-    def __save_target_and_recoils(self, thread=False):
+    def _save_target_and_recoils(self, thread=False):
         """
         Save target and element simulations.
 


### PR DESCRIPTION
It saves when the user, for example, moves those points.

![save-target-and-recoils](https://user-images.githubusercontent.com/82767802/123270019-2d378500-d508-11eb-8300-d668d26b506c.png)
