### PR TITLE
Highlight an element settings button when not using request setting values

### DIFF
--- a/dialogs/simulation/element_simulation_settings.py
+++ b/dialogs/simulation/element_simulation_settings.py
@@ -50,7 +50,7 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
     use_default_settings = bnd.bind("defaultSettingsCheckBox",
                                     track_change=True)
 
-    def __init__(self, element_simulation, tab):
+    def __init__(self, element_simulation, tab, settings_button):
         """
         Initializes the dialog.
 
@@ -61,6 +61,8 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
         super().__init__()
         uic.loadUi(gutils.get_ui_dir() / "ui_specific_settings.ui", self)
         self.setWindowTitle("Element Settings")
+
+        self.settings_button = settings_button
 
         self.element_simulation = element_simulation
         self.tab = tab
@@ -104,9 +106,11 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
         if self.use_default_settings:
             self.tabs.setEnabled(False)
             self.sim_widget.setEnabled(False)
+            self.settings_button.setStyleSheet("")
         else:
             self.tabs.setEnabled(True)
             self.sim_widget.setEnabled(True)
+            self.settings_button.setStyleSheet("background-color : yellow")
 
     def update_settings_and_close(self):
         """Updates settings and closes the dialog if update_settings returns

--- a/dialogs/simulation/element_simulation_settings.py
+++ b/dialogs/simulation/element_simulation_settings.py
@@ -50,7 +50,7 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
     use_default_settings = bnd.bind("defaultSettingsCheckBox",
                                     track_change=True)
 
-    def __init__(self, element_simulation, tab, settings_button):
+    def __init__(self, element_simulation, tab):
         """
         Initializes the dialog.
 
@@ -61,8 +61,6 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
         super().__init__()
         uic.loadUi(gutils.get_ui_dir() / "ui_specific_settings.ui", self)
         self.setWindowTitle("Element Settings")
-
-        self.settings_button = settings_button
 
         self.element_simulation = element_simulation
         self.tab = tab
@@ -106,11 +104,9 @@ class ElementSimulationSettingsDialog(QtWidgets.QDialog,
         if self.use_default_settings:
             self.tabs.setEnabled(False)
             self.sim_widget.setEnabled(False)
-            self.settings_button.setStyleSheet("")
         else:
             self.tabs.setEnabled(True)
             self.sim_widget.setEnabled(True)
-            self.settings_button.setStyleSheet("background-color : yellow")
 
     def update_settings_and_close(self):
         """Updates settings and closes the dialog if update_settings returns

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -111,13 +111,14 @@ class ElementWidget(QtWidgets.QWidget):
             spectra_changed=spectra_changed))
         draw_spectrum_button.setToolTip("Draw energy spectra")
 
-        settings_button = QtWidgets.QPushButton()
+        settings_button = QtWidgets .QPushButton()
         settings_button.setIcon(icon_manager.get_icon("gear.svg"))
         settings_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
                                       QtWidgets.QSizePolicy.Fixed)
         settings_button.clicked.connect(
             lambda: self.open_element_simulation_settings(
-                settings_updated=settings_updated))
+                settings_updated=settings_updated,
+                settings_button=settings_button))
         settings_button.setToolTip("Edit element simulation settings")
 
         add_recoil_button = QtWidgets.QPushButton()
@@ -187,11 +188,13 @@ class ElementWidget(QtWidgets.QWidget):
         # Save recoil element
         recoil_element.to_file(self.element_simulation.directory)
 
-    def open_element_simulation_settings(self, settings_updated=None):
+    def open_element_simulation_settings(self, settings_updated=None,
+                                         settings_button=None):
         """
         Open element simulation settings.
         """
-        es = ElementSimulationSettingsDialog(self.element_simulation, self.tab)
+        es = ElementSimulationSettingsDialog(self.element_simulation,
+                                             self.tab, settings_button)
         if settings_updated is not None:
             es.settings_updated.connect(settings_updated.emit)
         es.exec_()

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -111,14 +111,13 @@ class ElementWidget(QtWidgets.QWidget):
             spectra_changed=spectra_changed))
         draw_spectrum_button.setToolTip("Draw energy spectra")
 
-        settings_button = QtWidgets .QPushButton()
+        settings_button = QtWidgets.QPushButton()
         settings_button.setIcon(icon_manager.get_icon("gear.svg"))
         settings_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
                                       QtWidgets.QSizePolicy.Fixed)
         settings_button.clicked.connect(
             lambda: self.open_element_simulation_settings(
-                settings_updated=settings_updated,
-                settings_button=settings_button))
+                settings_updated=settings_updated))
         settings_button.setToolTip("Edit element simulation settings")
 
         add_recoil_button = QtWidgets.QPushButton()
@@ -188,13 +187,11 @@ class ElementWidget(QtWidgets.QWidget):
         # Save recoil element
         recoil_element.to_file(self.element_simulation.directory)
 
-    def open_element_simulation_settings(self, settings_updated=None,
-                                         settings_button=None):
+    def open_element_simulation_settings(self, settings_updated=None):
         """
         Open element simulation settings.
         """
-        es = ElementSimulationSettingsDialog(self.element_simulation,
-                                             self.tab, settings_button)
+        es = ElementSimulationSettingsDialog(self.element_simulation, self.tab)
         if settings_updated is not None:
             es.settings_updated.connect(settings_updated.emit)
         es.exec_()

--- a/widgets/matplotlib/simulation/element.py
+++ b/widgets/matplotlib/simulation/element.py
@@ -117,8 +117,11 @@ class ElementWidget(QtWidgets.QWidget):
                                       QtWidgets.QSizePolicy.Fixed)
         settings_button.clicked.connect(
             lambda: self.open_element_simulation_settings(
-                settings_updated=settings_updated))
+                settings_updated=settings_updated,
+                settings_button=settings_button))
         settings_button.setToolTip("Edit element simulation settings")
+
+        self.update_settings_button(settings_button)
 
         add_recoil_button = QtWidgets.QPushButton()
         add_recoil_button.setIcon(icon_manager.get_icon("edit_add.svg"))
@@ -187,7 +190,8 @@ class ElementWidget(QtWidgets.QWidget):
         # Save recoil element
         recoil_element.to_file(self.element_simulation.directory)
 
-    def open_element_simulation_settings(self, settings_updated=None):
+    def open_element_simulation_settings(self, settings_updated=None,
+                                         settings_button=None):
         """
         Open element simulation settings.
         """
@@ -195,6 +199,8 @@ class ElementWidget(QtWidgets.QWidget):
         if settings_updated is not None:
             es.settings_updated.connect(settings_updated.emit)
         es.exec_()
+
+        self.update_settings_button(settings_button)
 
     def plot_spectrum(self, spectra_changed=None):
         """Plot an energy spectrum and show it in a widget.
@@ -243,3 +249,17 @@ class ElementWidget(QtWidgets.QWidget):
             elif not previous and energy_spectrum_widget is not None:
                 energy_spectrum_widget.save_to_file(measurement=False,
                                                     update=False)
+
+    def update_settings_button(self, settings_button):
+        """
+        Change a settings button's color (to yellow) when the user is not using
+        request settings values. Otherwise keep it uncolored.
+
+        Args:
+         settings_button: QtWidgets.QPushButton() that opens the element
+         (simulation) settings dialog.
+        """
+        if self.element_simulation.use_default_settings:
+            settings_button.setStyleSheet("")
+        else:
+            settings_button.setStyleSheet("background-color: yellow")


### PR DESCRIPTION
FIX: #245 and REPLACE: #246

Note that there is an old commit 8a265464a65c0870c9c8c0305247a4eca11e708c and its revert. However they should not affect anything.

![use_request_settings](https://user-images.githubusercontent.com/82767802/151199480-5df590b1-259f-4a75-9218-3efe638af041.png)
