### PR TITLE
Fixed efficiency plot

### DIFF
--- a/widgets/detector_settings.py
+++ b/widgets/detector_settings.py
@@ -631,16 +631,9 @@ class DetectorSettingsWidget(QtWidgets.QWidget, bnd.PropertyTrackingWidget,
         """
         Open efficiency plot widget
         """
-        self.eff_folder = gutils.get_potku_setting(
-            DetectorSettingsWidget.EFF_FILE_FOLDER_KEY,
-            self.request.default_folder)
-        self.efficiency_files = self.obj.get_efficiency_files()
-        self.efficiency_files_list = []
-        for file in self.efficiency_files:
-            file_name = gf.get_root_dir() / self.eff_folder / str(
-                self.efficiency_files[self.efficiency_files.index(file)])
-            self.efficiency_files_list.append(file_name)
-        EfficiencyDialog(self.efficiency_files_list, self)
+        eff_files = self.obj.get_efficiency_files(return_full_paths=True)
+        dialog = EfficiencyDialog(eff_files, self)
+        dialog.exec_()
 
     def __open_calibration_dialog(self):
         """

--- a/widgets/eff_plot.py
+++ b/widgets/eff_plot.py
@@ -28,24 +28,28 @@ along with this program (file named 'LICENCE').
 __author__ = "Aleksi Kauppi"
 __version__ = "2.0"
 
+from pathlib import Path
+from typing import List
+
 from PyQt5 import QtWidgets
 from PyQt5 import uic
 
 import widgets.gui_utils as gutils
+from widgets.base_tab import BaseTab
 from widgets.matplotlib.eff_plot import \
     MatplotlibEfficiencyWidget
 
 
 class EfficiencyDialog(QtWidgets.QDialog):
-    """Efficiency widget which is opened on top of detector settings.
+    """Efficiency dialog which is opened on top of detector settings.
     """
 
-    def __init__(self, efficiency_files, parent_widget=None):
-        """Inits widget.
+    def __init__(self, efficiency_files: List[Path], parent_widget: BaseTab = None):
+        """Inits dialog.
 
         Args:
-            parent: A TabWidget.
             efficiency_files: Paths to .eff files
+            parent_widget: Parent TabWidget.
         """
         super().__init__()
         uic.loadUi(gutils.get_ui_dir() / "ui_eff_plot.ui", self)

--- a/widgets/eff_plot.py
+++ b/widgets/eff_plot.py
@@ -36,7 +36,7 @@ from widgets.matplotlib.eff_plot import \
     MatplotlibEfficiencyWidget
 
 
-class EfficiencyDialog(QtWidgets.QWidget):
+class EfficiencyDialog(QtWidgets.QDialog):
     """Efficiency widget which is opened on top of detector settings.
     """
 


### PR DESCRIPTION
This PR fixes the issue #250 where efficiency plots weren't working by basically making two changes. 

- First change was changing [EfficiencyDialog](https://github.com/JYU-IBA/potku/blob/master/widgets/eff_plot.py#L39) from `QWidget` to `QDialog` so that `exec_` could be called
- Second change was to fix the files being plotted. Potku was trying to plot files from the last folder the user used when they added new efficiency files but this might cause crashes and other problems. Now it tries to plot files from `<request>/Default/Detector/Efficiency_files`