### PR TITLE
Move the color selection dialog from the "Recoil Element Info" window to the matplotlib window / widget

### DIFF
--- a/dialogs/global_settings.py
+++ b/dialogs/global_settings.py
@@ -112,7 +112,7 @@ class GlobalSettingsDialog(QtWidgets.QDialog):
         self.OKButton.clicked.connect(self.__accept_changes)
         self.cancelButton.clicked.connect(self.close)
         buttons = self.findChild(QtWidgets.QButtonGroup, "elementButtons")
-        buttons.buttonClicked.connect(self.__change_element_color)
+        buttons.buttonClicked.connect(self.__change_recoil_element_info)
 
         self.min_conc_spinbox.setLocale(QtCore.QLocale.c())
 
@@ -269,7 +269,7 @@ class GlobalSettingsDialog(QtWidgets.QDialog):
         if folder:
             self.requestPathLineEdit.setText(folder)
 
-    def __change_element_color(self, button):
+    def __change_recoil_element_info(self, button):
         """Change color of element button.
         
         Args:

--- a/dialogs/global_settings.py
+++ b/dialogs/global_settings.py
@@ -112,7 +112,7 @@ class GlobalSettingsDialog(QtWidgets.QDialog):
         self.OKButton.clicked.connect(self.__accept_changes)
         self.cancelButton.clicked.connect(self.close)
         buttons = self.findChild(QtWidgets.QButtonGroup, "elementButtons")
-        buttons.buttonClicked.connect(self.__change_recoil_element_info)
+        buttons.buttonClicked.connect(self.__change_element_color)
 
         self.min_conc_spinbox.setLocale(QtCore.QLocale.c())
 
@@ -269,7 +269,7 @@ class GlobalSettingsDialog(QtWidgets.QDialog):
         if folder:
             self.requestPathLineEdit.setText(folder)
 
-    def __change_recoil_element_info(self, button):
+    def __change_element_color(self, button):
         """Change color of element button.
         
         Args:

--- a/dialogs/simulation/recoil_info_dialog.py
+++ b/dialogs/simulation/recoil_info_dialog.py
@@ -9,7 +9,7 @@ telescope. For physics calculations Potku uses external
 analyzation components.
 Copyright (C) 2013-2018 Jarkko Aalto, Severi Jääskeläinen, Samuel Kaiponen,
 Timo Konu, Samuli Kärkkäinen, Samuli Rahkonen, Miika Raunio, Heta Rekilä and
-Sinikka Siironen, 2020 Juhani Sundell
+Sinikka Siironen, 2020 Juhani Sundell, 2021 Joonas Koponen
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -25,14 +25,13 @@ You should have received a copy of the GNU General Public License
 along with this program (file named 'LICENCE').
 """
 __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä \n " \
-             "Sinikka Siironen \n Juhani Sundell"
+             "Sinikka Siironen \n Juhani Sundell \n Joonas Koponen"
 __version__ = "2.0"
 
 import time
 
 import widgets.binding as bnd
 import widgets.input_validation as iv
-import dialogs.dialog_functions as df
 import widgets.gui_utils as gutils
 
 from modules.element_simulation import ElementSimulation
@@ -40,7 +39,6 @@ from modules.recoil_element import RecoilElement
 
 from PyQt5 import QtWidgets
 from PyQt5 import uic
-from PyQt5.QtGui import QColor
 
 from widgets.scientific_spinbox import ScientificSpinBox
 
@@ -55,25 +53,17 @@ class RecoilInfoDialog(QtWidgets.QDialog, bnd.PropertyBindingWidget,
     description = bnd.bind("descriptionLineEdit")
     reference_density = bnd.bind("scientific_spinbox")
 
-    @property
-    def color(self):
-        return self.tmp_color.name()
-
-    def __init__(self, recoil_element: RecoilElement, colormap,
+    def __init__(self, recoil_element: RecoilElement,
                  element_simulation: ElementSimulation):
         """Inits a recoil info dialog.
 
         Args:
             recoil_element: A RecoilElement object.
-            colormap: Colormap for elements.
             element_simulation: Element simulation that has the recoil element.
         """
         super().__init__()
         self.recoil_element = recoil_element
         self.element_simulation = element_simulation
-
-        self.tmp_color = QColor(self.recoil_element.color)
-        self.colormap = colormap
 
         value = self.recoil_element.reference_density
         self.scientific_spinbox = ScientificSpinBox(
@@ -83,7 +73,6 @@ class RecoilInfoDialog(QtWidgets.QDialog, bnd.PropertyBindingWidget,
 
         self.okPushButton.clicked.connect(self.__accept_settings)
         self.cancelPushButton.clicked.connect(self.close)
-        self.colorPushButton.clicked.connect(self.__change_color)
 
         self.fields_are_valid = True
         iv.set_input_field_red(self.nameLineEdit)
@@ -109,8 +98,6 @@ class RecoilInfoDialog(QtWidgets.QDialog, bnd.PropertyBindingWidget,
                 f"{self.recoil_element.element.get_prefix()}"
 
         self.infoGroupBox.setTitle(title)
-
-        self.__set_color_button_color(self.recoil_element.element.symbol)
 
         self.exec_()
 
@@ -173,36 +160,6 @@ class RecoilInfoDialog(QtWidgets.QDialog, bnd.PropertyBindingWidget,
 
         self.isOk = True
         self.close()
-
-    def __change_color(self):
-        """
-        Change the color of the recoil element.
-        """
-        dialog = QtWidgets.QColorDialog(self)
-        color = dialog.getColor(self.tmp_color)
-        if color.isValid():
-            self.tmp_color = color
-            self.__change_color_button_color(self.recoil_element.element.symbol)
-
-    def __change_color_button_color(self, element: str):
-        """
-        Change color button's color.
-
-        Args:
-            element: String representing element name.
-        """
-        df.set_btn_color(
-            self.colorPushButton, self.tmp_color, self.colormap, element)
-
-    def __set_color_button_color(self, element):
-        """Set default color of element to color button.
-
-        Args:
-            element: String representing element.
-        """
-        self.colorPushButton.setEnabled(True)
-        self.tmp_color = QColor(self.recoil_element.color)
-        self.__change_color_button_color(element)
 
     def __validate(self):
         """

--- a/dialogs/simulation/recoil_info_dialog.py
+++ b/dialogs/simulation/recoil_info_dialog.py
@@ -1,0 +1,159 @@
+# coding=utf-8
+"""
+Created on 3.5.2018
+Updated on 30.10.2018
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2013-2018 Jarkko Aalto, Severi Jääskeläinen, Samuel Kaiponen,
+Timo Konu, Samuli Kärkkäinen, Samuli Rahkonen, Miika Raunio, Heta Rekilä and
+Sinikka Siironen, 2020 Juhani Sundell, 2021 Joonas Koponen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä \n " \
+             "Sinikka Siironen \n Juhani Sundell \n Joonas Koponen"
+__version__ = "2.0"
+
+import time
+
+import widgets.binding as bnd
+import dialogs.dialog_functions as df
+import widgets.gui_utils as gutils
+import widgets.input_validation as iv
+
+
+from modules.element_simulation import ElementSimulation
+from modules.recoil_element import RecoilElement
+
+
+from PyQt5 import QtWidgets
+from PyQt5 import uic
+from PyQt5.QtGui import QColor
+
+
+class RecoilInfoDialog(QtWidgets.QDialog,
+                       bnd.PropertyBindingWidget,
+                       metaclass=gutils.QtABCMeta):
+    """Dialog for editing the name, description and color
+    of a recoil element.
+    """
+    # TODO possibly track name changes
+    name = bnd.bind("nameLineEdit")
+    description = bnd.bind("descriptionLineEdit")
+
+    @property
+    def reference_density(self):
+        return self.recoil_element.reference_density
+
+    @property
+    def color(self):
+        return self.tmp_color.name()
+
+    def __init__(self, recoil_element: RecoilElement, colormap,
+                 element_simulation: ElementSimulation):
+        """Inits a recoil info dialog.
+        Args:
+            recoil_element: A RecoilElement object.
+            colormap: Colormap for elements.
+            element_simulation: Element simulation that has the recoil element.
+        """
+        super().__init__()
+        self.recoil_element = recoil_element
+        self.element_simulation = element_simulation
+
+        self.tmp_color = QColor(self.recoil_element.color)
+        self.colormap = colormap
+
+        uic.loadUi(gutils.get_ui_dir() / "ui_recoil_info_dialog.ui", self)
+
+        self.okPushButton.clicked.connect(self.__accept_settings)
+        self.cancelPushButton.clicked.connect(self.close)
+        self.colorPushButton.clicked.connect(self.__change_color)
+
+        self.fields_are_valid = True
+        iv.set_input_field_red(self.nameLineEdit)
+        self.nameLineEdit.textChanged.connect(
+            lambda: iv.check_text(self.nameLineEdit, qwidget=self))
+        self.nameLineEdit.textEdited.connect(self.__validate)
+
+        self.name = recoil_element.name
+        self.description = recoil_element.description
+        self.formLayout.removeRow(self.widget)
+
+        self.description = recoil_element.description
+        self.isOk = False
+
+        self.dateLabel.setText(time.strftime("%c %z %Z", time.localtime(
+            self.recoil_element.modification_time)))
+
+        title = f"Recoil element: " \
+                f"{self.recoil_element.element.get_prefix()}"
+
+        self.infoGroupBox.setTitle(title)
+
+        self.__set_color_button_color(self.recoil_element.element.symbol)
+
+        self.exec_()
+
+    def __accept_settings(self):
+        """Function for accepting the current settings and closing the dialog
+        window.
+        """
+        """Function for accepting the current settings and closing the dialog
+        window.
+        """
+        self.isOk = True
+        self.close()
+
+    def __change_color(self):
+        """
+        Change the color of the recoil element.
+        """
+        dialog = QtWidgets.QColorDialog(self)
+        color = dialog.getColor(self.tmp_color)
+        if color.isValid():
+            self.tmp_color = color
+            self.__change_color_button_color(self.recoil_element.element.symbol)
+
+    def __change_color_button_color(self, element: str):
+        """
+        Change color button's color.
+        Args:
+            element: String representing element name.
+        """
+        self.recoil_element.color = self.tmp_color.name()
+        df.set_btn_color(
+            self.colorPushButton, self.tmp_color, self.colormap, element)
+
+    def __set_color_button_color(self, element):
+        """Set default color of element to color button.
+        Args:
+            element: String representing element.
+        """
+        self.colorPushButton.setEnabled(True)
+        self.tmp_color = QColor(self.recoil_element.color)
+        self.__change_color_button_color(element)
+
+    def __validate(self):
+        """
+        Validate the recoil name.
+        """
+        text = self.name
+        regex = "^[A-Za-z0-9-ÖöÄäÅå]*"
+        valid_text = iv.validate_text_input(text, regex)
+
+        self.name = valid_text

--- a/dialogs/simulation/reference_density_dialog.py
+++ b/dialogs/simulation/reference_density_dialog.py
@@ -79,7 +79,6 @@ class ReferenceDensityDialog(QtWidgets.QDialog,
         value = self.recoil_element.reference_density
         self.scientific_spinbox = ScientificSpinBox(
             value=value, minimum=0.01, maximum=9.99e23)
-        self.scientific_spinbox.setDisabled(True)
 
         self.userSelectionCheckBox.stateChanged.connect(self._state_changed)
 

--- a/dialogs/simulation/reference_density_dialog.py
+++ b/dialogs/simulation/reference_density_dialog.py
@@ -80,6 +80,13 @@ class ReferenceDensityDialog(QtWidgets.QDialog,
         self.scientific_spinbox = ScientificSpinBox(
             value=value, minimum=0.01, maximum=9.99e23)
 
+        if self.recoil_element.manual_reference_density_checked:
+            self.scientific_spinbox.setDisabled(False)
+            self.userSelectionCheckBox.setChecked(True)
+        else:
+            self.scientific_spinbox.setDisabled(True)
+            self.userSelectionCheckBox.setChecked(False)
+
         self.userSelectionCheckBox.stateChanged.connect(self._state_changed)
 
         self.okPushButton.clicked.connect(self._accept_settings)

--- a/dialogs/simulation/reference_density_dialog.py
+++ b/dialogs/simulation/reference_density_dialog.py
@@ -102,11 +102,6 @@ class ReferenceDensityDialog(QtWidgets.QDialog,
 
         self.isOk = False
 
-        title = f"Recoil element: " \
-                f"{self.recoil_element.element.get_prefix()}"
-
-        self.infoGroupBox.setTitle(title)
-
         self.exec_()
 
     def _state_changed(self):

--- a/dialogs/simulation/reference_density_dialog.py
+++ b/dialogs/simulation/reference_density_dialog.py
@@ -49,18 +49,6 @@ class ReferenceDensityDialog(QtWidgets.QDialog,
     # TODO possibly track name changes
     reference_density = bnd.bind("scientific_spinbox")
 
-    @property
-    def name(self):
-        return self.recoil_element.name
-
-    @property
-    def description(self):
-        return self.recoil_element.description
-
-    @property
-    def color(self):
-        return self.recoil_element.color
-
     def __init__(self, recoil_element: RecoilElement,
                  element_simulation: ElementSimulation):
         """Inits a recoil info dialog.
@@ -75,6 +63,14 @@ class ReferenceDensityDialog(QtWidgets.QDialog,
 
         self.recoil_element = recoil_element
         self.element_simulation = element_simulation
+
+        if self.recoil_element is None:
+            QtWidgets.QMessageBox.warning(self, "Warning",
+                                                "The current simulation has "
+                                                "no recoil elements",
+                                                QtWidgets.QMessageBox.Ok,
+                                                QtWidgets.QMessageBox.Ok)
+            return
 
         value = self.recoil_element.reference_density
         self.scientific_spinbox = ScientificSpinBox(

--- a/dialogs/simulation/reference_density_dialog.py
+++ b/dialogs/simulation/reference_density_dialog.py
@@ -70,16 +70,20 @@ class ReferenceDensityDialog(QtWidgets.QDialog,
             element_simulation: Element simulation that has the recoil element.
         """
         super().__init__()
+
+        uic.loadUi(gutils.get_ui_dir() / "ui_reference_density_dialog.ui", self)
+
         self.recoil_element = recoil_element
         self.element_simulation = element_simulation
 
         value = self.recoil_element.reference_density
         self.scientific_spinbox = ScientificSpinBox(
             value=value, minimum=0.01, maximum=9.99e23)
+        self.scientific_spinbox.setDisabled(True)
 
-        uic.loadUi(gutils.get_ui_dir() / "ui_reference_density_dialog.ui", self)
+        self.userSelectionCheckBox.stateChanged.connect(self._state_changed)
 
-        self.okPushButton.clicked.connect(self.__accept_settings)
+        self.okPushButton.clicked.connect(self._accept_settings)
         self.cancelPushButton.clicked.connect(self.close)
 
         self.fields_are_valid = True
@@ -99,7 +103,13 @@ class ReferenceDensityDialog(QtWidgets.QDialog,
 
         self.exec_()
 
-    def __density_valid(self):
+    def _state_changed(self):
+        if self.userSelectionCheckBox.isChecked():
+            self.scientific_spinbox.setDisabled(False)
+        else:
+            self.scientific_spinbox.setDisabled(True)
+
+    def _density_valid(self):
         """
         Check if density value is valid and in limits.
 
@@ -112,11 +122,11 @@ class ReferenceDensityDialog(QtWidgets.QDialog,
         except TypeError:
             return False
 
-    def __accept_settings(self):
+    def _accept_settings(self):
         """Function for accepting the current settings and closing the dialog
         window.
         """
-        if not self.fields_are_valid or not self.__density_valid():
+        if not self.fields_are_valid or not self._density_valid():
             QtWidgets.QMessageBox.critical(
                 self, "Warning",
                 "Some of the setting values are invalid.\n"

--- a/modules/recoil_element.py
+++ b/modules/recoil_element.py
@@ -49,6 +49,7 @@ from .parsing import CSVParser
 
 from modules.global_settings import GlobalSettings
 
+
 class RecoilElement(MCERDParameterContainer, Serializable):
     """An element that has a list of points and a widget. The points are kept
     in ascending order by their x coordinate.
@@ -80,6 +81,8 @@ class RecoilElement(MCERDParameterContainer, Serializable):
             self.reference_density = GlobalSettings().get_default_reference_density()
         else:
             self.reference_density = reference_density
+
+        self.manual_reference_density_checked = False
             
         self.channel_width = channel_width
 

--- a/modules/recoil_element.py
+++ b/modules/recoil_element.py
@@ -81,8 +81,8 @@ class RecoilElement(MCERDParameterContainer, Serializable):
             self.reference_density = GlobalSettings().get_default_reference_density()
         else:
             self.reference_density = reference_density
-
-        self.manual_reference_density_checked = False
+            if reference_density == self.reference_density:
+                self.reference_density_element_default = reference_density
 
         self.channel_width = channel_width
 

--- a/modules/recoil_element.py
+++ b/modules/recoil_element.py
@@ -76,14 +76,14 @@ class RecoilElement(MCERDParameterContainer, Serializable):
         self.prefix = element.get_prefix()
         self.description = description
         self.type = rec_type
-        
+
         if reference_density is None:
             self.reference_density = GlobalSettings().get_default_reference_density()
         else:
             self.reference_density = reference_density
 
         self.manual_reference_density_checked = False
-            
+
         self.channel_width = channel_width
 
         # TODO might want to use some sort of sorted collection instead of a
@@ -446,6 +446,9 @@ class RecoilElement(MCERDParameterContainer, Serializable):
         Args:
             new_values: dictionary
         """
+        if "name" or "description" or "color" not in new_values:
+            self.reference_density = new_values["reference_density"]
+            return
         try:
             self.name = new_values["name"]
             self.description = new_values["description"]

--- a/modules/request.py
+++ b/modules/request.py
@@ -86,6 +86,8 @@ class Request(ElementSimulationContainer, RequestLogger):
         # e.g. Sample-01, Sample-02.optional_name,...
         self._running_int = 1  # TODO: Maybe be saved into .request file?
 
+        self.manual_reference_density_checked = False
+
         # Check folder exists and make request file there.
         if save_on_creation:
             self.create_folder_structure()

--- a/ui_files/ui_recoil_info_dialog.ui
+++ b/ui_files/ui_recoil_info_dialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>RecoilInfoDialog</class>
- <widget class="QWidget" name="RecoilInfoDialog">
+ <class>ReferenceDensityDialog</class>
+ <widget class="QWidget" name="ReferenceDensityDialog">
   <property name="enabled">
    <bool>true</bool>
   </property>
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>257</height>
+    <height>265</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -114,13 +114,6 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="referenceDensityLabel">
-            <property name="text">
-             <string>Reference density</string>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="1">
            <widget class="QWidget" name="widget" native="true">
             <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -139,39 +132,58 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
-             <item>
-              <widget class="QDoubleSpinBox" name="referenceDensityDoubleSpinBox">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>e22 at/cm&lt;sup&gt;3&lt;/sup&gt;</string>
-               </property>
-              </widget>
-             </item>
             </layout>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="formLayout_5">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMinimumSize</enum>
+          </property>
+          <property name="horizontalSpacing">
+           <number>6</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="1">
+           <widget class="QWidget" name="widget_5" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <property name="spacing">
+              <number>6</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+            </layout>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Color:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="colorPushButton">
+            <property name="text">
+             <string>Automatic</string>
+            </property>
            </widget>
           </item>
          </layout>

--- a/ui_files/ui_recoil_info_dialog.ui
+++ b/ui_files/ui_recoil_info_dialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>228</height>
+    <height>257</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -172,20 +172,6 @@
               </widget>
              </item>
             </layout>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Color:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QPushButton" name="colorPushButton">
-            <property name="text">
-             <string>Automatic</string>
-            </property>
            </widget>
           </item>
          </layout>

--- a/ui_files/ui_reference_density_dialog.ui
+++ b/ui_files/ui_reference_density_dialog.ui
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ReferenceDensityDialog</class>
+ <widget class="QWidget" name="ReferenceDensityDialog">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>432</width>
+    <height>159</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>400</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Recoil element info</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <item row="0" column="1">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QGroupBox" name="infoGroupBox">
+       <property name="title">
+        <string>Recoil element</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_7">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetMinimumSize</enum>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="userSelectionCheckBox">
+          <property name="text">
+           <string>I want to define the reference density by myself</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="formLayout">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMinimumSize</enum>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="referenceDensityLabel">
+            <property name="text">
+             <string>Reference density</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QWidget" name="widget" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_4">
+             <property name="spacing">
+              <number>6</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QDoubleSpinBox" name="referenceDensityDoubleSpinBox">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>e22 at/cm&lt;sup&gt;3&lt;/sup&gt;</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMinimumSize</enum>
+       </property>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="okPushButton">
+         <property name="text">
+          <string>OK</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="cancelPushButton">
+         <property name="text">
+          <string>Cancel</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui_files/ui_reference_density_dialog.ui
+++ b/ui_files/ui_reference_density_dialog.ui
@@ -46,7 +46,7 @@
         <item>
          <widget class="QCheckBox" name="userSelectionCheckBox">
           <property name="text">
-           <string>I want to define the reference density by myself</string>
+           <string>Set the reference density manually</string>
           </property>
          </widget>
         </item>

--- a/ui_files/ui_reference_density_dialog.ui
+++ b/ui_files/ui_reference_density_dialog.ui
@@ -26,7 +26,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Recoil element info</string>
+   <string>Reference density</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="sizeConstraint">
@@ -37,7 +37,7 @@
      <item>
       <widget class="QGroupBox" name="infoGroupBox">
        <property name="title">
-        <string>Recoil element</string>
+        <string/>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_7">
         <property name="sizeConstraint">

--- a/ui_files/ui_target_info.ui
+++ b/ui_files/ui_target_info.ui
@@ -26,7 +26,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Recoil element info</string>
+   <string>Target composition info</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="sizeConstraint">

--- a/ui_files/ui_target_widget.ui
+++ b/ui_files/ui_target_widget.ui
@@ -232,11 +232,41 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="nameLabel">
-          <property name="text">
-           <string>Name:</string>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="horizontalLayout_13">
+          <item>
+           <widget class="QLabel" name="nameLabel">
+            <property name="text">
+             <string>Name:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="drawEnergySpectra">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="editRecoilElementInfo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QScrollArea" name="recoilScrollArea">
@@ -249,7 +279,7 @@
              <x>0</x>
              <y>0</y>
              <width>198</width>
-             <height>383</height>
+             <height>371</height>
             </rect>
            </property>
           </widget>

--- a/ui_files/ui_target_widget.ui
+++ b/ui_files/ui_target_widget.ui
@@ -241,19 +241,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="drawEnergySpectra">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QPushButton" name="editRecoilElementInfo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/ui_files/ui_target_widget.ui
+++ b/ui_files/ui_target_widget.ui
@@ -74,13 +74,6 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="nameLabel">
-          <property name="text">
-           <string>Name:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QLabel" name="referenceDensityLabel">
           <property name="text">
            <string>Reference density:</string>
@@ -88,7 +81,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="editPushButton">
+         <widget class="QPushButton" name="editPushButtonRecoil">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -122,6 +115,19 @@
          <widget class="QLabel" name="targetReferenceDensityLabel">
           <property name="text">
            <string>Reference density:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="editPushButtonTarget">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
           </property>
          </widget>
         </item>
@@ -212,6 +218,13 @@
          <number>0</number>
         </property>
         <item>
+         <widget class="QLabel" name="nameLabel">
+          <property name="text">
+           <string>Name:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QScrollArea" name="recoilScrollArea">
           <property name="widgetResizable">
            <bool>true</bool>
@@ -222,7 +235,7 @@
              <x>0</x>
              <y>0</y>
              <width>198</width>
-             <height>402</height>
+             <height>383</height>
             </rect>
            </property>
           </widget>

--- a/ui_files/ui_target_widget.ui
+++ b/ui_files/ui_target_widget.ui
@@ -119,22 +119,9 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="targetNameLabel">
+         <widget class="QLabel" name="targetReferenceDensityLabel">
           <property name="text">
-           <string>Name:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="editTargetInfoButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string/>
+           <string>Reference density:</string>
           </property>
          </widget>
         </item>

--- a/ui_files/ui_target_widget.ui
+++ b/ui_files/ui_target_widget.ui
@@ -93,6 +93,13 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QLabel" name="recoilUserSelectionLabel">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>
@@ -126,6 +133,13 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="targetUserSelectionLabel">
           <property name="text">
            <string/>
           </property>

--- a/widgets/matplotlib/measurement/energy_spectrum.py
+++ b/widgets/matplotlib/measurement/energy_spectrum.py
@@ -154,8 +154,9 @@ class MatplotlibEnergySpectrumWidget(MatplotlibWidget):
         self.mpl_toolbar.addSeparator()
 
         self.__change_recoil_element_info = QtWidgets.QToolButton(self)
-        self.__change_recoil_element_info.clicked.connect(
-            self.parent.parent.simulation_target.recoil_distribution_widget.change_recoil_element_info)
+        # FIXME: Does not work on the measurement tab
+        # self.__change_recoil_element_info.clicked.connect(
+        #     self.parent.parent.simulation_target.recoil_distribution_widget.change_recoil_element_info)
         self.__change_recoil_element_info.setCheckable(True)
         self.__change_recoil_element_info.setToolTip(
             "Change the color of the element")

--- a/widgets/matplotlib/measurement/energy_spectrum.py
+++ b/widgets/matplotlib/measurement/energy_spectrum.py
@@ -153,16 +153,16 @@ class MatplotlibEnergySpectrumWidget(MatplotlibWidget):
 
         self.mpl_toolbar.addSeparator()
 
-        self.__change_recoil_element_info = QtWidgets.QToolButton(self)
-        # FIXME: Does not work on the measurement tab
-        # self.__change_recoil_element_info.clicked.connect(
-        #     self.parent.parent.simulation_target.recoil_distribution_widget.change_recoil_element_info)
-        self.__change_recoil_element_info.setCheckable(True)
-        self.__change_recoil_element_info.setToolTip(
-            "Change the color of the element")
-        self.__icon_manager.set_icon(self.__change_recoil_element_info,
-                                     "measuring_unit_settings.svg")
-        self.mpl_toolbar.addWidget(self.__change_recoil_element_info)
+        if hasattr(self.parent.parent, 'simulation_target'):
+            self.__change_recoil_element_info = QtWidgets.QToolButton(self)
+            self.__change_recoil_element_info.clicked.connect(
+                self.parent.parent.simulation_target.recoil_distribution_widget.change_recoil_element_info)
+            self.__change_recoil_element_info.setCheckable(True)
+            self.__change_recoil_element_info.setToolTip(
+                "Modify the recoil element info")
+            self.__icon_manager.set_icon(self.__change_recoil_element_info,
+                                         "measuring_unit_settings.svg")
+            self.mpl_toolbar.addWidget(self.__change_recoil_element_info)
 
         self.__button_toggle_log = QtWidgets.QToolButton(self)
         self.__button_toggle_log.clicked.connect(self.__toggle_log_scale)

--- a/widgets/matplotlib/measurement/energy_spectrum.py
+++ b/widgets/matplotlib/measurement/energy_spectrum.py
@@ -152,6 +152,17 @@ class MatplotlibEnergySpectrumWidget(MatplotlibWidget):
         self.canvas.get_default_filename = lambda: default_filename
 
         self.mpl_toolbar.addSeparator()
+
+        self.__change_recoil_element_info = QtWidgets.QToolButton(self)
+        self.__change_recoil_element_info.clicked.connect(
+            self.parent.parent.simulation_target.recoil_distribution_widget.change_recoil_element_info)
+        self.__change_recoil_element_info.setCheckable(True)
+        self.__change_recoil_element_info.setToolTip(
+            "Change the color of the element")
+        self.__icon_manager.set_icon(self.__change_recoil_element_info,
+                                     "measuring_unit_settings.svg")
+        self.mpl_toolbar.addWidget(self.__change_recoil_element_info)
+
         self.__button_toggle_log = QtWidgets.QToolButton(self)
         self.__button_toggle_log.clicked.connect(self.__toggle_log_scale)
         self.__button_toggle_log.setCheckable(True)

--- a/widgets/matplotlib/simulation/composition.py
+++ b/widgets/matplotlib/simulation/composition.py
@@ -480,9 +480,11 @@ class TargetCompositionWidget(_CompositionWidget):
         self.simulation = simulation
         self.canvas.manager.set_title("Target composition")
 
-        self.parent.targetNameLabel.setText(f"Name: {target.name}")
+        self.parent.targetReferenceDensityLabel.setText(
+            f"Reference density: "
+            f"{self.parent.recoil_distribution_widget.current_recoil_element.reference_density:1.2e} at./cm\xb3")
+        # self.parent.targetNameLabel.setText(f"Name: {target.name}")
 
-        self.parent.editTargetInfoButton.clicked.connect(self.edit_target_info)
         self.layers_changed.connect(self._save_target)
 
     def edit_target_info(self):
@@ -497,7 +499,10 @@ class TargetCompositionWidget(_CompositionWidget):
             os.remove(old_target)
             self.target.name = dialog.name
             self.target.description = dialog.description
-            self.parent.targetNameLabel.setText(self.target.name)
+            self.parent.targetReferenceDensityLabel.setText(
+                f"Reference density: "
+                f"{self.parent.recoil_distribution_widget.current_recoil_element.reference_density:1.2e} at./cm\xb3")
+            # self.parent.targetNameLabel.setText(self.target.name)
             self._save_target()
 
     def _save_target(self):

--- a/widgets/matplotlib/simulation/composition.py
+++ b/widgets/matplotlib/simulation/composition.py
@@ -463,6 +463,7 @@ class TargetCompositionWidget(_CompositionWidget):
     layers to the user. Using this widget user can also modify the layers of the
     target.
     """
+
     def __init__(self, parent, target, icon_manager, simulation):
         """Initializes a TargetCompositionWidget object.
 
@@ -480,9 +481,17 @@ class TargetCompositionWidget(_CompositionWidget):
         self.simulation = simulation
         self.canvas.manager.set_title("Target composition")
 
-        self.parent.targetReferenceDensityLabel.setText(
-            f"Reference density: "
-            f"{self.parent.recoil_distribution_widget.current_recoil_element.reference_density:1.2e} at./cm\xb3")
+        if self.parent.recoil_distribution_widget.current_recoil_element is \
+                None:
+            self.parent.targetReferenceDensityLabel.setText(
+                f"Reference density: "
+                f"{self.simulation.request.global_settings.DEFAULT_REF_DENSITY:1.2e} at./cm\xb3")
+
+        else:
+            self.parent.targetReferenceDensityLabel.setText(
+                f"Reference density: "
+                f"{self.parent.recoil_distribution_widget.current_recoil_element.reference_density:1.2e} at./cm\xb3")
+
         # self.parent.targetNameLabel.setText(f"Name: {target.name}")
 
         self.layers_changed.connect(self._save_target)

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -89,6 +89,7 @@ class ElementWidget(QtWidgets.QWidget):
         horizontal_layout = QtWidgets.QHBoxLayout()
         horizontal_layout.setContentsMargins(0, 0, 0, 0)
 
+        # FIXME: REMOVE THESE - UNNECESSARY
         buttons = []
         instance_buttons = []
 
@@ -109,57 +110,59 @@ class ElementWidget(QtWidgets.QWidget):
         self.circle = Circle(color)
         instance_buttons.append(self.circle)
 
-        change_recoil_element_info = QtWidgets.QPushButton()
-        change_recoil_element_info.setIcon(icon_manager.get_icon(
+        self.change_recoil_element_info = QtWidgets.QPushButton()
+        self.change_recoil_element_info.setIcon(icon_manager.get_icon(
             "measuring_unit_settings.svg"))
-        change_recoil_element_info.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                                           QtWidgets.QSizePolicy.Fixed)
+        self.change_recoil_element_info.setSizePolicy(
+            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
 
-        change_recoil_element_info.clicked.connect(parent.change_recoil_element_info)
-        change_recoil_element_info.setToolTip("Modify the recoil element info")
+        self.change_recoil_element_info.clicked.connect(
+            parent.change_recoil_element_info)
+        self.change_recoil_element_info.setToolTip("Modify the recoil element "
+                                                   "info")
 
-        draw_spectrum_button = QtWidgets.QPushButton()
-        draw_spectrum_button.setIcon(icon_manager.get_icon(
+        self.draw_spectrum_button = QtWidgets.QPushButton()
+        self.draw_spectrum_button.setIcon(icon_manager.get_icon(
             "energy_spectrum_icon.svg"))
-        draw_spectrum_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                                           QtWidgets.QSizePolicy.Fixed)
+        self.draw_spectrum_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                                                QtWidgets.QSizePolicy.Fixed)
 
-        draw_spectrum_button.clicked.connect(lambda: self.plot_spectrum(
+        self.draw_spectrum_button.clicked.connect(lambda: self.plot_spectrum(
             spectra_changed=spectra_changed))
-        draw_spectrum_button.setToolTip("Draw energy spectra")
+        self.draw_spectrum_button.setToolTip("Draw energy spectra")
 
-        settings_button = QtWidgets.QPushButton()
-        settings_button.setIcon(icon_manager.get_icon("gear.svg"))
-        settings_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                                      QtWidgets.QSizePolicy.Fixed)
-        settings_button.clicked.connect(
+        self.settings_button = QtWidgets.QPushButton()
+        self.settings_button.setIcon(icon_manager.get_icon("gear.svg"))
+        self.settings_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                                           QtWidgets.QSizePolicy.Fixed)
+        self.settings_button.clicked.connect(
             lambda: self.open_element_simulation_settings(
                 settings_updated=settings_updated))
-        settings_button.setToolTip("Edit element simulation settings")
+        self.settings_button.setToolTip("Edit element simulation settings")
 
-        add_recoil_button = QtWidgets.QPushButton()
-        add_recoil_button.setIcon(icon_manager.get_icon("edit_add.svg"))
-        add_recoil_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
-                                        QtWidgets.QSizePolicy.Fixed)
-        add_recoil_button.clicked.connect(lambda: self.add_new_recoil(
+        self.add_recoil_button = QtWidgets.QPushButton()
+        self.add_recoil_button.setIcon(icon_manager.get_icon("edit_add.svg"))
+        self.add_recoil_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                                             QtWidgets.QSizePolicy.Fixed)
+        self.add_recoil_button.clicked.connect(lambda: self.add_new_recoil(
             spectra_changed=spectra_changed,
             recoil_name_changed=recoil_name_changed))
-        add_recoil_button.setToolTip("Add a new recoil to element")
+        self.add_recoil_button.setToolTip("Add a new recoil to element")
 
         if platform.system() == "Darwin":
             horizontal_layout.setContentsMargins(0, 0, 12, 0)
 
-        change_recoil_element_info.setMaximumWidth(BUTTON_MAX_WIDTH)
-        draw_spectrum_button.setMaximumWidth(BUTTON_MAX_WIDTH)
-        settings_button.setMaximumWidth(BUTTON_MAX_WIDTH)
-        add_recoil_button.setMaximumWidth(BUTTON_MAX_WIDTH)
+        self.change_recoil_element_info.setMaximumWidth(BUTTON_MAX_WIDTH)
+        self.draw_spectrum_button.setMaximumWidth(BUTTON_MAX_WIDTH)
+        self.settings_button.setMaximumWidth(BUTTON_MAX_WIDTH)
+        self.add_recoil_button.setMaximumWidth(BUTTON_MAX_WIDTH)
 
         horizontal_layout.addWidget(self.radio_button)
         horizontal_layout.addWidget(self.circle)
-        horizontal_layout.addWidget(change_recoil_element_info)
-        horizontal_layout.addWidget(draw_spectrum_button)
-        horizontal_layout.addWidget(settings_button)
-        horizontal_layout.addWidget(add_recoil_button)
+        horizontal_layout.addWidget(self.change_recoil_element_info)
+        horizontal_layout.addWidget(self.draw_spectrum_button)
+        horizontal_layout.addWidget(self.settings_button)
+        horizontal_layout.addWidget(self.add_recoil_button)
 
         self.setLayout(horizontal_layout)
 

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -110,48 +110,56 @@ class ElementWidget(QtWidgets.QWidget):
         instance_buttons.append(self.circle)
 
         change_recoil_element_info = QtWidgets.QPushButton()
+        change_recoil_element_info.setIcon(icon_manager.get_icon(
+            "measuring_unit_settings.svg"))
+        change_recoil_element_info.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                                           QtWidgets.QSizePolicy.Fixed)
+
+        change_recoil_element_info.clicked.connect(parent.change_recoil_element_info)
+        change_recoil_element_info.setToolTip("Add a new recoil to element")
+
         draw_spectrum_button = QtWidgets.QPushButton()
+        draw_spectrum_button.setIcon(icon_manager.get_icon(
+            "energy_spectrum_icon.svg"))
+        draw_spectrum_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                                           QtWidgets.QSizePolicy.Fixed)
+
+        draw_spectrum_button.clicked.connect(lambda: self.plot_spectrum(
+            spectra_changed=spectra_changed))
+        draw_spectrum_button.setToolTip("Draw energy spectra")
+
         settings_button = QtWidgets.QPushButton()
+        settings_button.setIcon(icon_manager.get_icon("gear.svg"))
+        settings_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                                      QtWidgets.QSizePolicy.Fixed)
+        settings_button.clicked.connect(
+            lambda: self.open_element_simulation_settings(
+                settings_updated=settings_updated))
+        settings_button.setToolTip("Edit element simulation settings")
+
         add_recoil_button = QtWidgets.QPushButton()
-
-        buttons.append(change_recoil_element_info)
-        buttons.append(draw_spectrum_button)
-        buttons.append(settings_button)
-        buttons.append(add_recoil_button)
-
-        icons = ["measuring_unit_settings.svg",
-                 "energy_spectrum_icon.svg",
-                 "gear.svg", "edit_add.svg"]
-        tool_tips = ["Change the color of the element",
-                     "Draw energy spectra",
-                     "Edit element simulation settings",
-                     "Add a new recoil to element"]
-        method_calls = [parent.change_recoil_element_info,
-                        lambda: self.plot_spectrum(
-                            spectra_changed=spectra_changed),
-                        lambda: self.open_element_simulation_settings(
-                            settings_updated=settings_updated),
-                        lambda: self.add_new_recoil(
-                            spectra_changed=spectra_changed,
-                            recoil_name_changed=recoil_name_changed)
-                        ]
-        i = 0
-        while i < len(buttons):
-            buttons[i].setIcon(icon_manager.get_icon(icons[i]))
-            buttons[i].setSizePolicy(
-                QtWidgets.QSizePolicy.Fixed,
-                QtWidgets.QSizePolicy.Fixed)
-            buttons[i].clicked.connect(method_calls[i])
-            buttons[i].setToolTip(tool_tips[i])
-            i += 1
+        add_recoil_button.setIcon(icon_manager.get_icon("edit_add.svg"))
+        add_recoil_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+                                        QtWidgets.QSizePolicy.Fixed)
+        add_recoil_button.clicked.connect(lambda: self.add_new_recoil(
+            spectra_changed=spectra_changed,
+            recoil_name_changed=recoil_name_changed))
+        add_recoil_button.setToolTip("Add a new recoil to element")
 
         if platform.system() == "Darwin":
             horizontal_layout.setContentsMargins(0, 0, 12, 0)
 
-        all_buttons = [*instance_buttons, *buttons]
-        for button in all_buttons:
-            button.setMaximumWidth(BUTTON_MAX_WIDTH)
-            horizontal_layout.addWidget(button)
+        change_recoil_element_info.setMaximumWidth(BUTTON_MAX_WIDTH)
+        draw_spectrum_button.setMaximumWidth(BUTTON_MAX_WIDTH)
+        settings_button.setMaximumWidth(BUTTON_MAX_WIDTH)
+        add_recoil_button.setMaximumWidth(BUTTON_MAX_WIDTH)
+
+        horizontal_layout.addWidget(self.radio_button)
+        horizontal_layout.addWidget(self.circle)
+        horizontal_layout.addWidget(change_recoil_element_info)
+        horizontal_layout.addWidget(draw_spectrum_button)
+        horizontal_layout.addWidget(settings_button)
+        horizontal_layout.addWidget(add_recoil_button)
 
         self.setLayout(horizontal_layout)
 

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -103,17 +103,6 @@ class ElementWidget(QtWidgets.QWidget):
         # Circle for showing the recoil color
         self.circle = Circle(color)
 
-        self.change_recoil_element_info = QtWidgets.QPushButton()
-        self.change_recoil_element_info.setIcon(icon_manager.get_icon(
-            "measuring_unit_settings.svg"))
-        self.change_recoil_element_info.setSizePolicy(
-            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
-
-        self.change_recoil_element_info.clicked.connect(
-            parent.change_recoil_element_info)
-        self.change_recoil_element_info.setToolTip("Modify the recoil element "
-                                                   "info")
-
         self.draw_spectrum_button = QtWidgets.QPushButton()
         self.draw_spectrum_button.setIcon(icon_manager.get_icon(
             "energy_spectrum_icon.svg"))
@@ -145,14 +134,12 @@ class ElementWidget(QtWidgets.QWidget):
         if platform.system() == "Darwin":
             horizontal_layout.setContentsMargins(0, 0, 12, 0)
 
-        self.change_recoil_element_info.setMaximumWidth(BUTTON_MAX_WIDTH)
         self.draw_spectrum_button.setMaximumWidth(BUTTON_MAX_WIDTH)
         self.settings_button.setMaximumWidth(BUTTON_MAX_WIDTH)
         self.add_recoil_button.setMaximumWidth(BUTTON_MAX_WIDTH)
 
         horizontal_layout.addWidget(self.radio_button)
         horizontal_layout.addWidget(self.circle)
-        horizontal_layout.addWidget(self.change_recoil_element_info)
         horizontal_layout.addWidget(self.draw_spectrum_button)
         horizontal_layout.addWidget(self.settings_button)
         horizontal_layout.addWidget(self.add_recoil_button)

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -89,13 +89,7 @@ class ElementWidget(QtWidgets.QWidget):
         horizontal_layout = QtWidgets.QHBoxLayout()
         horizontal_layout.setContentsMargins(0, 0, 0, 0)
 
-        # FIXME: REMOVE THESE - UNNECESSARY
-        buttons = []
-        instance_buttons = []
-
         self.radio_button = QtWidgets.QRadioButton()
-
-        instance_buttons.append(self.radio_button)
 
         if element.isotope:
             isotope_superscript = general.digits_to_superscript(
@@ -108,7 +102,6 @@ class ElementWidget(QtWidgets.QWidget):
 
         # Circle for showing the recoil color
         self.circle = Circle(color)
-        instance_buttons.append(self.circle)
 
         self.change_recoil_element_info = QtWidgets.QPushButton()
         self.change_recoil_element_info.setIcon(icon_manager.get_icon(

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -109,22 +109,24 @@ class ElementWidget(QtWidgets.QWidget):
         self.circle = Circle(color)
         instance_buttons.append(self.circle)
 
-        change_element_color = QtWidgets.QPushButton()
+        change_recoil_element_info = QtWidgets.QPushButton()
         draw_spectrum_button = QtWidgets.QPushButton()
         settings_button = QtWidgets.QPushButton()
         add_recoil_button = QtWidgets.QPushButton()
 
-        buttons.append(change_element_color)
+        buttons.append(change_recoil_element_info)
         buttons.append(draw_spectrum_button)
         buttons.append(settings_button)
         buttons.append(add_recoil_button)
 
-        icons = ["measuring_unit_settings.svg", "energy_spectrum_icon.svg",
+        icons = ["measuring_unit_settings.svg",
+                 "energy_spectrum_icon.svg",
                  "gear.svg", "edit_add.svg"]
-        tool_tips = ["Change the element color", "Draw energy spectra",
+        tool_tips = ["Change the color of the element",
+                     "Draw energy spectra",
                      "Edit element simulation settings",
                      "Add a new recoil to element"]
-        method_calls = [parent.change_element_color,
+        method_calls = [parent.change_recoil_element_info,
                         lambda: self.plot_spectrum(
                             spectra_changed=spectra_changed),
                         lambda: self.open_element_simulation_settings(

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -116,7 +116,7 @@ class ElementWidget(QtWidgets.QWidget):
                                            QtWidgets.QSizePolicy.Fixed)
 
         change_recoil_element_info.clicked.connect(parent.change_recoil_element_info)
-        change_recoil_element_info.setToolTip("Add a new recoil to element")
+        change_recoil_element_info.setToolTip("Modify the recoil element info")
 
         draw_spectrum_button = QtWidgets.QPushButton()
         draw_spectrum_button.setIcon(icon_manager.get_icon(

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -848,9 +848,12 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         if self.current_recoil_element is None:  # Otherwise crash
             return
 
-        if dialog.userSelectionCheckBox.isChecked():
+        if dialog.isCancelled:
+            return
 
-            self.current_recoil_element.manual_reference_density_checked = True
+        if dialog.userSelectionCheckBox.isChecked():
+            self.current_element_simulation.request\
+                .manual_reference_density_checked = True
 
             self.parent.targetUserSelectionLabel.setText(
                 "Using user-defined reference density")
@@ -862,9 +865,12 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
             self.parent.recoilUserSelectionLabel.setStyleSheet(
                 "background-color: yellow")
         else:
-            self.current_recoil_element.manual_reference_density_checked = False
+            self.current_element_simulation.request\
+                .manual_reference_density_checked = False
             self.parent.targetUserSelectionLabel.setText("")
             self.parent.recoilUserSelectionLabel.setText("")
+            dialog.reference_density = \
+                self.current_recoil_element.reference_density_element_default
 
         if dialog.isOk:
             try:
@@ -1248,10 +1254,14 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         self.parent.nameLabel.setText(
             f"Name: {self.current_recoil_element.name}")
 
-        density = self.current_recoil_element.reference_density
+        if self.current_element_simulation.request\
+                .manual_reference_density_checked:
+            density = self.current_recoil_element.reference_density
+        else:
+            density = self.current_recoil_element.reference_density_element_default
+
         updated_reference_density = f" Reference density:" \
                                     f" {density:1.2e} at./cm\xb3 "
-
         # The target tab
         self.parent.targetReferenceDensityLabel.setText(
             updated_reference_density)

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -8,7 +8,7 @@ visualization of measurement data collected from a ToF-ERD
 telescope. For physics calculations Potku uses external
 analyzation components.
 Copyright (C) 2018 Severi Jääskeläinen, Samuel Kaiponen, Heta Rekilä and
-Sinikka Siironen, 2020 Juhani Sundell
+Sinikka Siironen, 2020 Juhani Sundell, 2021 Joonas Koponen
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -25,13 +25,14 @@ along with this program (file named 'LICENCE').
 """
 
 __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä \n " \
-             "Sinikka Siironen \n Juhani Sundell"
+             "Sinikka Siironen \n Juhani Sundell \n Joonas Koponen"
 __version__ = "2.0"
 
 import matplotlib
 
 import modules.general_functions as gf
 import dialogs.dialog_functions as df
+from dialogs.simulation.recoil_change_color import RecoilChangeColor
 
 from widgets.matplotlib import mpl_utils
 from pathlib import Path
@@ -800,8 +801,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         """Open recoil element info.
         """
         dialog = RecoilInfoDialog(
-            self.current_recoil_element, self.colormap,
-            self.current_element_simulation)
+            self.current_recoil_element, self.current_element_simulation)
         if dialog.isOk:
             new_values = dialog.get_properties()
             try:
@@ -821,7 +821,6 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
                         self.current_element_simulation,
                         self.current_recoil_element)
                 self.update_recoil_element_info_labels()
-                self.update_colors()
             except KeyError:
                 error_box = QtWidgets.QMessageBox()
                 error_box.setIcon(QtWidgets.QMessageBox.Warning)
@@ -830,6 +829,13 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
                     "All recoil element information could not be saved.")
                 error_box.setWindowTitle("Error")
                 error_box.exec()
+
+    def change_element_color(self):
+        dialog = RecoilChangeColor(
+            self.current_recoil_element, self.colormap,
+            self.current_element_simulation)
+        if dialog.isOk:
+            self.update_colors()
 
     def save_mcsimu_rec_profile(self, directory: Path, progress=None):
         """Save information to .mcsimu and .profile files.
@@ -2480,7 +2486,6 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         self.canvas.draw_idle()
 
         return area
-
 
     def on_rectangle_select(self, eclick, erelease):
         """Select multiple points.

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -855,6 +855,21 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         """
         dialog = ReferenceDensityDialog(
             self.current_recoil_element, self.current_element_simulation)
+
+        if dialog.userSelectionCheckBox.isChecked():
+            self.parent.targetUserSelectionLabel.setText(
+                "Using the user selection")
+            self.parent.targetUserSelectionLabel.setStyleSheet(
+                "background-color: yellow")
+            self.parent.recoilUserSelectionLabel.setText(
+                "Using the user selection")
+            self.parent.recoilUserSelectionLabel.setStyleSheet(
+                "background-color: yellow")
+        else:
+            self.parent.targetUserSelectionLabel.setText("")
+
+            self.parent.recoilUserSelectionLabel.setText("")
+
         if dialog.isOk:
             try:
                 new_values = dialog.get_properties()

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -1050,6 +1050,10 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         # TODO it would be better to update the old lines rather than keep
         #   adding new lines
         self.other_recoils_lines = []
+
+        if not self.simulation.element_simulations:
+            self.main_frame.remove_target_labels()
+
         for element_simulation in self.simulation.element_simulations:
             for recoil in element_simulation.recoil_elements:
                 if recoil in self.other_recoils:

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -389,26 +389,6 @@ class ElementManager:
             radio_buttons.append(recoil_element.widgets[0].radio_button)
         return radio_buttons
 
-    def disable_push_buttons(self, current_element):
-        for element_simulation in self.element_simulations:
-            if element_simulation == current_element:
-                for recoil_element in element_simulation.recoil_elements:
-                    self.change_button_state(recoil_element, True)
-            else:
-                for recoil_element in element_simulation.recoil_elements:
-                    self.change_button_state(recoil_element, False)
-
-    @staticmethod
-    def change_button_state(recoil_element: RecoilElement, state: bool):
-        recoil_element.widgets[
-            0].change_recoil_element_info.setEnabled(
-            state)
-        recoil_element.widgets[0].draw_spectrum_button.setEnabled(
-            state)
-        recoil_element.widgets[0].settings_button.setEnabled(state)
-        recoil_element.widgets[0].add_recoil_button.setEnabled(
-            state)
-
     def has_element(self, element: Element) -> bool:
         """Checks whether any ElementSimulation has an element that matches
         the given argument.
@@ -1001,7 +981,6 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
             self.other_recoils.append(self.current_recoil_element)
         current_element_simulation = self.element_manager \
             .get_element_simulation_with_radio_button(button)
-        self.element_manager.disable_push_buttons(current_element_simulation)
         self.current_element_simulation = current_element_simulation
         self.current_recoil_element = \
             self.element_manager.get_recoil_element_with_radio_button(

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -853,21 +853,26 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
     def open_recoil_element_info(self):
         """Open recoil element info.
         """
+
         dialog = ReferenceDensityDialog(
             self.current_recoil_element, self.current_element_simulation)
 
         if dialog.userSelectionCheckBox.isChecked():
+
+            self.current_recoil_element.manual_reference_density_checked = True
+
             self.parent.targetUserSelectionLabel.setText(
-                "Using the user selection")
+                "Using user-defined reference density")
             self.parent.targetUserSelectionLabel.setStyleSheet(
                 "background-color: yellow")
+
             self.parent.recoilUserSelectionLabel.setText(
-                "Using the user selection")
+                "Using user-defined reference density")
             self.parent.recoilUserSelectionLabel.setStyleSheet(
                 "background-color: yellow")
         else:
+            self.current_recoil_element.manual_reference_density_checked = False
             self.parent.targetUserSelectionLabel.setText("")
-
             self.parent.recoilUserSelectionLabel.setText("")
 
         if dialog.isOk:

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -503,7 +503,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
             self.choose_element)
 
         self.parent.editPushButton.clicked.connect(
-            self.open_reference_density_dialog)
+            self.open_recoil_element_info)
 
         self.edit_lock_push_button = self.parent.editLockPushButton
         self.edit_lock_push_button.clicked.connect(self.unlock_or_lock_edit)
@@ -797,7 +797,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         )
         self.tab.add_widget(percentage_widget)
 
-    def open_reference_density_dialog(self):
+    def open_recoil_element_info(self):
         """Open recoil element info.
         """
         dialog = ReferenceDensityDialog(
@@ -1211,10 +1211,17 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         """
         self.parent.nameLabel.setText(
             f"Name: {self.current_recoil_element.name}")
+
+        density = self.current_recoil_element.reference_density
+        updated_reference_density = f" Reference density:" \
+                                    f" {density:1.2e} at./cm\xb3 "
+
+        # The target tab
+        self.parent.targetReferenceDensityLabel.setText(
+            updated_reference_density)
+        # The recoil atom distribution tab
         self.parent.referenceDensityLabel.setText(
-            f"Reference density: "
-            f"{self.current_recoil_element.reference_density:1.2e} at./cm\xb3"
-        )
+            updated_reference_density)
 
     def recoil_element_info_on_switch(self):
         """Show recoil element info on switch.

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -175,7 +175,7 @@ class ElementManager:
             Created ElementSimulation
         """
         # TODO check that element does not exist
-        
+
         # There is no y_2 if there is only one layer
         y_2 = None
         # Set first point
@@ -183,47 +183,47 @@ class ElementManager:
         first_layer = self.parent.target.layers[0]
         if element in first_layer.elements:
             ys = [element.amount]
-        else: 
+        else:
             ys = [self.parent.get_minimum_concentration()]
-        
+
         # Make two points for each change between layers
         layer_index = 0
         for layer in self.parent.target.layers:
             # Set x-coordinates for the both points
-            x_1 = layer.start_depth + layer.thickness 
+            x_1 = layer.start_depth + layer.thickness
             xs.append(x_1)
             x_2 = x_1 + self.parent.x_res
             xs.append(x_2)
-            
+
             # Set y-coordinate for the first point
             for current_element in layer.elements:
-                if (current_element.symbol == element.symbol and 
+                if (current_element.symbol == element.symbol and
                         current_element.isotope == element.isotope):
                     y_1 = current_element.amount
                     break
                 else:
                     y_1 = self.parent.get_minimum_concentration()
-                    
+
             ys.append(y_1)
 
             # Set y-coordinate for the second point if not in the last layer
             if layer_index + 1 < len(self.parent.target.layers):
-                next_layer = self.parent.target.layers[layer_index+1]
+                next_layer = self.parent.target.layers[layer_index + 1]
                 current_symbol = element.symbol
                 current_isotope = element.isotope
-                
+
                 for next_element in next_layer.elements:
                     if (next_element.symbol == current_symbol and
                             next_element.isotope == current_isotope):
                         y_2 = next_element.amount
                         break
                     else:
-                        y_2 = self.parent.get_minimum_concentration()  
-            
+                        y_2 = self.parent.get_minimum_concentration()
+
             if y_2 is not None:
                 ys.append(y_2)
             layer_index += 1
-            
+
         # Removes last point from the list
         if y_2 is not None:
             ys.pop()
@@ -234,7 +234,7 @@ class ElementManager:
         for xy in xys:
             points.append(Point(xy))
 
-        rec_type = self.simulation.request.default_element_simulation\
+        rec_type = self.simulation.request.default_element_simulation \
             .simulation_type.get_recoil_type()
 
         recoil_element = RecoilElement(
@@ -661,7 +661,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         distribution.
         """
         return self.clicked_point is \
-            self.current_recoil_element.get_first_point()
+               self.current_recoil_element.get_first_point()
 
     def first_point_in_selection(self) -> bool:
         """Checks whether the first point of the distribution is in current
@@ -675,7 +675,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         distribution.
         """
         return self.clicked_point is \
-            self.current_recoil_element.get_last_point()
+               self.current_recoil_element.get_last_point()
 
     def last_point_in_selection(self) -> bool:
         """Checks whether the last point of the distribution is in current
@@ -729,7 +729,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
                     self.canvas, self.axes,
                     xs=self.current_recoil_element.get_range(),
                     colors=("orange", "green"), flush=False
-            )
+                )
 
     def set_individual_intervals_visible(self, b: bool):
         for interval in self.individual_intervals.values():
@@ -803,8 +803,8 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         dialog = ReferenceDensityDialog(
             self.current_recoil_element, self.current_element_simulation)
         if dialog.isOk:
-            new_values = dialog.get_properties()
             try:
+                new_values = dialog.get_properties()
                 old_recoil_name = self.current_recoil_element.name
                 self.current_element_simulation.update_recoil_element(
                     self.current_recoil_element,
@@ -821,14 +821,16 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
                         self.current_element_simulation,
                         self.current_recoil_element)
                 self.update_recoil_element_info_labels()
-            except KeyError:
-                error_box = QtWidgets.QMessageBox()
-                error_box.setIcon(QtWidgets.QMessageBox.Warning)
-                error_box.addButton(QtWidgets.QMessageBox.Ok)
-                error_box.setText(
-                    "All recoil element information could not be saved.")
-                error_box.setWindowTitle("Error")
-                error_box.exec()
+            except KeyError as e:
+                print(str(e))
+                QtWidgets.QMessageBox.critical(
+                    self,
+                    "Error",
+                    "All recoil element "
+                    "information could not be saved.",
+                    QtWidgets.QMessageBox.Ok,
+                    QtWidgets.QMessageBox.Ok)
+                return
 
     def change_recoil_element_info(self):
         dialog = RecoilInfoDialog(
@@ -855,14 +857,16 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
                 self.update_recoil_element_info_labels()
                 self.update_colors()
 
-            except KeyError:
-                error_box = QtWidgets.QMessageBox()
-                error_box.setIcon(QtWidgets.QMessageBox.Warning)
-                error_box.addButton(QtWidgets.QMessageBox.Ok)
-                error_box.setText(
-                    "All recoil element information could not be saved.")
-                error_box.setWindowTitle("Error")
-                error_box.exec()
+            except KeyError as e:
+                print(str(e))
+                QtWidgets.QMessageBox.critical(
+                    self,
+                    "Error",
+                    "All recoil element "
+                    "information could not be saved.",
+                    QtWidgets.QMessageBox.Ok,
+                    QtWidgets.QMessageBox.Ok)
+                return
 
     def save_mcsimu_rec_profile(self, directory: Path, progress=None):
         """Save information to .mcsimu and .profile files.
@@ -898,7 +902,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
             # TODO use the function in dialog functions
             # Check if current element simulation is running
             add = None
-            if self.current_element_simulation.is_simulation_running() and not\
+            if self.current_element_simulation.is_simulation_running() and not \
                     self.current_element_simulation.is_optimization_running():
                 add = "Are you sure you want to unlock full edit for this" \
                       " running element simulation?\nIt will be stopped and " \
@@ -1101,13 +1105,13 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         if self.get_current_main_recoil().zero_intervals_on_x != \
                 self.current_recoil_element.zero_intervals_on_x:
             for interval2 in self.current_recoil_element.zero_intervals_on_x:
-                if interval2 not in self.get_current_main_recoil().\
-                                zero_intervals_on_x:
+                if interval2 not in self.get_current_main_recoil(). \
+                        zero_intervals_on_x:
                     for point2 in self.current_recoil_element.get_points():
                         p_x = point2.get_x()
                         if interval2[0] <= p_x <= interval2[1]:
                             is_inside = False
-                            for interval3 in self.get_current_main_recoil().\
+                            for interval3 in self.get_current_main_recoil(). \
                                     zero_intervals_on_x:
                                 if interval3[0] <= p_x <= interval3[1]:
                                     is_inside = True
@@ -1263,7 +1267,8 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
             try:
                 element_simulation = \
                     self.element_manager.add_new_element_simulation(
-                        element, color, spectra_changed=self.recoil_dist_changed,
+                        element, color,
+                        spectra_changed=self.recoil_dist_changed,
                         recoil_name_changed=self.recoil_name_changed, **kwargs)
             except ValueError as e:
                 QtWidgets.QMessageBox.critical(
@@ -1359,7 +1364,8 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         if recoil_to_delete in self.individual_intervals:
             self.individual_intervals.pop(recoil_to_delete).remove()
 
-    def remove_current_element(self, ignore_dialog=False, ignore_selection=False):
+    def remove_current_element(self, ignore_dialog=False,
+                               ignore_selection=False):
         """Remove current element simulation.
         
         Args:
@@ -1367,7 +1373,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
              ignore_selection: A boolean ignoring radio button selections
         """
         if self.current_element_simulation is None:
-            return    
+            return
         if not ignore_selection:
             if not self.main_recoil_selected():
                 return
@@ -1378,9 +1384,9 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
             add = "\nAlso its simulation will be stopped."
         else:
             add = ""
-            
+
         # TODO use the function from dialog_functions in here        
-        if not ignore_dialog: 
+        if not ignore_dialog:
             reply = QtWidgets.QMessageBox.question(
                 self.parent, "Confirmation",
                 "If you delete selected element simulation, all possible recoils "
@@ -1458,17 +1464,18 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
                 f"Their simulations will be stopped. "
                 f"This also applies to possible optimizations.",
                 QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No |
-                QtWidgets.QMessageBox.Cancel, QtWidgets.QMessageBox.Cancel)        
-            
+                QtWidgets.QMessageBox.Cancel, QtWidgets.QMessageBox.Cancel)
+
         if reply == QtWidgets.QMessageBox.No or reply == \
                 QtWidgets.QMessageBox.Cancel:
             return  # If clicked Yes, then continue normally
-            
+
         element_simulations = self.element_manager.element_simulations
         while len(element_simulations) >= 1:
             for element_simulation in element_simulations:
                 self.current_element_simulation = element_simulations[0]
-                self.remove_current_element(ignore_dialog=True, ignore_selection=True)
+                self.remove_current_element(ignore_dialog=True,
+                                            ignore_selection=True)
 
     def export_elements(self, **kwargs):
         """Export elements from target layers into element simulations if they
@@ -1864,7 +1871,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
             if not multiply:
                 if not self.full_edit_on or \
                         self.current_element_simulation.get_main_recoil() != \
-                            recoil:
+                        recoil:
                     # Check if point is added between two zeros
                     if right_neighbor.get_y() == 0.0 and \
                             left_neighbor.get_y() == 0.0:

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -795,6 +795,14 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         self.tab.add_widget(percentage_widget)
 
     def change_recoil_element_info(self):
+        if self.current_recoil_element is None:
+            QtWidgets.QMessageBox.warning(self, "Warning",
+                                                "The current simulation has "
+                                                "no recoil elements",
+                                                QtWidgets.QMessageBox.Ok,
+                                                QtWidgets.QMessageBox.Ok)
+            return
+
         dialog = RecoilInfoDialog(
             self.current_recoil_element, self.colormap,
             self.current_element_simulation)
@@ -836,6 +844,9 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
 
         dialog = ReferenceDensityDialog(
             self.current_recoil_element, self.current_element_simulation)
+
+        if self.current_recoil_element is None:  # Otherwise crash
+            return
 
         if dialog.userSelectionCheckBox.isChecked():
 
@@ -1247,10 +1258,7 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
     def recoil_element_info_on_switch(self):
         """Show recoil element info on switch.
         """
-        if self.current_element_simulation is None:
-            self.parent.elementInfoWidget.hide()
-        else:
-            self.parent.elementInfoWidget.show()
+        self.parent.elementInfoWidget.show()
 
     def add_element_with_dialog(self, **kwargs):
         """Add new element simulation with dialog.
@@ -1454,7 +1462,6 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
         self.current_element_simulation = None
         self.remove_element(element_simulation)
         self.show_other_recoils()
-        self.parent.elementInfoWidget.hide()
         self.update_plot()
 
     def remove_all_elements(self, export_dialog=False):

--- a/widgets/simulation/target.py
+++ b/widgets/simulation/target.py
@@ -8,7 +8,7 @@ visualization of measurement data collected from a ToF-ERD
 telescope. For physics calculations Potku uses external
 analyzation components.
 Copyright (C) 2018 Severi Jääskeläinen, Samuel Kaiponen, Heta Rekilä and
-Sinikka Siironen
+Sinikka Siironen, 2021 Joonas Koponen
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with this program (file named 'LICENCE').
 """
 __author__ = "Severi Jääskeläinen \n Samuel Kaiponen \n Heta Rekilä " \
-             "\n Sinikka Siironen"
+             "\n Sinikka Siironen \n Joonas Koponen"
 __version__ = "2.0"
 
 import platform
@@ -104,11 +104,20 @@ class TargetWidget(QtWidgets.QWidget):
         self.spectra_changed = self.recoil_distribution_widget. \
             recoil_dist_changed
 
-        icon_manager.set_icon(self.editPushButton, "edit.svg")
-        self.editPushButton.setIconSize(QtCore.QSize(14, 14))
-        self.editPushButton.setToolTip(
-            "Edit name, description and reference density "
-            "of this recoil element")
+        icon_manager.set_icon(self.editPushButtonTarget, "edit.svg")
+        self.editPushButtonTarget.clicked.connect(
+            self.recoil_distribution_widget.open_recoil_element_info)
+        self.editPushButtonTarget.setIconSize(QtCore.QSize(14, 14))
+        self.editPushButtonTarget.setToolTip(
+            "Edit the reference density this target composition")
+
+        icon_manager.set_icon(self.editPushButtonRecoil, "edit.svg")
+        self.editPushButtonRecoil.clicked.connect(
+            self.recoil_distribution_widget.open_recoil_element_info)
+        self.editPushButtonRecoil.setIconSize(QtCore.QSize(14, 14))
+        self.editPushButtonRecoil.setToolTip(
+            "Edit the reference density this target composition")
+
         self.recoilListWidget.hide()
         self.editLockPushButton.hide()
         self.elementInfoWidget.hide()

--- a/widgets/simulation/target.py
+++ b/widgets/simulation/target.py
@@ -118,6 +118,24 @@ class TargetWidget(QtWidgets.QWidget):
         self.editPushButtonRecoil.setToolTip(
             "Edit the reference density this target composition")
 
+        icon_manager.set_icon(
+            self.editRecoilElementInfo, "measuring_unit_settings.svg")
+        self.editRecoilElementInfo.clicked.connect(
+            self.recoil_distribution_widget.change_recoil_element_info)
+        self.editRecoilElementInfo.setIconSize(QtCore.QSize(14, 14))
+        self.editRecoilElementInfo.setToolTip(
+            "Edit the recoil element info")
+
+        icon_manager.set_icon(
+            self.drawEnergySpectra, "energy_spectrum_icon.svg")
+        # self.drawEnergySpectra.clicked.connect(
+        #     lambda: self.recoil_distribution_widget.parent.plot_spectrum(
+        #         spectra_changed=self.recoil_distribution_widget.parent.spectra_changed))
+        self.drawEnergySpectra.setIconSize(QtCore.QSize(14, 14))
+        self.drawEnergySpectra.setToolTip(
+            "Draw energy spectra")
+        self.drawEnergySpectra.setEnabled(False)
+
         self.recoilListWidget.hide()
         self.editLockPushButton.hide()
         self.elementInfoWidget.hide()

--- a/widgets/simulation/target.py
+++ b/widgets/simulation/target.py
@@ -89,15 +89,16 @@ class TargetWidget(QtWidgets.QWidget):
         self.target = target
         self.statusbar = statusbar
 
+        self.recoil_distribution_widget = RecoilAtomDistributionWidget(
+            self, self.simulation, self.target, tab, icon_manager, settings,
+            statusbar=self.statusbar, **kwargs)
+
         self.target_widget = TargetCompositionWidget(
             self, self.target, icon_manager, self.simulation)
 
         if progress is not None:
             progress.report(50)
 
-        self.recoil_distribution_widget = RecoilAtomDistributionWidget(
-            self, self.simulation, self.target, tab, icon_manager, settings,
-            statusbar=self.statusbar, **kwargs)
         self.results_accepted.connect(
             self.recoil_distribution_widget.update_element_simulation.emit)
         self.spectra_changed = self.recoil_distribution_widget. \
@@ -111,11 +112,6 @@ class TargetWidget(QtWidgets.QWidget):
         self.recoilListWidget.hide()
         self.editLockPushButton.hide()
         self.elementInfoWidget.hide()
-
-        icon_manager.set_icon(self.editTargetInfoButton, "edit.svg")
-        self.editTargetInfoButton.setIconSize(QtCore.QSize(14, 14))
-        self.editTargetInfoButton.setToolTip(
-            "Edit name and description of the target")
 
         if platform.system() == "Darwin":
             self.percentButton.setText("Calculate\npercents")

--- a/widgets/simulation/target.py
+++ b/widgets/simulation/target.py
@@ -126,16 +126,6 @@ class TargetWidget(QtWidgets.QWidget):
         self.editRecoilElementInfo.setToolTip(
             "Edit the recoil element info")
 
-        icon_manager.set_icon(
-            self.drawEnergySpectra, "energy_spectrum_icon.svg")
-        # self.drawEnergySpectra.clicked.connect(
-        #     lambda: self.recoil_distribution_widget.parent.plot_spectrum(
-        #         spectra_changed=self.recoil_distribution_widget.parent.spectra_changed))
-        self.drawEnergySpectra.setIconSize(QtCore.QSize(14, 14))
-        self.drawEnergySpectra.setToolTip(
-            "Draw energy spectra")
-        self.drawEnergySpectra.setEnabled(False)
-
         self.recoilListWidget.hide()
         self.editLockPushButton.hide()
         self.elementInfoWidget.hide()

--- a/widgets/simulation/target.py
+++ b/widgets/simulation/target.py
@@ -258,3 +258,13 @@ class TargetWidget(QtWidgets.QWidget):
         self.del_points.setKey(QtCore.Qt.Key_Delete)
         self.del_points.activated.connect(
             lambda: self.recoil_distribution_widget.remove_points())
+
+    def remove_target_labels(self):
+        self.referenceDensityLabel.setText("")
+        self.targetReferenceDensityLabel.setText("")
+
+        self.targetUserSelectionLabel.setText("")
+        self.targetUserSelectionLabel.setStyleSheet("")
+
+        self.recoilUserSelectionLabel.setText("")
+        self.recoilUserSelectionLabel.setStyleSheet("")

--- a/widgets/simulation/target.py
+++ b/widgets/simulation/target.py
@@ -93,11 +93,11 @@ class TargetWidget(QtWidgets.QWidget):
             self, self.simulation, self.target, tab, icon_manager, settings,
             statusbar=self.statusbar, **kwargs)
 
-        self.target_widget = TargetCompositionWidget(
-            self, self.target, icon_manager, self.simulation)
-
         if progress is not None:
             progress.report(50)
+
+        self.target_widget = TargetCompositionWidget(
+            self, self.target, icon_manager, self.simulation)
 
         self.results_accepted.connect(
             self.recoil_distribution_widget.update_element_simulation.emit)
@@ -126,7 +126,7 @@ class TargetWidget(QtWidgets.QWidget):
             self.recoilRadioButton.setEnabled(False)
 
         self.targetRadioButton.setChecked(True)
-        self.stackedWidget.setCurrentIndex(0)
+        self.stackedWidget.setCurrentIndex(1)
 
         self.saveButton.clicked.connect(self._save_target_and_recoils)
 
@@ -156,7 +156,7 @@ class TargetWidget(QtWidgets.QWidget):
         """
         self.recoil_distribution_widget.original_x_limits = \
             self.recoil_distribution_widget.axes.get_xlim()
-        self.stackedWidget.setCurrentIndex(0)
+        self.stackedWidget.setCurrentIndex(1)
         self.recoilListWidget.hide()
         self.editLockPushButton.hide()
         self.exportElementsButton.show()
@@ -168,7 +168,7 @@ class TargetWidget(QtWidgets.QWidget):
         """
         Switch to recoil atom distribution view.
         """
-        self.stackedWidget.setCurrentIndex(1)
+        self.stackedWidget.setCurrentIndex(0)
         self.recoil_distribution_widget.update_layer_borders()
         self.exportElementsButton.hide()
         self.recoilListWidget.show()


### PR DESCRIPTION
Fix: #228: 
- Create new RecoilChangeColor class which removes color features from the older RecoilInfoDialog class
- Move the color selection dialog from the "Recoil Element Info" window to the matplotlib window / widget
- Simplify the code in a way that the buttons (in the GUI) are created in a loop