### PR TITLE
Saves and shows automatically ToF-calibration graph + Fixes QTimer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Pipfile.lock
 
 # Ignore hypothesis folder (in case it will be used in the future)
 .hypothesis
+
+# Visual Studio
+.vs

--- a/dialogs/measurement/calibration.py
+++ b/dialogs/measurement/calibration.py
@@ -131,8 +131,16 @@ class CalibrationDialog(QtWidgets.QDialog):
         # Set the validator for lineEdit so user can't give invalid values
         double_validator = QtGui.QDoubleValidator()
         self.tofChannelLineEdit.setValidator(double_validator)
-        
-        self.timer = QtCore.QTimer(interval=1500, timeout=self.timeout)
+
+        self.timer = QtCore.QTimer()
+        self.timer.timeout.connect(self.label_remove_timeout)
+
+        try:
+            self.__load_object(self.POINTS_OBJECT_FILENAME)
+            for p in self.tof_calibration.tof_points:
+                self.__accept_points(p)
+        except OSError:
+            pass
 
         self.exec_()
 
@@ -264,9 +272,9 @@ class CalibrationDialog(QtWidgets.QDialog):
             text: String to be set to the label.
         """
         self.acceptPointLabel.setText(text)
-        self.timer.start()
+        self.timer.start(1500)
 
-    def timeout(self):
+    def label_remove_timeout(self):
         """Timeout event method to remove label text.
         """
         self.acceptPointLabel.setText("")


### PR DESCRIPTION
- Saves ToF-calibration graph as pkl-file and loads it (and modifications) when the calibration tab is opened.  Before the user had to accept points again / separately to plot the graph again.  

- Fixes QTimer

![calibration_graph](https://user-images.githubusercontent.com/82767802/124911459-6fc38c00-dff5-11eb-831d-0ede27c81826.png)
