### PR TITLE
Removes element letters from the depth profile legend 2

### DIFF
--- a/widgets/matplotlib/measurement/depth_profile.py
+++ b/widgets/matplotlib/measurement/depth_profile.py
@@ -99,6 +99,7 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
         self._elements = elements
         self._ignore_from_graph: Set[Element] = set()
         self._ignore_from_ratio: Set[Element] = set()
+        self._ignore_from_both: Set[Element] = set()
         self._systematic_error = systematic_error
 
         self._show_eff_files = show_eff_files
@@ -452,7 +453,11 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
 
         self._ignore_from_graph = set(dialog.ignored_from_graph)
         self._ignore_from_ratio = set(dialog.ignored_from_ratio)
+        
+        # Intersection is an union of two sets
+        self._ignore_from_both = self._ignore_from_graph.intersection(self._ignore_from_ratio)
         self._line_chart.hide_lines(self._ignore_from_graph)
+        self._line_chart.hide_legend(self._ignore_from_both)
         self._make_legend_box()
 
     def _toggle_absolute_values(self) -> None:

--- a/widgets/matplotlib/mpl_utils.py
+++ b/widgets/matplotlib/mpl_utils.py
@@ -296,6 +296,16 @@ class LineChart(GraphWrapper):
                 line.set_linestyle("None")
             else:
                 line.set_linestyle(LineChart._DEFAULT_LINESTYLE)
+                
+    @draw_and_flush
+    def hide_legend(self, legends_to_hide: Set):
+        for label, line in self._lines.items():
+            if label in legends_to_hide:
+                # Underscore in front of a label hides it
+                if not line.get_label().startswith("_"):
+                    line.set_label("_" + line.get_label())
+            else:
+                line.set_label(line.get_label().replace("_",""))
 
     @draw_and_flush
     def set_yscale(self, y_scale: str):


### PR DESCRIPTION
Removes unused element symbol from the legend if it is not included in plot nor the ratio calculation