### PR TITLE
Expands depth profile's window and sorts cut files + elemental losses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Pipfile.lock
 
 # Ignore hypothesis folder (in case it will be used in the future)
 .hypothesis
+
+# Visual Studio
+.vs

--- a/modules/measurement.py
+++ b/modules/measurement.py
@@ -943,7 +943,9 @@ class Measurement(MeasurementLogger, Serializable):
             Returns a list of cut files in measurement.
         """
         cuts = self._get_cut_files(self.get_cuts_dir())
+        cuts.sort()
         elem_losses = self._get_cut_files(self.get_changes_dir())
+        elem_losses.sort()
         return cuts, elem_losses
 
     def load_selection(self, filename, progress=None):

--- a/ui_files/ui_depth_profile_params.ui
+++ b/ui_files/ui_depth_profile_params.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QTreeWidget" name="treeWidget">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>


### PR DESCRIPTION
The user could not expand the window size when viewing the depth profile windows. Filenames are often (too) long and not in alphabetical order. The window did not expand correctly.

![depth_profile_filename_width](https://user-images.githubusercontent.com/82767802/124718828-2c8eed80-df0f-11eb-8789-813f9c260911.png)
