### PR TITLE
Make default reference density user configurable in global settings

### DIFF
--- a/dialogs/global_settings.py
+++ b/dialogs/global_settings.py
@@ -39,6 +39,7 @@ import widgets.gui_utils as gutils
 from pathlib import Path
 
 from widgets.base_tab import BaseTab
+from widgets.scientific_spinbox import ScientificSpinBox
 from modules.global_settings import GlobalSettings
 from modules.enums import IonDivision
 from modules.enums import CrossSection
@@ -75,7 +76,8 @@ class GlobalSettingsDialog(QtWidgets.QDialog):
     sim_ions = bnd.bind("sim_spinbox")
     ion_division = bnd.bind("ion_division_radios")
     min_concentration = bnd.bind("min_conc_spinbox")
-
+    default_density = bnd.bind("scientific_spinbox")
+    
     coinc_count = bnd.bind("line_coinc_count")
     
     cross_section = bnd.bind("cross_section_radios")
@@ -88,9 +90,11 @@ class GlobalSettingsDialog(QtWidgets.QDialog):
         """Constructor for the program
         """
         super().__init__()
+        
+        self.settings = settings
+        
         uic.loadUi(gutils.get_ui_dir() / "ui_global_settings.ui", self)
 
-        self.settings = settings
         self.__added_timings = {}  # Placeholder for timings
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
@@ -176,6 +180,16 @@ class GlobalSettingsDialog(QtWidgets.QDialog):
         self.min_conc_spinbox.setMinimum(GlobalSettings.MIN_CONC_LIMIT)
         self.min_concentration = self.settings.get_minimum_concentration()
         
+        reference_density_value = self.settings.get_default_reference_density()
+        self.scientific_spinbox = ScientificSpinBox(
+            value=reference_density_value, minimum=0.01, maximum=9.99e26) 
+        
+        self.formLayout_3.insertRow(
+            4,
+            QtWidgets.QLabel(r"Reference density [at./cm<sup>3</sup>]:"),
+            self.scientific_spinbox)        
+        
+        
         # Set used paths to LineEdits
         self.lineEdit_ini.setText(str(self.settings.get_config_file()))
         self.lineEdit_Request.setText(str(self.settings.get_request_directory_last_open()))
@@ -235,6 +249,7 @@ class GlobalSettingsDialog(QtWidgets.QDialog):
         self.settings.set_min_simulation_ions(self.sim_ions)
         self.settings.set_ion_division(self.ion_division)
         self.settings.set_minimum_concentration(self.min_concentration)
+        self.settings.set_default_reference_density(self.default_density)
 
         gutils.set_potku_setting(
             BaseTab.SAVE_WINDOW_GEOM_KEY, self.save_window_geometries)

--- a/modules/get_espe.py
+++ b/modules/get_espe.py
@@ -39,6 +39,7 @@ from .detector import Detector
 from .parsing import CSVParser
 from .target import Target
 
+from modules.global_settings import GlobalSettings
 
 class GetEspe:
     """Class for handling calling the external program get_espe to generate
@@ -51,7 +52,7 @@ class GetEspe:
     def __init__(self, beam_ion: str, energy: float, theta: float,
                  tangle: float, toflen: float, solid: float,
                  recoil_file: Path, erd_file: Path,
-                 reference_density: float = 4.98e22,
+                 reference_density: Optional[float] = None,
                  ch: float = 0.025, fluence: float = 5.00e+11,
                  timeres: float = 250.0):
         """Initializes the GetEspe class.
@@ -78,7 +79,12 @@ class GetEspe:
         self.channel_width = ch
         self.fluence = fluence
         self.timeres = timeres
-        self.density = reference_density
+        
+        if reference_density is None:
+            self.density = GlobalSettings().get_default_reference_density()
+        else:
+            self.density = reference_density
+        
         self.solid = solid
         self.recoil_file = recoil_file
         self.erd_file = erd_file

--- a/modules/global_settings.py
+++ b/modules/global_settings.py
@@ -82,6 +82,9 @@ class GlobalSettings:
     # concentration
     MIN_CONC_LIMIT = 1e-6
     _DEFAULT_CONC_LIMIT = 1e-4
+    
+    # Hard-coded initial default value for reference density
+    DEFAULT_REF_DENSITY = 4.982e22
 
     def __init__(self, config_dir=None, save_on_creation=True):
         """Inits GlobalSettings class.
@@ -536,6 +539,17 @@ class GlobalSettings:
         """
         self._config[self._SIMULATION]["min_concentration"] = str(
             max(value, GlobalSettings.MIN_CONC_LIMIT))
+
+    @handle_exceptions(return_value=DEFAULT_REF_DENSITY)
+    def get_default_reference_density(self) -> float:
+        """Returns the default reference density
+        """
+        return self._config.getfloat(self._SIMULATION, "default_density")
+
+    def set_default_reference_density(self, value: float):
+        """Sets the default reference density
+        """
+        self._config[self._SIMULATION]["default_density"] = str(value)
 
     @staticmethod
     def get_default_colors():

--- a/modules/recoil_element.py
+++ b/modules/recoil_element.py
@@ -47,6 +47,7 @@ from .element import Element
 from .point import Point
 from .parsing import CSVParser
 
+from modules.global_settings import GlobalSettings
 
 class RecoilElement(MCERDParameterContainer, Serializable):
     """An element that has a list of points and a widget. The points are kept
@@ -55,7 +56,7 @@ class RecoilElement(MCERDParameterContainer, Serializable):
     def __init__(self, element: Element, points: List[Point], color="red",
                  name="Default", rec_type="rec",
                  description="These are default recoil settings.",
-                 reference_density=4.98e22, modification_time=None,
+                 reference_density=None, modification_time=None,
                  channel_width=None):
         """Inits recoil element.
 
@@ -74,8 +75,12 @@ class RecoilElement(MCERDParameterContainer, Serializable):
         self.prefix = element.get_prefix()
         self.description = description
         self.type = rec_type
-
-        self.reference_density = reference_density
+        
+        if reference_density is None:
+            self.reference_density = GlobalSettings().get_default_reference_density()
+        else:
+            self.reference_density = reference_density
+            
         self.channel_width = channel_width
 
         # TODO might want to use some sort of sorted collection instead of a


### PR DESCRIPTION
User can now set the default reference density in the global settings. The density is stored in potku2.ini file like the other global parameters. 4.98e22 is still the initial value but now it can be changed by user.