### PR TITLE
Fix parameter verbose in calculate_espe

### DIFF
--- a/modules/element_simulation.py
+++ b/modules/element_simulation.py
@@ -829,7 +829,7 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
     def calculate_espe(
             self,
             recoil_element: RecoilElement,
-            verbose: False,
+            verbose: bool = False,
             ch: Optional[float] = None,
             fluence: Optional[float] = None,
             optimization_type: Optional[OptimizationType] = None,


### PR DESCRIPTION
`verbose` didn't have a default value when it should have.

Fixes `ElementSimulation.calculate_espe()` calls and `TestElementSimulation.test_calculate_spectrum()`.

This pull request is a cherry-picked version of #176.