### PR TITLE
Highlight settings buttons when not using request settings

### DIFF
--- a/dialogs/simulation/element_simulation_settings.py
+++ b/dialogs/simulation/element_simulation_settings.py
@@ -50,7 +50,7 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
     use_default_settings = bnd.bind("defaultSettingsCheckBox",
                                     track_change=True)
 
-    def __init__(self, element_simulation, tab):
+    def __init__(self, element_simulation, tab, settings_button):
         """
         Initializes the dialog.
 
@@ -61,6 +61,8 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
         super().__init__()
         uic.loadUi(gutils.get_ui_dir() / "ui_specific_settings.ui", self)
         self.setWindowTitle("Element Settings")
+
+        self.settings_button = settings_button
 
         self.element_simulation = element_simulation
         self.tab = tab
@@ -104,9 +106,11 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
         if self.use_default_settings:
             self.tabs.setEnabled(False)
             self.sim_widget.setEnabled(False)
+            self.settings_button.setStyleSheet("")
         else:
             self.tabs.setEnabled(True)
             self.sim_widget.setEnabled(True)
+            self.settings_button.setStyleSheet("background-color : yellow")
 
     def update_settings_and_close(self):
         """Updates settings and closes the dialog if update_settings returns

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -111,13 +111,14 @@ class ElementWidget(QtWidgets.QWidget):
             spectra_changed=spectra_changed))
         draw_spectrum_button.setToolTip("Draw energy spectra")
 
-        settings_button = QtWidgets.QPushButton()
+        settings_button = QtWidgets .QPushButton()
         settings_button.setIcon(icon_manager.get_icon("gear.svg"))
         settings_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
                                       QtWidgets.QSizePolicy.Fixed)
         settings_button.clicked.connect(
             lambda: self.open_element_simulation_settings(
-                settings_updated=settings_updated))
+                settings_updated=settings_updated,
+                settings_button=settings_button))
         settings_button.setToolTip("Edit element simulation settings")
 
         add_recoil_button = QtWidgets.QPushButton()
@@ -187,11 +188,13 @@ class ElementWidget(QtWidgets.QWidget):
         # Save recoil element
         recoil_element.to_file(self.element_simulation.directory)
 
-    def open_element_simulation_settings(self, settings_updated=None):
+    def open_element_simulation_settings(self, settings_updated=None,
+                                         settings_button=None):
         """
         Open element simulation settings.
         """
-        es = ElementSimulationSettingsDialog(self.element_simulation, self.tab)
+        es = ElementSimulationSettingsDialog(self.element_simulation,
+                                             self.tab, settings_button)
         if settings_updated is not None:
             es.settings_updated.connect(settings_updated.emit)
         es.exec_()


### PR DESCRIPTION
FIX: #245 

TODO: The settings buttons (and the highlighting feature) are created BEFORE the "Target Composition and Recoil Atom Distribution" window. The feature is connected to the checkbox in the "Element Settings" window.

![use_request_settings](https://user-images.githubusercontent.com/82767802/151163017-2b53e148-1793-4884-ae30-9aad3def4395.png)
