### PR TITLE
Add linear optimization to Optimize Recoils or Fluence

### DIFF
--- a/dialogs/simulation/optimization.py
+++ b/dialogs/simulation/optimization.py
@@ -169,7 +169,7 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
         self.efficiency_label.setEnabled(self.use_efficiency)
 
     def _verbose(self):
-        if self.optimization_verbose_box.isChecked() == True:
+        if self.optimization_verbose_box.isChecked():
             return True
         else:
             return False
@@ -260,20 +260,17 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
 
         if self.current_mode == OptimizationType.RECOIL:
             params = self.recoil_widget.get_properties()
+            optimize_by_area = self.recoil_widget.optimize_by_area
         else:
             params = self.fluence_widget.get_properties()
+            optimize_by_area = self.fluence_widget.optimize_by_area
 
         # TODO move following code to the result widget
-        if self.current_mode == OptimizationType.RECOIL:
-            nsgaii = Nsgaii(
-                element_simulation=elem_sim, measurement=measurement, cut_file=cut,
-                ch=self.ch, **params, use_efficiency=self.use_efficiency, optimize_by_area=self.recoil_widget.optimize_by_area,
-                verbose=self.verbose)
-        else:
-            nsgaii = Nsgaii(
-                element_simulation=elem_sim, measurement=measurement, cut_file=cut,
-                ch=self.ch, **params, use_efficiency=self.use_efficiency, optimize_by_area=self.fluence_widget.optimize_by_area,
-                verbose=self.verbose)
+        nsgaii = Nsgaii(
+            element_simulation=elem_sim, measurement=measurement,
+            cut_file=cut, ch=self.ch, **params,
+            use_efficiency=self.use_efficiency,
+            optimize_by_area=optimize_by_area, verbose=self.verbose)
 
         # Optimization running thread
         ct = CancellationToken()

--- a/dialogs/simulation/optimization.py
+++ b/dialogs/simulation/optimization.py
@@ -72,15 +72,12 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
         fset=bnd.set_selected_tree_item)
     auto_adjust_x: bool = bnd.bind("auto_adjust_x_box")
 
-    # TODO: Add PropertySavingWidget (& PropertyBindingWidget) support for
-    #   linear optimization settings. How to save both nsgaii and linear?
-
     @property
     def fluence_parameters(self) -> Dict[str, Any]:
         return self.nsgaii_fluence_widget.get_properties()
 
     @fluence_parameters.setter
-    def fluence_parameters(self, value: Dict[str, Any]):
+    def fluence_parameters(self, value: Dict[str, Any]) -> None:
         self.nsgaii_fluence_widget.set_properties(**value)
 
     @property
@@ -88,10 +85,32 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
         return self.nsgaii_recoil_widget.get_properties()
 
     @recoil_parameters.setter
-    def recoil_parameters(self, value: Dict[str, Any]):
+    def recoil_parameters(self, value: Dict[str, Any]) -> None:
         self.nsgaii_recoil_widget.set_properties(**value)
 
-    # TODO: Create property for current_mode
+    @property
+    def linear_fluence_parameters(self) -> Dict[str, Any]:
+        try:
+            return self.linear_fluence_widget.get_properties()
+        except AttributeError:
+            pass  # Backwards compatibility
+
+    @linear_fluence_parameters.setter
+    def linear_fluence_parameters(self, value: Dict[str, Any]) -> None:
+        self.linear_fluence_widget.set_properties(**value)
+
+    @property
+    def linear_recoil_parameters(self) -> Dict[str, Any]:
+        try:
+            return self.linear_recoil_widget.get_properties()
+        except AttributeError:
+            pass  # Backwards compatibility
+
+    @linear_recoil_parameters.setter
+    def linear_recoil_parameters(self, value: Dict[str, Any]) -> None:
+        self.linear_recoil_widget.set_properties(**value)
+
+    # TODO: Remember method & mode too
 
     def __init__(self, simulation: Simulation, parent):
         """Initializes an OptimizationDialog that displays various optimization

--- a/dialogs/simulation/optimization.py
+++ b/dialogs/simulation/optimization.py
@@ -263,22 +263,18 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
                 if self.current_mode == OptimizationType.RECOIL:
                     self.linear_recoil_widget.hide()
                     self.nsgaii_recoil_widget.show()
-                    self.nsgaii_recoil_widget.enable_sim_params()
                 else:
                     self.linear_fluence_widget.hide()
                     self.nsgaii_fluence_widget.show()
-                    self.nsgaii_fluence_widget.enable_sim_params()
             else:
                 self.current_method = OptimizationMethod.LINEAR
 
                 if self.current_mode == OptimizationType.RECOIL:
                     self.nsgaii_recoil_widget.hide()
                     self.linear_recoil_widget.show()
-                    self.linear_recoil_widget.enable_sim_params()
                 else:
                     self.nsgaii_fluence_widget.hide()
                     self.linear_fluence_widget.show()
-                    self.linear_fluence_widget.enable_sim_params()
 
     def choose_optimization_mode(self, button, checked):
         """Choose whether to optimize recoils or fluence. Show correct widget.

--- a/dialogs/simulation/optimization.py
+++ b/dialogs/simulation/optimization.py
@@ -147,6 +147,7 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
 
         self.mode_radios.addButton(self.fluenceRadioButton)
         self.mode_radios.addButton(self.recoilRadioButton)
+        self._enable_linear_fluence()
 
         gutils.fill_tree(
             self.simulationTreeWidget.invisibleRootItem(),
@@ -253,6 +254,27 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
         self.nsgaii_recoil_widget.upper_limits = max_x, prev_y
         self.linear_recoil_widget.upper_limits = max_x, prev_y
 
+    # TODO: Remove once linear fluence optimization is done
+    def _enable_linear_fluence(self) -> None:
+        """Disable fluence button if linear is selected or
+        linear button if fluence is selected. Otherwise enable both.
+        """
+        disabled_text = "Fluence optimization using linear optimization is not implemented yet"
+
+        if self.current_method == OptimizationMethod.LINEAR:
+            self.fluenceRadioButton.setEnabled(False)
+            self.fluenceRadioButton.setToolTip(disabled_text)
+        else:
+            self.fluenceRadioButton.setEnabled(True)
+            self.fluenceRadioButton.setToolTip("")
+
+        if self.current_mode == OptimizationType.FLUENCE:
+            self.linearRadioButton.setEnabled(False)
+            self.linearRadioButton.setToolTip(disabled_text)
+        else:
+            self.linearRadioButton.setEnabled(True)
+            self.linearRadioButton.setToolTip("")
+
     def choose_optimization_method(self, button, checked):
         """Choose whether to use NSGA-II or linear optimization method."""
         if checked:
@@ -275,6 +297,8 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
                 else:
                     self.nsgaii_fluence_widget.hide()
                     self.linear_fluence_widget.show()
+
+            self._enable_linear_fluence()
 
     def choose_optimization_mode(self, button, checked):
         """Choose whether to optimize recoils or fluence. Show correct widget.
@@ -299,6 +323,8 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
                 else:
                     self.linear_recoil_widget.hide()
                     self.linear_fluence_widget.show()
+
+            self._enable_linear_fluence()
 
     def start_optimization(self):
         """Find necessary cut file and make energy spectrum with it, and start

--- a/dialogs/simulation/optimization.py
+++ b/dialogs/simulation/optimization.py
@@ -147,7 +147,6 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
             self._enable_ok_button)
         self.verbose = False
         self.eff_file_check_box.clicked.connect(self._enable_efficiency_label)
-        # self.optimization_verbose_box.clicked.connect(self._verbose)
         self._update_efficiency_label()
 
         self.exec_()
@@ -176,12 +175,6 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
         """Enables or disables efficiency label.
         """
         self.efficiency_label.setEnabled(self.use_efficiency)
-
-    def _verbose(self):
-        if self.optimization_verbose_box.isChecked():
-            return True
-        else:
-            return False
 
     def _fill_measurement_widget(self):
         """Add calculated tof_list files to tof_list_tree_widget by

--- a/dialogs/simulation/optimization.py
+++ b/dialogs/simulation/optimization.py
@@ -239,6 +239,7 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
     def choose_optimization_method(self, button, checked):
         """Choose whether to use NSGA-II or linear optimization method."""
         if checked:
+            # TODO: Recognize the button without relying on constant text
             if button.text() == "NSGA-II (slow)":
                 self.current_method = OptimizationMethod.NSGAII
             else:
@@ -248,6 +249,7 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
         """Choose whether to optimize recoils or fluence. Show correct widget.
         """
         if checked:
+            # TODO: Recognize the button without relying on constant tex
             if button.text() == "Recoil":
                 self.current_mode = OptimizationType.RECOIL
                 self.fluence_widget.hide()

--- a/modules/enums.py
+++ b/modules/enums.py
@@ -31,6 +31,12 @@ from enum import Enum
 
 
 @enum.unique
+class OptimizationMethod(IntEnum):
+    NSGAII = 1
+    LINEAR = 2
+
+
+@enum.unique
 class OptimizationType(IntEnum):
     RECOIL = 1
     FLUENCE = 2

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -398,8 +398,6 @@ class LinearOptimization(opt.BaseOptimizer):
 
         self.prepare_measured_spectra()
 
-        # TODO: Smoothen the measured spectrum
-
         # TODO: Is this needed?
         self.combine_previous_erd_files()
 
@@ -419,9 +417,9 @@ class LinearOptimization(opt.BaseOptimizer):
         if self.optimization_type is OptimizationType.RECOIL:
             # Empty the list of optimization recoils
 
-            # Form points from first solution. First solution of first
-            # population will always cover the whole x axis range between
-            # lower and upper values -> MCERD never needs to be run again
+            # Form points from initial solution. The solution covers the
+            # whole x axis range between lower and upper values -> MCERD
+            # never needs to be run again
             self.element_simulation.optimization_recoils = [
                 self.form_recoil(initial_solution)
             ]

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -751,9 +751,11 @@ class LinearOptimization(opt.BaseOptimizer):
         solution = copy.deepcopy(self.solution)
         bounds = self._get_bounds()
 
-        optimized = self._fit_simulation(solution, bounds)
+        optimized1 = self._fit_simulation(solution, bounds)
+        optimized_copy = copy.deepcopy(optimized1)
+        optimized2 = self._fit_simulation(optimized_copy, bounds)
 
-        return optimized
+        return optimized1, optimized2
 
     # TODO: Change starting_solutions to starting_solution
     def start_optimization(self, starting_solutions=None,
@@ -777,13 +779,11 @@ class LinearOptimization(opt.BaseOptimizer):
 
         self.on_next(self._get_message(OptimizationState.RUNNING))
 
-        # result = self.solution  # TODO: Replace with _optimize
-        result = self._optimize()
-
+        result1, result2 = self._optimize()
         if self.optimization_type is OptimizationType.RECOIL:
             first_sol = self.solution
-            med_sol = self.solution  # TODO: Add something sensible here
-            last_sol = result
+            med_sol = result1
+            last_sol = result2
 
             self.element_simulation.optimization_recoils = [
                 self.form_recoil(first_sol, "optfirst"),

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -1,0 +1,414 @@
+"""
+Created on 20.09.2021
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2021 Tuomas Pitkänen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = "Tuomas Pitkänen"
+__version__ = "2.0"
+
+import subprocess
+from pathlib import Path
+from timeit import default_timer as timer
+from typing import Tuple
+
+import numpy as np
+import scipy as sp
+from scipy import optimize
+
+from . import file_paths as fp
+from . import general_functions as gf
+from . import math_functions as mf
+from . import optimization as opt
+from .element_simulation import ElementSimulation
+from .energy_spectrum import EnergySpectrum
+from .enums import OptimizationState, IonDivision
+from .enums import OptimizationType
+from .parsing import CSVParser
+
+
+# TODO:
+#  - documentation
+#  - unit tests
+#  - type annotations
+from .point import Point
+from .recoil_element import RecoilElement
+
+
+class LinearOptimization(opt.BaseOptimizer):
+    """Class that handles linear optimization for Optimize Recoils or
+    Fluence."""
+    pass
+
+    def __init__(self, element_simulation: ElementSimulation = None,
+                 sol_size=5, upper_limits=None, lower_limits=None,
+                 optimization_type=OptimizationType.RECOIL, recoil_type="box",
+                 number_of_processes=1, stop_percent=0.3, check_time=20,
+                 ch=0.025, measurement=None, cut_file=None, check_max=900,
+                 check_min=0, skip_simulation=False, use_efficiency=False,
+                 optimize_by_area=True, verbose=False,
+                 **kwargs):  # TODO: Remove kwargs when this is fully integrated
+        opt.BaseOptimizer.__init__(
+            self,
+            element_simulation=element_simulation,
+            upper_limits=upper_limits,
+            lower_limits=lower_limits,
+            optimization_type=optimization_type,
+            recoil_type=recoil_type,
+            number_of_processes=number_of_processes,
+            stop_percent=stop_percent,
+            check_time=check_time,
+            ch=ch,
+            measurement=measurement,
+            cut_file=cut_file,
+            check_max=check_max,
+            check_min=check_min,
+            skip_simulation=skip_simulation,
+            use_efficiency=use_efficiency,
+            verbose=verbose,
+            optimize_by_area=optimize_by_area
+        )
+        self.element_simulation = element_simulation
+
+        self.sol_size = sol_size
+
+        self.solution = None
+
+    def _prepare_optimization(self, initial_solution=None,
+                              cancellation_token=None,
+                              ion_division=IonDivision.BOTH):
+        """Performs internal preparation before optimization begins.
+        """
+        # TODO: Reduce copy-paste
+        self.element_simulation.optimization_recoils = []
+
+        if self.measurement is None:
+            raise ValueError(
+                "Optimization could not be prepared, no measurement defined.")
+
+        self.element_simulation.optimized_fluence = None
+
+        self.prepare_measured_spectra()
+
+        # TODO: Is this needed?
+        self.combine_previous_erd_files()
+
+        # Modify measurement file to match the simulation file in regards to
+        # the x coordinates -> they have matching values for ease of distance
+        # counting
+        self.modify_measurement()
+
+        if initial_solution is None:
+            initial_solution = self.initialize_solution()
+
+        if self.optimization_type is OptimizationType.RECOIL:
+            # Empty the list of optimization recoils
+
+            # Form points from first solution. First solution of first
+            # population will always cover the whole x axis range between
+            # lower and upper values -> MCERD never needs to be run again
+            self.element_simulation.optimization_recoils = [
+                self.form_recoil(initial_solution)
+            ]
+
+        if not self._skip_simulation:
+            self.run_initial_simulation(cancellation_token, ion_division)
+
+        self.solution = initial_solution
+
+        # TODO: Is something like this needed?
+        # self.population = self.evaluate_solutions(initial_pop)
+
+    def _get_spectra_difference(self, optim_espe) -> float:
+        """Returns the difference between spectra points or area.
+
+        self.optimize_by_area defines which result to get.
+        """
+        # Make spectra the same size
+        optim_espe, measured_espe = gf.uniform_espe_lists(
+            optim_espe, self.measured_espe,
+            channel_width=self.element_simulation.channel_width)
+
+        # Find the area between simulated and measured energy spectra
+        if self.optimize_by_area:
+            return mf.calculate_area(optim_espe, measured_espe)
+
+        # Difference between spectra
+        return sum(abs(opt_p[1] - mesu_p[1])
+                   for opt_p, mesu_p in zip(optim_espe, measured_espe))
+
+    def form_recoil(self, current_solution, name="") -> RecoilElement:
+        points = []
+
+        # TODO: implement properly: check sol_size and order points
+
+        size = current_solution.size // 2
+        for i in range(size):
+            point = Point(current_solution[i], current_solution[i + size])
+            points.append(point)
+
+        if not name:
+            name = "opt"
+
+        recoil = RecoilElement(
+            self.element_simulation.get_main_recoil().element, points,
+            color="red", name=name)
+
+        return recoil
+
+        # raise NotImplementedError
+
+    def initialize_solution(self):
+        if self.optimization_type is OptimizationType.RECOIL:
+            if len(self.upper_limits) < 2:
+                x_upper = 1.0
+                y_upper = 1.0
+            else:
+                x_upper = self.upper_limits[0]
+                y_upper = self.upper_limits[1]
+            if len(self.lower_limits) < 2:
+                x_lower = 0.0
+                y_lower = 0.0
+            else:
+                x_lower = self.lower_limits[0]
+                y_lower = self.lower_limits[1]
+
+            # TODO: Copy elif's and else's from Nsgaii
+            if self.rec_type == "box":
+                if self.sol_size == 5:  # 4-point recoil
+                    raise NotImplementedError
+                elif self.sol_size == 7:  # 6-point recoil
+                    raise NotImplementedError
+                else:
+                    raise ValueError(
+                        f"Unsupported sol_size {self.sol_size} for recoil type {self.rec_type}")
+            elif self.rec_type == "two-peak":  # Two-peak recoil
+                if self.sol_size == 9:  # First peak at the surface
+                    x_coords = np.array(
+                        [0.0, 30.0, 30.01, 59.99, 60.0, 89.99, 90.0, 120.0])
+                    y_coords = np.array(
+                        [0.5, 0.5, 0.0001, 0.0001, 0.5, 0.5, 0.0001, 0.0001])
+                elif self.sol_size == 11:  # First peak not at the surface
+                    raise NotImplementedError
+                else:
+                    raise ValueError(
+                        f"Unsupported sol_size {self.sol_size} for recoil type {self.rec_type}")
+            else:
+                raise ValueError(
+                    f"Unknown recoil type {self.rec_type}")
+
+            # TODO: Should x and y be combined or separate?
+            solution = np.append(x_coords, y_coords)
+
+        elif self.optimization_type is OptimizationType.FLUENCE:
+            raise NotImplementedError
+
+        else:
+            raise ValueError(
+                f"Unknown optimization type {self.optimization_type}")
+
+        return solution
+
+    def evaluate_solution(self, solution) -> float:
+        if self.optimization_type is OptimizationType.RECOIL:
+            self.element_simulation.optimization_recoils = [
+                self.form_recoil(solution)
+            ]
+
+            espe, _ = self.element_simulation.calculate_espe(
+                self.element_simulation.optimization_recoils[0],
+                verbose=self.verbose,
+                optimization_type=self.optimization_type,
+                ch=self.channel_width,
+                write_to_file=False)
+            objective_value = self._get_spectra_difference(espe)
+        elif self.optimization_type is OptimizationType.FLUENCE:
+            raise NotImplementedError
+        else:
+            raise ValueError(
+                f"Unknown optimization type {self.optimization_type}")
+
+        return objective_value
+
+    @staticmethod
+    def _optimize_func(points, *args) -> float:
+        # Function for scipy.optimize.minimize
+
+        # optimize.minimize doesn't support calling objects' methods directly
+        self = args[0]
+
+        # Function:
+        # fun(x, *args) -> float
+        # where x is an 1-D array with shape (n,) and args is a tuple of the
+        # fixed parameters needed to completely specify the function.
+
+        objective_value = self.evaluate_solution(points)
+
+        return objective_value
+
+    @staticmethod
+    def _check_optimize_end(points, state: optimize.OptimizeResult) -> bool:
+        """Checks if optimization can be ended.
+
+        Args:
+            points: current optimized points
+            state: current optimization state, with same fields as the result
+
+        Returns:
+            True if optimization can be ended, False otherwise
+        """
+        # TODO: remove
+        # print(points)
+        print(state.x)
+        print(state.fun, state.jac)
+        print(state.nfev, state.njev)
+        print()
+
+        # https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.OptimizeResult.html
+        # x: solution
+        # success: done/not
+        # status: termination status
+        # message: termination cause
+        # fun, jac, hess: values of objective function, Jacobian, Hessian
+        # hess_inv: inverse of Hessian, if available
+        # nfev, njev, nhev: number of evaluations
+        # nit: number of iterations
+        # maxcv: maximum constraint violation
+
+        # TODO: Better check
+        return state.fun < 12.0
+
+    def _get_bounds(self):
+        # TODO: Select by type, use real values
+        x_ub = 120.0
+        x_lb = 0.01
+
+        y_ub = 1.0000
+        y_lb = 0.0001
+
+        x_limits = [
+            (0.0, 0.0),
+            (x_lb, x_ub),
+            (x_lb, x_ub),
+            (x_lb, x_ub),
+            (x_lb, x_ub),
+            (x_lb, x_ub),
+            (x_lb, x_ub),
+            (120.0, 120.0)
+        ]
+
+        y_limits = [
+            (y_lb, y_ub),
+            (y_lb, y_ub),
+            (y_lb, y_ub),
+            (y_lb, y_ub),
+            (y_lb, y_ub),
+            (y_lb, y_ub),
+            (0.0001, 0.0001),
+            (y_lb, y_ub)
+        ]
+
+        lower_bounds = [x[0] for x in x_limits] + [y[0] for y in y_limits]
+        upper_bounds = [x[1] for x in x_limits] + [y[1] for y in y_limits]
+
+        return lower_bounds, upper_bounds
+
+    def _optimize(self):
+        # https://docs.scipy.org/doc/scipy/tutorial/optimize.html#constrained-minimization-of-multivariate-scalar-functions-minimize
+
+        func = self._optimize_func
+        initial = self.solution
+        args = (self,)
+        method = "trust-constr"  # trust-constr, SLSQP, COBYLA
+
+        lower_bounds, upper_bounds = self._get_bounds()
+        bounds = optimize.Bounds(lower_bounds, upper_bounds)
+        callback = self._check_optimize_end
+        options = {
+            "gtol": 0.0,  # 1e-16,  # Default: 1e-8
+            "xtol": 0.0   # 1e-16   # Default: 1e-8
+        }
+
+        # TODO: Would this work better with bigger initial values?
+        result = optimize.minimize(
+            func, initial, args=args, method=method, bounds=bounds,
+            callback=callback,  # TODO: tol(erance) instead of callback?
+            options=options)
+
+        # TODO: remove
+        print(result)
+        print(result.x)
+
+        return result.x
+
+        # TODO: Or this?
+        # https://docs.scipy.org/doc/scipy/tutorial/optimize.html#global-optimization
+
+    # TODO: Are starting_solutions and ion_division needed?
+    def start_optimization(self, starting_solutions=None,
+                           cancellation_token=None,
+                           ion_division=IonDivision.BOTH):
+        # TODO: Maybe?
+        # self.on_next(self._get_message(
+        #     OptimizationState.PREPARING, evaluatiations_left=self.evaluations))
+
+        try:
+            self._prepare_optimization(
+                starting_solutions, cancellation_token, ion_division)
+        except (OSError, ValueError, subprocess.SubprocessError) as e:
+            self.on_error(self._get_message(
+                OptimizationState.FINISHED,
+                error=f"Preparation for optimization failed: {e}"))
+            self.clean_up(cancellation_token)
+            return
+
+        pass
+
+        start_time = timer()
+
+        # self.on_next(self._get_message(
+        #     OptimizationState.RUNNING, evaluations_left=self.evaluations))
+
+        result = self._optimize()
+
+        if self.optimization_type is OptimizationType.RECOIL:
+            first_sol = self.solution
+            med_sol = self.solution  # TODO: Add something sensible here
+            last_sol = result
+
+            self.element_simulation.optimization_recoils = [
+                self.form_recoil(first_sol, "optfirst"),
+                self.form_recoil(med_sol, "optmed"),
+                self.form_recoil(last_sol, "optlast")
+            ]
+        else:
+            raise NotImplementedError
+
+        self.clean_up(cancellation_token)
+        self.element_simulation.optimization_results_to_file(self.cut_file)
+
+        self.on_completed(self._get_message(
+            OptimizationState.FINISHED,
+            evaluations_done="Unknown"))  # TODO: Proper value
+
+    # TODO: use this or a custom solver for scipy
+    def variation(self, solution: np.ndarray) -> np.ndarray:
+        # TODO: vary more than one solution at once
+        # TODO: "learn" from previous solutions
+        raise NotImplementedError

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -819,7 +819,7 @@ class LinearOptimization(opt.BaseOptimizer):
             else:
                 if prev_point.get_x() > cur_point.get_x():
                     raise ValueError(
-                        "Points are in wrong order in optimized solution")
+                        "Points are in wrong order in the optimized solution")
 
             prev_point = cur_point
 
@@ -854,8 +854,6 @@ class LinearOptimization(opt.BaseOptimizer):
             cancellation_token: token for cancelling the optimization
             ion_division: how to divide ions over multiple MCERD processes
         """
-        # TODO: Messages aren't visible, probably because they
-        #  don't carry information about evaluations
         self.on_next(self._get_message(OptimizationState.PREPARING))
 
         try:

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -171,6 +171,12 @@ class LinearOptimization(opt.BaseOptimizer):
         # Pick matching points, centered
         nms = nm_points[:mevs.shape[0]] + peak_width / 2
 
+        mevs_diff = np.diff(mevs)
+        if not np.all(mevs_diff <= 0):
+            # TODO: Remove non-monotonous parts from start and end.
+            #   Note that mevs_diff.shape[0] == mevs.shape[0] - 1
+            raise ValueError("Simulated MeV values were non-monotonous.")
+
         self._mev_to_nm_function = interpolate.interp1d(
             mevs, nms, fill_value="extrapolate", assume_sorted=True)
 

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -319,7 +319,16 @@ class LinearOptimization(opt.BaseOptimizer):
             solution = get_solution6(x, x + width)
             objective_values[i] = self.evaluate_solution(solution)
 
-        print(objective_values)
+        peak_i, peak_values = signal.find_peaks(-objective_values, width=5)
+        # TODO: Check if peak_i.size matches solution peak count
+
+        peaks = []
+        for i in range(peak_i.size):
+            left_i = peak_values["left_ips"][i]
+            right_i = peak_values["right_ips"][i]
+            peaks.append((left_i, right_i))
+            # solution = get_solution6(left_i, right_i)
+            # self.evaluate_solution(solution)
 
         # TODO: Find continous low error areas (widths)
         #       Find heights

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -62,7 +62,7 @@ class LinearOptimization(opt.BaseOptimizer):
                  number_of_processes=1, stop_percent=0.3, check_time=20,
                  ch=0.025, measurement=None, cut_file=None, check_max=900,
                  check_min=0, skip_simulation=False, use_efficiency=False,
-                 optimize_by_area=True, verbose=False,
+                 optimize_by_area=False, verbose=False,
                  **kwargs):  # TODO: Remove kwargs when this is fully integrated
         opt.BaseOptimizer.__init__(
             self,

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -862,7 +862,7 @@ class LinearOptimization(opt.BaseOptimizer):
         except (OSError, ValueError, subprocess.SubprocessError) as e:
             self.on_error(self._get_message(
                 OptimizationState.FINISHED,
-                error=f"Preparation for optimization failed: {e}"))
+                error=f"Preparation for optimization failed: {e}."))
             self.clean_up(cancellation_token)
             return
 

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -400,6 +400,8 @@ class LinearOptimization(opt.BaseOptimizer):
         return heights
 
     def _find_measured_valleys(self):
+        """Find valleys between peaks in measured espe.
+        """
         # TODO: Get include_start and include_end from solution shape.
         self.measured_valley_intervals = self._get_valley_intervals(
             self.measured_peak_info, include_start=True, include_end=False)
@@ -476,6 +478,8 @@ class LinearOptimization(opt.BaseOptimizer):
         return sum_diff
 
     def form_recoil(self, current_solution, name="") -> RecoilElement:
+        """Create a recoil element based on given solution.
+        """
         if not name:
             name = "opt"
 
@@ -487,6 +491,8 @@ class LinearOptimization(opt.BaseOptimizer):
         return recoil
 
     def initialize_solution(self):
+        """Create a starting solution.
+        """
         if self.optimization_type is OptimizationType.RECOIL:
             x_min, y_min = self.lower_limits
             x_max, y_max = self.upper_limits
@@ -567,6 +573,7 @@ class LinearOptimization(opt.BaseOptimizer):
         return solution
 
     def _run_solution(self, solution) -> Espe:
+        """Form a recoil based on the given solution and return its espe."""
         if self.optimization_type is OptimizationType.RECOIL:
             self.element_simulation.optimization_recoils = [
                 self.form_recoil(solution)
@@ -586,7 +593,10 @@ class LinearOptimization(opt.BaseOptimizer):
 
         return espe
 
+    # TODO: Unused, remove if not needed for fluence optimization
     def evaluate_solution(self, solution) -> float:
+        """Evaluate solution based on its difference from measured espe.
+        """
         espe = self._run_solution(solution)
 
         if self.optimization_type is OptimizationType.RECOIL:
@@ -654,6 +664,17 @@ class LinearOptimization(opt.BaseOptimizer):
         return resized_x, resized_y
 
     def _fit_simulation(self, solution: "BaseSolution"):
+        """Fit solution to simulation.
+
+        Fitting scales peak and valley heights, and widens peaks.
+        The fitting attempts to replicate the measured espe.
+
+        Args:
+            solution: starting point for fitting. solution is mutated.
+
+        Returns:
+            Fitted solution
+        """
         espe = self._run_solution(solution)
         espe_x, espe_y = split_espe(espe)
 
@@ -805,6 +826,8 @@ class LinearOptimization(opt.BaseOptimizer):
         return solution_corrected
 
     def _optimize(self):
+        """Run _fit_simulation several times.
+        """
         solution = copy.deepcopy(self.solution)
 
         try:
@@ -823,7 +846,14 @@ class LinearOptimization(opt.BaseOptimizer):
     # TODO: Change starting_solutions to starting_solution
     def start_optimization(self, starting_solutions=None,
                            cancellation_token=None,
-                           ion_division=IonDivision.BOTH):
+                           ion_division=IonDivision.BOTH) -> None:
+        """Run optimization from start to finish.
+
+        Args:
+            starting_solutions: possible starting solution(s)
+            cancellation_token: token for cancelling the optimization
+            ion_division: how to divide ions over multiple MCERD processes
+        """
         # TODO: Messages aren't visible, probably because they
         #  don't carry information about evaluations
         self.on_next(self._get_message(OptimizationState.PREPARING))

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -331,10 +331,12 @@ class LinearOptimization(opt.BaseOptimizer):
                 new_left = max(converted[0] + right_correction, self.lower_limits[0])
                 new_right = converted[-1] + right_correction
 
-            if new_left >= new_right:  # Equivalent to new_right < new_left
-                raise ValueError("Detected peak was too far to be corrected")
+            if new_left is not None and new_right is not None:
+                # Equivalent to new_right < new_left
+                if new_left >= new_right:
+                    raise ValueError(
+                        "Detected peak was too far to be corrected")
 
-            if new_left is not None or new_right is not None:
                 # TODO: Should new_middle be weighted?
                 #   It's not necessarily at the exact center in converted.
                 new_middle = (new_left + new_right) / 2

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -972,26 +972,27 @@ class Peak:
             scale_gap: whether to scale the gap between low and high points
                 (True) or keep it constant (False)
         """
-        center = self.center.get_x()
-        ll = self.ll.get_x()
         lh = self.lh.get_x()
         rh = self.rh.get_x()
-        rl = self.rl.get_x()
+        center = self.center.get_x()
 
         left_width = lh - center
-        left_gap = ll - lh
         right_width = rh - center
-        right_gap = rl - rh
-
         lh_new = center + left_width * factor
-        ll_new = lh_new + left_gap if not scale_gap else lh_new + left_gap * factor
         rh_new = center + right_width * factor
-        rl_new = rh_new + right_gap if not scale_gap else rh_new + right_gap * factor
 
-        self.ll.set_x(ll_new)
         self.lh.set_x(lh_new)
         self.rh.set_x(rh_new)
-        self.rl.set_x(rl_new)
+
+        if self.ll:
+            left_gap = self.ll.get_x() - lh
+            ll_new = lh_new + left_gap if not scale_gap else lh_new + left_gap * factor
+            self.ll.set_x(ll_new)
+
+        if self.rl:
+            right_gap = self.rl.get_x() - rh
+            rl_new = rh_new + right_gap if not scale_gap else rh_new + right_gap * factor
+            self.rl.set_x(rl_new)
 
     def scale_height(self, factor: float) -> None:
         """Scale peak's height (y values)

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -136,6 +136,11 @@ class LinearOptimization(opt.BaseOptimizer):
             solution = get_solution6(
                 nm, nm + sample_width, self.lower_limits, self.upper_limits)
             espe = self._run_solution(solution)
+            if not espe:
+                raise ValueError(
+                    "Ensure that there is simulated data for this recoil "
+                    "element before starting optimization.")
+
             espe_x, espe_y = split_espe(espe)
 
             try:
@@ -183,7 +188,6 @@ class LinearOptimization(opt.BaseOptimizer):
             Converted value (in nm)
         """
         if self._mev_to_nm_function is None:
-            # TODO: Better error type
             raise ValueError("Generate the MeV-to-nm conversion function first")
 
         return float(self._mev_to_nm_function(mev))
@@ -833,8 +837,6 @@ class LinearOptimization(opt.BaseOptimizer):
                 error=f"Preparation for optimization failed: {e}"))
             self.clean_up(cancellation_token)
             return
-
-        pass
 
         self.on_next(self._get_message(OptimizationState.RUNNING))
 

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -75,7 +75,7 @@ class LinearOptimization(opt.BaseOptimizer):
                 MeV-to-nm interpolation function. Compared to the average peak
                 prominence.
             fitting_iteration_count: number of fitting iterations
-            is_skewed: whether solution can be non-rectangular
+            is_skewed: whether solution shape can be non-rectangular
         """
         opt.BaseOptimizer.__init__(
             self,

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -149,9 +149,13 @@ class LinearOptimization(opt.BaseOptimizer):
         if self.optimize_by_area:
             return mf.calculate_area(optim_espe, measured_espe)
 
-        # Difference between spectra
-        return sum(abs(opt_p[1] - mesu_p[1])
-                   for opt_p, mesu_p in zip(optim_espe, measured_espe))
+        # Find the mean squared error between simulated and measured
+        # energy spectra y values
+        diff = [(opt_p[1] - mesu_p[1])**2
+                for opt_p, mesu_p in zip(optim_espe, measured_espe)]
+        sum_diff = sum(diff) / len(diff)
+
+        return sum_diff
 
     def form_recoil(self, current_solution, name="") -> RecoilElement:
         points = []

--- a/modules/nsgaii.py
+++ b/modules/nsgaii.py
@@ -22,34 +22,26 @@ __author__ = "Heta Rekilä \n Juhani Sundell \n Tuomas Pitkänen"
 __version__ = "2.0"
 
 import collections
-import math
 import os
 import subprocess
 from pathlib import Path
 from timeit import default_timer as timer
 
 import numpy as np
-import rx
-from rx import operators as ops
 
-from . import file_paths as fp
 from . import general_functions as gf
 from . import math_functions as mf
 from . import optimization as opt
 from .concurrency import CancellationToken
 from .element_simulation import ElementSimulation
-from .energy_spectrum import EnergySpectrum
 from .enums import IonDivision
 from .enums import OptimizationState
 from .enums import OptimizationType
-from .mcerd import MCERD
-from .observing import Observable
-from .parsing import CSVParser
 from .point import Point
 from .recoil_element import RecoilElement
 
 
-class Nsgaii(Observable):
+class Nsgaii(opt.BaseOptimizer):
     """
     Class that handles the NSGA-II optimization. This needs to handle both
     fluence and recoil element optimization. Recoil element optimization
@@ -71,60 +63,46 @@ class Nsgaii(Observable):
         """
         Initialize the NSGA-II algorithm with needed parameters and start
         running it.
+
+        Only NSGA-II-specific arguments are documented here. See
+        BaseOptimizer for general arguments.
+
         Args:
             gen: Number of generations to be done.
-            element_simulation: ElementSimulation object that is optimized.
             pop_size: Population size.
             sol_size: Amount of variables in one solution.
-            upper_limits: Upper limit(s) for variables in a solution.
-            lower_limits: Lower limit(s) for a variable in a solution.
-            optimization_type: Whether to optimize recoil or fluence.
-            recoil_type: Type of recoil: either "box" (4 points or 5),
-                "two-peak" (high areas at both ends of recoil, low in the
-                middle) or "free" (no limits to the shape of the recoil).
-                number_of_processes: How many processes are used in MCERD
-                calculation.
             cross_p: Crossover probability.
             mut_p: Mutation probability, should be something small.
-            stop_percent: When to stop running MCERD (based on the ratio in
-            average change between checkups).
-            check_time: Time interval for checking if MCERD should be stopped.
-            ch: Channel with for running get_espe.
-                used in comparing the simulated energy spectra.
             dis_c: Distribution index for crossover. When this is big,
                 a new solution is close to its parents.
             dis_m: Distribution for mutation.
-            check_max: Maximum time for running a simulation.
-            check_min: Minimum time for running a simulation.
-            skip_simulation: whether simulation is skipped altogether
-            use_efficiency: whether to use efficiency for pre-calculated
-                spectrum.
         """
         # TODO separate the two optimization types into two classes
-        Observable.__init__(self)
+        # Observable.__init__(self)
+        opt.BaseOptimizer.__init__(
+            self,
+            element_simulation=element_simulation,
+            upper_limits=upper_limits,
+            lower_limits=lower_limits,
+            optimization_type=optimization_type,
+            recoil_type=recoil_type,
+            number_of_processes=number_of_processes,
+            stop_percent=stop_percent,
+            check_time=check_time,
+            ch=ch,
+            measurement=measurement,
+            cut_file=cut_file,
+            check_max=check_max,
+            check_min=check_min,
+            skip_simulation=skip_simulation,
+            use_efficiency=use_efficiency,
+            verbose=verbose,
+            optimize_by_area=optimize_by_area
+        )
+
         self.evaluations = gen * pop_size
-        self.element_simulation = element_simulation  # Holds other needed
-        # information including recoil points and access to simulation settings
         self.pop_size = pop_size
         self.sol_size = sol_size
-        self.upper_limits = upper_limits
-        if not self.upper_limits:
-            self.upper_limits = [120, 1]
-        self.lower_limits = lower_limits
-        if self.lower_limits is None:
-            self.lower_limits = [0.01, 0.0001]
-        self.optimization_type = optimization_type
-        self.rec_type = recoil_type
-
-        # MCERD-specific parameters
-        self.number_of_processes = number_of_processes
-        self._skip_simulation = skip_simulation
-        self.stop_percent = stop_percent
-        self.check_time = check_time
-        self.check_max = check_max
-        self.check_min = check_min
-
-        self.channel_width = ch
 
         # Crossover and mutation parameters
         self.cross_p = cross_p
@@ -135,14 +113,7 @@ class Nsgaii(Observable):
         self.bit_length_x = 0
         self.bit_length_y = 0
 
-        self.measurement = measurement
-        self.cut_file = Path(cut_file)
-
         self.population = None
-        self.measured_espe = None
-        self.use_efficiency = use_efficiency
-        self.verbose = verbose
-        self.optimize_by_area = optimize_by_area
 
     def _prepare_optimization(self, initial_pop=None,
                               cancellation_token=None,
@@ -184,104 +155,6 @@ class Nsgaii(Observable):
             self.run_initial_simulation(cancellation_token, ion_division)
 
         self.population = self.evaluate_solutions(initial_pop)
-
-    def prepare_measured_spectra(self):
-        """Calculate measured spectra and parse it.
-
-        Optimized solutions are compared to the measured spectra.
-        """
-        EnergySpectrum.calculate_measured_spectra(
-            self.measurement, [self.cut_file], self.channel_width,
-            no_foil=True, use_efficiency=self.use_efficiency)
-
-        # TODO maybe just use the value returned by calc_spectrum?
-        # Add result files
-        hist_file = Path(self.measurement.get_energy_spectra_dir(),
-                         f"{self.cut_file.stem}.no_foil.hist")
-
-        parser = CSVParser((0, float), (1, float))
-        self.measured_espe = list(parser.parse_file(hist_file, method="row"))
-
-    def combine_previous_erd_files(self):
-        """Combine previous erd files to used as the starting point."""
-        erd_file_name = fp.get_erd_file_name(
-            self.element_simulation.get_main_recoil(), "combined",
-            optim_mode=self.optimization_type)
-
-        gf.combine_files(self.element_simulation.get_erd_files(),
-                         Path(self.element_simulation.directory,
-                              erd_file_name))
-
-    def run_initial_simulation(self, cancellation_token, ion_division):
-        """Run initial element simulation.
-        """
-        def stop_if_cancelled(
-                optim_ct: CancellationToken, mcerd_ct: CancellationToken):
-            optim_ct.stop_if_cancelled(mcerd_ct)
-            return mcerd_ct.is_cancellation_requested()
-
-        ct = CancellationToken()
-        observable = self.element_simulation.start(
-            self.number_of_processes, start_value=201,
-            optimization_type=self.optimization_type,
-            ct=ct, print_output=True, max_time=self.check_max,
-            ion_division=ion_division)
-
-        if observable is not None:
-            self.on_next(self._get_message(
-                OptimizationState.SIMULATING,
-                evaluations_left=self.evaluations))
-
-            ct_check = rx.timer(0, 0.2).pipe(
-                ops.take_while(lambda _: not stop_if_cancelled(
-                    cancellation_token, ct)),
-                ops.filter(lambda _: False),
-            )
-            # FIXME spectra_chk should only be performed when pre-simulation
-            #   has finished, otherwise there will be no new observed atoms
-            #   and the difference between the two spectra is 0
-            spectra_chk = rx.timer(self.check_min, self.check_time).pipe(
-                ops.merge(ct_check),
-                ops.map(lambda _: get_optim_espe(
-                    self.element_simulation, self.optimization_type)),
-                ops.scan(
-                    lambda prev_espe, next_espe: (prev_espe[1], next_espe),
-                    seed=[None, None]),
-                ops.map(lambda espes: calculate_change(
-                    *espes, self.element_simulation.channel_width)),
-                ops.take_while(
-                    lambda change: change > self.stop_percent and not
-                    ct.is_cancellation_requested()
-                ),
-                ops.do_action(
-                    on_completed=ct.request_cancellation)
-            )
-            merged = rx.merge(observable, spectra_chk).pipe(
-                ops.take_while(
-                    lambda x: not isinstance(x, dict) or x[
-                        MCERD.IS_RUNNING],
-                    inclusive=True)
-            )
-            # Simulation needs to finish before optimization can start
-            # so we run this synchronously.
-            # TODO use callback instead of running sync
-            merged.run()
-            # TODO should not have to call this manually
-            self.element_simulation._clean_up(ct)
-
-        else:
-            raise ValueError(
-                "Could not start simulation. Check that simulation is not "
-                "currently running.")
-
-    @staticmethod
-    def _get_message(state, **kwargs):
-        """Returns a dictionary with the state of the optimization and
-        other """
-        return {
-            "state": state,
-            **kwargs
-        }
 
     @staticmethod
     def crowding_distance(front_no, objective_values):
@@ -432,6 +305,8 @@ class Nsgaii(Observable):
         self.bit_length_x = len_of_x
         self.bit_length_y = len_of_y
 
+    # TODO: Move to BaseOptimizer (deal with self.sol_size)
+    # TODO: Reduce repetition
     def form_recoil(self, current_solution, name=""):
         """
         Form recoil based on solution size.
@@ -796,33 +671,6 @@ class Nsgaii(Observable):
                         + self.lower_limits
 
         return init_sols
-
-    def modify_measurement(self):
-        """
-        Modify measured energy spectrum to match the simulated in regards to
-        the x coordinates.
-        """
-        new = []
-        i = 0
-        # Add zero points to start and end to get correct mean values
-        first_x = self.measured_espe[0][0]
-        last_x = self.measured_espe[-1][0]
-
-        # TODO could use deque for quicker inserts
-        self.measured_espe.insert(
-            0, (round(first_x - self.element_simulation.channel_width, 4), 0.0))
-        self.measured_espe.append(
-            (round(last_x + self.element_simulation.channel_width, 4), 0.0))
-
-        while i < len(self.measured_espe) - 1:  # Do nothing to the last point
-            current_point = self.measured_espe[i]
-            next_point = self.measured_espe[i + 1]
-
-            new_x = round((next_point[0] + current_point[0]) / 2, 4)
-            new_y = round((next_point[1] + current_point[1]) / 2, 5)
-            new.append((new_x, new_y))
-            i += 1
-        self.measured_espe = new
 
     @staticmethod
     def nd_sort(pop_obj, n, r_n=np.inf):
@@ -1411,36 +1259,3 @@ def get_ys(y_lower, y_upper, pop_size, z=None, lower_limit_at_first=False):
             return np.array([low_limit, y_coords[0], y_coords[1],
                              y_coords[2], low_limit])
     return np.array([y_coords[0], y_coords[1], y_coords[2], low_limit])
-
-
-def get_optim_espe(elem_sim: ElementSimulation,
-                   optimization_type: OptimizationType):
-    if optimization_type is OptimizationType.RECOIL:
-        recoil = elem_sim.optimization_recoils[0]
-    else:
-        recoil = elem_sim.get_main_recoil()
-
-    espe, _ = elem_sim.calculate_espe(
-        recoil, optimization_type=optimization_type, write_to_file=False)
-    return espe
-
-
-def calculate_change(espe1, espe2, channel_width):
-    if not espe1 or not espe2:
-        return math.inf
-    uniespe1, uniespe2 = gf.uniform_espe_lists(
-        espe1, espe2, channel_width=channel_width)
-
-    # Calculate distance between energy spectra
-    # TODO move this to math_functions
-    sum_diff = 0
-    amount = 0
-    for point1, point2 in zip(uniespe1, uniespe2):
-        if point1[1] != 0 or point2[1] != 0:
-            amount += 1
-            sum_diff += abs(point1[1] - point2[1])
-    # Take average of sum_diff (non-zero diffs)
-    if amount:
-        return sum_diff / amount
-    else:
-        return math.inf

--- a/modules/nsgaii.py
+++ b/modules/nsgaii.py
@@ -116,7 +116,7 @@ class Nsgaii(Observable):
         self.optimization_type = optimization_type
         self.rec_type = recoil_type
 
-        # MCERd specific parameters
+        # MCERD-specific parameters
         self.number_of_processes = number_of_processes
         self._skip_simulation = skip_simulation
         self.stop_percent = stop_percent
@@ -131,7 +131,7 @@ class Nsgaii(Observable):
         self.dis_c = dis_c
         self.mut_p = mut_p
         self.dis_m = dis_m
-        self.__const_var_i = []
+        self._const_var_i = []
         self.bit_length_x = 0
         self.bit_length_y = 0
 
@@ -144,9 +144,9 @@ class Nsgaii(Observable):
         self.verbose = verbose
         self.optimize_by_area = optimize_by_area
 
-    def __prepare_optimization(self, initial_pop=None,
-                               cancellation_token=None,
-                               ion_division=IonDivision.BOTH):
+    def _prepare_optimization(self, initial_pop=None,
+                              cancellation_token=None,
+                              ion_division=IonDivision.BOTH):
         """Performs internal preparation before optimization begins.
         """
         self.element_simulation.optimization_recoils = []
@@ -276,9 +276,11 @@ class Nsgaii(Observable):
     def crowding_distance(front_no, objective_values):
         """Calculate crowding distance for each solution in the population, by
         the Pareto front it belongs to.
+
         Args:
             front_no: Front numbers for all solutions.
             objective_values: collection of objective values
+
         Return:
             Array that holds crowding distances for all solutions.
         """
@@ -323,8 +325,10 @@ class Nsgaii(Observable):
     def evaluate_solutions(self, sols):
         """
         Calculate objective function values for given solutions.
+
         Args:
              sols: List of solutions.
+
         Return:
             Solutions and their objective function values.
         """
@@ -379,7 +383,7 @@ class Nsgaii(Observable):
         """Calculates the objective values and returns them as a np.array.
         """
 
-        if self.optimize_by_area == True:
+        if self.optimize_by_area:
             obj_values = collections.namedtuple(
                 "ObjectiveValues", ("area", "sum_distance"))
             if optim_espe:
@@ -418,10 +422,12 @@ class Nsgaii(Observable):
     def form_recoil(self, current_solution, name=""):
         """
         Form recoil based on solution size.
+
         Args:
             current_solution: Solution which holds the information needed t
             form the recoil.
             name: Possible name for recoil element.
+
         Return:
              Recoil Element.
         """
@@ -605,6 +611,7 @@ class Nsgaii(Observable):
     def initialize_population(self):
         """
         Create a new starting population.
+
         Return:
             Created population with solutions and objective function values.
         """
@@ -628,13 +635,13 @@ class Nsgaii(Observable):
 
                     x_coords = get_xs(x_lower, x_upper, self.pop_size)
 
-                    self.__const_var_i.append(0)
-                    self.__const_var_i.append(4)
+                    self._const_var_i.append(0)
+                    self._const_var_i.append(4)
 
                     y_coords = get_ys(y_lower, y_upper, self.pop_size)
 
                     # Add y1 to constants
-                    self.__const_var_i.append(3)
+                    self._const_var_i.append(3)
 
                     # Sort x elements in ascending order
                     x_coords.sort(axis=1)
@@ -654,15 +661,15 @@ class Nsgaii(Observable):
                     x_coords = get_xs(x_lower, x_upper, self.pop_size, 2)
 
                     # Add x0 index to constant variables
-                    self.__const_var_i.append(0)
-                    self.__const_var_i.append(6)
+                    self._const_var_i.append(0)
+                    self._const_var_i.append(6)
 
                     y_coords = get_ys(y_lower, y_upper, self.pop_size,
                                       lower_limit_at_first=True)
 
                     # Add y0 and y2 to constants
-                    self.__const_var_i.append(1)
-                    self.__const_var_i.append(5)
+                    self._const_var_i.append(1)
+                    self._const_var_i.append(5)
 
                     # Sort x elements in ascending order
                     x_coords.sort(axis=1)
@@ -687,13 +694,13 @@ class Nsgaii(Observable):
                     x_coords = get_xs(x_lower, x_upper, self.pop_size, 3)
 
                     # Add x0 index to constant variables
-                    self.__const_var_i.append(0)
-                    self.__const_var_i.append(8)
+                    self._const_var_i.append(0)
+                    self._const_var_i.append(8)
 
                     y_coords = get_ys(y_lower, y_upper, self.pop_size, z=3)
 
                     # Add y3 to constants
-                    self.__const_var_i.append(7)
+                    self._const_var_i.append(7)
 
                     # Sort x elements in ascending order
                     x_coords.sort(axis=1)
@@ -717,15 +724,15 @@ class Nsgaii(Observable):
                     # (x0, y0, y4 and x5 constants)
                     x_coords = get_xs(x_lower, x_upper, self.pop_size, 4)
 
-                    self.__const_var_i.append(0)
-                    self.__const_var_i.append(10)
+                    self._const_var_i.append(0)
+                    self._const_var_i.append(10)
 
                     y_coords = get_ys(y_lower, y_upper, self.pop_size, z=3,
                                       lower_limit_at_first=True)
 
                     # Add y0 and y4 to constants
-                    self.__const_var_i.append(1)
-                    self.__const_var_i.append(9)
+                    self._const_var_i.append(1)
+                    self._const_var_i.append(9)
 
                     # Sort x elements in ascending order
                     x_coords.sort(axis=1)
@@ -808,10 +815,12 @@ class Nsgaii(Observable):
     def nd_sort(pop_obj, n, r_n=np.inf):
         """
         Sort population pop_obj according to non-domination.
+
         Args:
             pop_obj: Solutions (objective function values).
             n: Size of the current population to be sorted.
             r_n: How many elements fit inside the resulting population.
+
         Return:
             List with front numbers, corresponding to pop_obj indices, number of
             last front found.
@@ -878,9 +887,11 @@ class Nsgaii(Observable):
         """
         Select individuals to a new population based on crowded comparison
         operator.
+
         Args:
             population: Current intermediate population.
             pop_size: TODO
+
         Return:
             Next generation population.
         """
@@ -921,6 +932,7 @@ class Nsgaii(Observable):
         non-domination and crowding distance, creating offspring population
         by crossover and mutation, and selecting individuals to the new
         population.
+
         Args:
             starting_solutions: First solutions used in optimization. If
                 None, initialize new solutions.
@@ -931,7 +943,7 @@ class Nsgaii(Observable):
         self.on_next(self._get_message(
             OptimizationState.PREPARING, evaluations_left=self.evaluations))
         try:
-            self.__prepare_optimization(
+            self._prepare_optimization(
                 starting_solutions, cancellation_token, ion_division)
         except (OSError, ValueError, subprocess.SubprocessError) as e:
             self.on_error(self._get_message(
@@ -1081,8 +1093,10 @@ class Nsgaii(Observable):
         Generate offspring population using SBX and polynomial mutation for
         fluence, and simple binary crossover and binary
         mutation for recoil element points.
+
         Args:
             pop_sols: Solutions that are used to create offspring population.
+
         Return:
             Offspring size self.pop_size.
         """
@@ -1156,7 +1170,7 @@ class Nsgaii(Observable):
                     length = self.bit_length_x
                 else:
                     length = self.bit_length_y
-                if i in self.__const_var_i:
+                if i in self._const_var_i:
                     do_mutation[:, bit_index: bit_index + length] = False
                 bit_index += length
 
@@ -1193,7 +1207,7 @@ class Nsgaii(Observable):
                         b_i += self.bit_length_x
                         # Turn variable back into decimal
                         dec = round(int(str_bin, 2) / 100, 2)
-                        if h not in self.__const_var_i:
+                        if h not in self._const_var_i:
                             # Check of out of limits, not for constants
                             if dec < self.lower_limits[0]:
                                 dec = self.lower_limits[0]
@@ -1208,7 +1222,7 @@ class Nsgaii(Observable):
                         # Turn variable back into decimal
                         dec = round(int(str_bin, 2) / 10000, 4)
                         # Don't do anything to constants
-                        if h not in self.__const_var_i:
+                        if h not in self._const_var_i:
                             if dec < self.lower_limits[1]:
                                 dec = self.lower_limits[1]
                             if dec > self.upper_limits[1]:
@@ -1302,10 +1316,12 @@ def solution_to_binary(solution, bit_length_x, bit_length_y):
 def pick_final_solutions(objective_values, solutions, count=2):
     """Picks solutions from the given set of solutions based on the
     corresponding objective values.
+
     Args:
         objective_values: collections of objective values
         solutions: collections of solutions
         count: how many solutions to return (2 or 3)
+
     Returns:
         tuple of solutions. Either (first solution, last solution) or
         (first solution, median solution, last solution) depending on

--- a/modules/nsgaii.py
+++ b/modules/nsgaii.py
@@ -111,7 +111,7 @@ class Nsgaii(opt.BaseOptimizer):
 
         self.evaluations = gen * pop_size
         self.pop_size = pop_size
-        self.sol_size = sol_size
+        self.sol_size = sol_size  # TODO: Move to BaseOptimizer?
 
         # Crossover and mutation parameters
         self.cross_p = cross_p
@@ -268,11 +268,11 @@ class Nsgaii(opt.BaseOptimizer):
         # spectra
         area = mf.calculate_area(optim_espe, measured_espe)
 
-        # TODO: Move to mf.calculate_sum(line1, line2)
-        # Find the summed distance between the points of these two
-        # spectra
-        sum_diff = sum(abs(opt_p[1] - mesu_p[1])
-                       for opt_p, mesu_p in zip(optim_espe, measured_espe))
+        # Find the mean squared error between simulated and measured
+        # energy spectra y values
+        diff = [(opt_p[1] - mesu_p[1])**2
+                for opt_p, mesu_p in zip(optim_espe, measured_espe)]
+        sum_diff = sum(diff) / len(diff)
 
         return area, sum_diff
 

--- a/modules/nsgaii.py
+++ b/modules/nsgaii.py
@@ -67,7 +67,7 @@ class Nsgaii(opt.BaseOptimizer):
                  stop_percent=0.3, check_time=20, ch=0.025,
                  measurement=None, cut_file=None, dis_c=20,
                  dis_m=20, check_max=900, check_min=0, skip_simulation=False,
-                 use_efficiency=False, optimize_by_area=True, verbose=False):
+                 use_efficiency=False, optimize_by_area=False, verbose=False):
 
         """
         Initialize the NSGA-II algorithm with needed parameters and start

--- a/modules/nsgaii.py
+++ b/modules/nsgaii.py
@@ -824,7 +824,7 @@ class Nsgaii(opt.BaseOptimizer):
         except (OSError, ValueError, subprocess.SubprocessError) as e:
             self.on_error(self._get_message(
                 OptimizationState.FINISHED,
-                error=f"Preparation for optimization failed: {e}"))
+                error=f"Preparation for optimization failed: {e}."))
             self.clean_up(cancellation_token)
             return
 
@@ -872,7 +872,7 @@ class Nsgaii(opt.BaseOptimizer):
             except IndexError as e:
                 self.on_error(self._get_message(
                     OptimizationState.FINISHED,
-                    error=f"Failed to process offspring: {e}"))
+                    error=f"Failed to process offspring: {e}."))
                 self.clean_up(cancellation_token)
                 return
             # Evaluate offspring solutions to get offspring population

--- a/modules/nsgaii.py
+++ b/modules/nsgaii.py
@@ -118,7 +118,7 @@ class Nsgaii(opt.BaseOptimizer):
         self.dis_c = dis_c
         self.mut_p = mut_p
         self.dis_m = dis_m
-        self._const_var_i = []
+        self._const_var_i = []  # Indexes of constants
         self.bit_length_x = 0
         self.bit_length_y = 0
 
@@ -949,22 +949,7 @@ class Nsgaii(opt.BaseOptimizer):
             OptimizationState.FINISHED,
             evaluations_done=self.evaluations - evaluations))
 
-    def clean_up(self, cancellation_token: CancellationToken) -> None:
-        if cancellation_token is not None:
-            cancellation_token.request_cancellation()
-        self.delete_temp_files()
-
-    def delete_temp_files(self) -> None:
-        # Remove unnecessary opt.recoil file
-        for file in os.listdir(self.element_simulation.directory):
-            # TODO better method for determining which files to delete
-            if file.endswith("opt.recoil") or "optfl" in file:
-                try:
-                    os.remove(Path(self.element_simulation.directory, file))
-                except OSError:
-                    pass
-
-    def variation(self, pop_sols):
+    def variation(self, pop_sols: List[Solution]) -> PopulationNp:
         """
         Generate offspring population using SBX and polynomial mutation for
         fluence, and simple binary crossover and binary

--- a/modules/nsgaii.py
+++ b/modules/nsgaii.py
@@ -70,8 +70,7 @@ class Nsgaii(opt.BaseOptimizer):
                  use_efficiency=False, optimize_by_area=False, verbose=False):
 
         """
-        Initialize the NSGA-II algorithm with needed parameters and start
-        running it.
+        Initialize the NSGA-II optimizer.
 
         Only NSGA-II-specific arguments are documented here. See
         BaseOptimizer for general arguments.

--- a/modules/optimization.py
+++ b/modules/optimization.py
@@ -223,16 +223,6 @@ class BaseOptimizer(abc.ABC, Observable):
                 "Could not start simulation. Check that simulation is not "
                 "currently running.")
 
-    # TODO: maybe?
-    # @abc.abstractmethod
-    # def evaluate_solutions(self, sols):
-    #     pass
-
-    # TODO: maybe? How to deal with different call signatures?
-    # @abc.abstractmethod
-    # def get_objective_values(self, optim_espe):
-    #     pass
-
     def modify_measurement(self) -> None:
         """
         Modify measured energy spectrum to match the simulated in regards to

--- a/modules/optimization.py
+++ b/modules/optimization.py
@@ -62,7 +62,7 @@ class BaseOptimizer(abc.ABC, Observable):
                  number_of_processes=1, stop_percent=0.3, check_time=20,
                  ch=0.025, measurement=None, cut_file=None, check_max=900,
                  check_min=0, skip_simulation=False, use_efficiency=False,
-                 verbose=False, optimize_by_area=True) -> None:
+                 verbose=False, optimize_by_area=False) -> None:
         """Initialize a BaseOptimizer.
 
         Args:

--- a/modules/optimization.py
+++ b/modules/optimization.py
@@ -6,7 +6,8 @@ Potku is a graphical user interface for analyzation and
 visualization of measurement data collected from a ToF-ERD
 telescope. For physics calculations Potku uses external
 analyzation components.
-Copyright (C) 2013-2018 Heta Rekilä
+Copyright (C) 2013-2018 Heta Rekilä, 2020 Juhani Sundell,
+2021 Tuomas Pitkänen
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -24,10 +25,292 @@ along with this program (file named 'LICENCE').
 Optimization module contains functions used in NSGA2 algorithm
 """
 
-__author__ = "Heta Rekilä \n Juhani Sundell"
+__author__ = "Heta Rekilä \n Juhani Sundell \n Tuomas Pitkänen"
 __version__ = "2.0"
 
+import abc
+import math
+from pathlib import Path
+from typing import Any
+
 import numpy as np
+import rx
+from rx import operators as ops
+
+from . import file_paths as fp
+from . import general_functions as gf
+from .concurrency import CancellationToken
+from .element_simulation import ElementSimulation
+from .energy_spectrum import EnergySpectrum
+from .enums import IonDivision
+from .enums import OptimizationState
+from .enums import OptimizationType
+from .mcerd import MCERD
+from .observing import Observable
+from .parsing import CSVParser
+
+
+class BaseOptimizer(abc.ABC, Observable):
+    """A base class for optimizers.
+    """
+
+    def __init__(self, evaluations=None,
+                 element_simulation: ElementSimulation = None,
+                 upper_limits=None, lower_limits=None,
+                 optimization_type=OptimizationType.RECOIL, recoil_type="box",
+                 number_of_processes=1, stop_percent=0.3, check_time=20,
+                 ch=0.025, measurement=None, cut_file=None, check_max=900,
+                 check_min=0, skip_simulation=False, use_efficiency=False,
+                 verbose=False, optimize_by_area=True) -> None:
+        """Initialize a BaseOptimizer.
+
+        Args:
+            evaluations: Number of evaluations to be done.
+            element_simulation: ElementSimulation object that is optimized.
+            upper_limits: Upper limit(s) for variables in a solution.
+            lower_limits: Lower limit(s) for a variable in a solution.
+            recoil_type: Type of recoil: either "box" (4 points or 5),
+                "two-peak" (high areas at both ends of recoil, low in the
+                middle) or "free" (no limits to the shape of the recoil).
+                number_of_processes: How many processes are used in MCERD
+                calculation.
+            optimization_type: Whether to optimize recoil or fluence.
+            stop_percent: When to stop running MCERD (based on the ratio in
+                average change between checkups).
+            check_time: Time interval for checking if MCERD should be stopped.
+            ch: Channel with (?) for running get_espe.  # TODO: What?
+                used in comparing the simulated energy spectra.
+            check_max: Maximum time for running a simulation.
+            check_min: Minimum time for running a simulation.
+            skip_simulation: whether simulation is skipped altogether
+            use_efficiency: whether to use efficiency for pre-calculated
+                spectrum.
+        """
+        Observable.__init__(self)
+
+        # TODO: Remove evaluations? It's only used for a status message.
+        self.evaluations = evaluations
+        self.element_simulation = element_simulation  # Holds other needed
+        # information including recoil points and access to simulation settings
+
+        self.upper_limits = upper_limits
+        if not self.upper_limits:
+            self.upper_limits = [120, 1]
+        self.lower_limits = lower_limits
+        if not self.lower_limits:
+            self.lower_limits = [0.01, 0.0001]
+        self.optimization_type = optimization_type
+        self.rec_type = recoil_type
+
+        # MCERD-specific parameters
+        self.number_of_processes = number_of_processes
+        self._skip_simulation = skip_simulation
+        self.stop_percent = stop_percent
+        self.check_time = check_time
+        self.check_max = check_max
+        self.check_min = check_min
+
+        self.channel_width = ch
+
+        self.measurement = measurement
+        self.cut_file = Path(cut_file)
+
+        self.measured_espe = None
+        self.use_efficiency = use_efficiency
+        self.verbose = verbose
+        self.optimize_by_area = optimize_by_area
+
+    @staticmethod
+    def _get_message(state: Any, **kwargs) -> dict:
+        """Returns a dictionary with the state of the optimization and
+        other information.
+        """
+        return {
+            "state": state,
+            **kwargs
+        }
+
+    def prepare_measured_spectra(self) -> None:
+        """Calculate measured spectra and parse it.
+
+        Optimized solutions are compared to the measured spectra.
+        """
+        EnergySpectrum.calculate_measured_spectra(
+            self.measurement, [self.cut_file], self.channel_width,
+            no_foil=True, use_efficiency=self.use_efficiency)
+
+        # TODO maybe just use the value returned by calc_spectrum?
+        # Add result files
+        hist_file = Path(self.measurement.get_energy_spectra_dir(),
+                         f"{self.cut_file.stem}.no_foil.hist")
+
+        parser = CSVParser((0, float), (1, float))
+        self.measured_espe = list(parser.parse_file(hist_file, method="row"))
+
+    def combine_previous_erd_files(self) -> None:
+        """Combine previous erd files to used as the starting point."""
+        erd_file_name = fp.get_erd_file_name(
+            self.element_simulation.get_main_recoil(), "combined",
+            optim_mode=self.optimization_type)
+
+        gf.combine_files(self.element_simulation.get_erd_files(),
+                         Path(self.element_simulation.directory,
+                              erd_file_name))
+
+    def run_initial_simulation(self,
+                               cancellation_token: CancellationToken,
+                               ion_division: IonDivision) -> None:
+        """Run initial element simulation.
+        """
+
+        def stop_if_cancelled(
+                optim_ct: CancellationToken, mcerd_ct: CancellationToken):
+            optim_ct.stop_if_cancelled(mcerd_ct)
+            return mcerd_ct.is_cancellation_requested()
+
+        ct = CancellationToken()
+        observable = self.element_simulation.start(
+            self.number_of_processes, start_value=201,
+            optimization_type=self.optimization_type,
+            ct=ct, print_output=True, max_time=self.check_max,
+            ion_division=ion_division)
+
+        if observable is not None:
+            self.on_next(self._get_message(
+                OptimizationState.SIMULATING,
+                evaluations_left=self.evaluations))
+
+            ct_check = rx.timer(0, 0.2).pipe(
+                ops.take_while(lambda _: not stop_if_cancelled(
+                    cancellation_token, ct)),
+                ops.filter(lambda _: False),
+            )
+            # FIXME spectra_chk should only be performed when pre-simulation
+            #   has finished, otherwise there will be no new observed atoms
+            #   and the difference between the two spectra is 0
+            spectra_chk = rx.timer(self.check_min, self.check_time).pipe(
+                ops.merge(ct_check),
+                ops.map(lambda _: get_optim_espe(
+                    self.element_simulation, self.optimization_type)),
+                ops.scan(
+                    lambda prev_espe, next_espe: (prev_espe[1], next_espe),
+                    seed=[None, None]),
+                ops.map(lambda espes: calculate_change(
+                    *espes, self.element_simulation.channel_width)),
+                ops.take_while(
+                    lambda change: change > self.stop_percent and not
+                    ct.is_cancellation_requested()
+                ),
+                ops.do_action(
+                    on_completed=ct.request_cancellation)
+            )
+            merged = rx.merge(observable, spectra_chk).pipe(
+                ops.take_while(
+                    lambda x: not isinstance(x, dict) or x[
+                        MCERD.IS_RUNNING],
+                    inclusive=True)
+            )
+            # Simulation needs to finish before optimization can start
+            # so we run this synchronously.
+            # TODO use callback instead of running sync
+            merged.run()
+            # TODO should not have to call this manually
+            self.element_simulation._clean_up(ct)
+
+        else:
+            raise ValueError(
+                "Could not start simulation. Check that simulation is not "
+                "currently running.")
+
+    # TODO: maybe?
+    # @abc.abstractmethod
+    # def evaluate_solutions(self, sols):
+    #     pass
+
+    # TODO: maybe? How to deal with different call signatures?
+    # @abc.abstractmethod
+    # def get_objective_values(self, optim_espe):
+    #     pass
+
+    def modify_measurement(self) -> None:
+        """
+        Modify measured energy spectrum to match the simulated in regards to
+        the x coordinates.
+        """
+        new = []
+        i = 0
+        # Add zero points to start and end to get correct mean values
+        first_x = self.measured_espe[0][0]
+        last_x = self.measured_espe[-1][0]
+
+        # TODO could use deque for quicker inserts
+        self.measured_espe.insert(
+            0, (round(first_x - self.element_simulation.channel_width, 4), 0.0))
+        self.measured_espe.append(
+            (round(last_x + self.element_simulation.channel_width, 4), 0.0))
+
+        while i < len(self.measured_espe) - 1:  # Do nothing to the last point
+            current_point = self.measured_espe[i]
+            next_point = self.measured_espe[i + 1]
+
+            new_x = round((next_point[0] + current_point[0]) / 2, 4)
+            new_y = round((next_point[1] + current_point[1]) / 2, 5)
+            new.append((new_x, new_y))
+            i += 1
+        self.measured_espe = new
+
+    # TODO: Should starting_solutions be typed list or np.ndarray?
+    @abc.abstractmethod
+    def start_optimization(self, starting_solutions: list = None,
+                           cancellation_token: CancellationToken = None,
+                           ion_division=IonDivision.BOTH) -> None:
+        """Start the optimization.
+
+        Args:
+            starting_solutions: First solutions used in optimization. If
+                None, initialize new solutions.
+            cancellation_token: CancellationToken that is used to stop the
+                optimization before all evaluations have been evaluated.
+            ion_division: ion division mode used when simulating
+        """
+        pass
+
+    @abc.abstractmethod
+    def clean_up(self, cancellation_token: CancellationToken) -> None:
+        pass
+
+
+def get_optim_espe(elem_sim: ElementSimulation,
+                   optimization_type: OptimizationType):
+    if optimization_type is OptimizationType.RECOIL:
+        recoil = elem_sim.optimization_recoils[0]
+    else:
+        recoil = elem_sim.get_main_recoil()
+
+    espe, _ = elem_sim.calculate_espe(
+        recoil, optimization_type=optimization_type, write_to_file=False)
+    return espe
+
+
+def calculate_change(espe1, espe2, channel_width):
+    if not espe1 or not espe2:
+        return math.inf
+    uniespe1, uniespe2 = gf.uniform_espe_lists(
+        espe1, espe2, channel_width=channel_width)
+
+    # Calculate distance between energy spectra
+    # TODO move this to math_functions
+    sum_diff = 0
+    amount = 0
+    for point1, point2 in zip(uniespe1, uniespe2):
+        if point1[1] != 0 or point2[1] != 0:
+            amount += 1
+            sum_diff += abs(point1[1] - point2[1])
+    # Take average of sum_diff (non-zero diffs)
+    if amount:
+        return sum_diff / amount
+    else:
+        return math.inf
 
 
 def dominates(a, b):

--- a/ui_files/ui_optimization_fluence_params.ui
+++ b/ui_files/ui_optimization_fluence_params.ui
@@ -42,8 +42,95 @@
        <layout class="QVBoxLayout" name="verticalLayout_5">
         <item>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="5" column="1">
-           <widget class="QSpinBox" name="disMSpinBox">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Population size</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="populationSpinBox">
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>1000</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Generations</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="generationSpinBox">
+            <property name="maximum">
+             <number>999999</number>
+            </property>
+            <property name="value">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Crossover probability</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="crossoverProbDoubleSpinBox">
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.900000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Mutation probability</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="mutationProbDoubleSpinBox">
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Distribution index for crossover</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QSpinBox" name="disCSpinBox">
             <property name="value">
              <number>20</number>
             </property>
@@ -53,6 +140,26 @@
            <widget class="QLabel" name="label_3">
             <property name="text">
              <string>Distribution index for mutation</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="disMSpinBox">
+            <property name="value">
+             <number>20</number>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_36">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Prioritize optimization by:</string>
             </property>
            </widget>
           </item>
@@ -80,113 +187,6 @@
             </item>
            </layout>
           </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_36">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Prioritize optimization by:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="generationSpinBox">
-            <property name="maximum">
-             <number>999999</number>
-            </property>
-            <property name="value">
-             <number>5</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Population size</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="crossoverProbDoubleSpinBox">
-            <property name="decimals">
-             <number>2</number>
-            </property>
-            <property name="maximum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.900000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="populationSpinBox">
-            <property name="minimum">
-             <number>10</number>
-            </property>
-            <property name="maximum">
-             <number>1000</number>
-            </property>
-            <property name="value">
-             <number>100</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Generations</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Crossover probability</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="mutationProbDoubleSpinBox">
-            <property name="maximum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.010000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Distribution index for crossover</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Mutation probability</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QSpinBox" name="disCSpinBox">
-            <property name="value">
-             <number>20</number>
-            </property>
-           </widget>
-          </item>
          </layout>
         </item>
        </layout>
@@ -203,6 +203,30 @@
           <layout class="QVBoxLayout" name="verticalLayout_3">
            <item>
             <layout class="QGridLayout" name="gridLayout_2">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_7">
+               <property name="text">
+                <string>Processes</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QSpinBox" name="processesSpinBox">
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="value">
+                <number>1</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_11">
+               <property name="text">
+                <string>Stopping percent</string>
+               </property>
+              </widget>
+             </item>
              <item row="1" column="1">
               <widget class="QDoubleSpinBox" name="percentDoubleSpinBox">
                <property name="minimum">
@@ -226,37 +250,6 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="label_5">
-               <property name="text">
-                <string>Min. run time</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="QTimeEdit" name="maxTimeEdit">
-               <property name="maximumTime">
-                <time>
-                 <hour>23</hour>
-                 <minute>59</minute>
-                 <second>59</second>
-                </time>
-               </property>
-               <property name="currentSection">
-                <enum>QDateTimeEdit::HourSection</enum>
-               </property>
-               <property name="displayFormat">
-                <string>H.mm.ss</string>
-               </property>
-               <property name="time">
-                <time>
-                 <hour>0</hour>
-                 <minute>15</minute>
-                 <second>0</second>
-                </time>
-               </property>
-              </widget>
-             </item>
              <item row="2" column="1">
               <widget class="QSpinBox" name="timeSpinBox">
                <property name="maximum">
@@ -264,6 +257,13 @@
                </property>
                <property name="value">
                 <number>20</number>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>Min. run time</string>
                </property>
               </widget>
              </item>
@@ -291,27 +291,34 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_7">
-               <property name="text">
-                <string>Processes</string>
+             <item row="4" column="1">
+              <widget class="QTimeEdit" name="maxTimeEdit">
+               <property name="maximumTime">
+                <time>
+                 <hour>23</hour>
+                 <minute>59</minute>
+                 <second>59</second>
+                </time>
+               </property>
+               <property name="currentSection">
+                <enum>QDateTimeEdit::HourSection</enum>
+               </property>
+               <property name="displayFormat">
+                <string>H.mm.ss</string>
+               </property>
+               <property name="time">
+                <time>
+                 <hour>0</hour>
+                 <minute>15</minute>
+                 <second>0</second>
+                </time>
                </property>
               </widget>
              </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_11">
+             <item row="5" column="0">
+              <widget class="QLabel" name="label_24">
                <property name="text">
-                <string>Stopping percent</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QSpinBox" name="processesSpinBox">
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="value">
-                <number>1</number>
+                <string>Skip simulation</string>
                </property>
               </widget>
              </item>
@@ -328,13 +335,6 @@
                </property>
                <property name="tristate">
                 <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="label_24">
-               <property name="text">
-                <string>Skip simulation</string>
                </property>
               </widget>
              </item>

--- a/ui_files/ui_optimization_fluence_params.ui
+++ b/ui_files/ui_optimization_fluence_params.ui
@@ -66,15 +66,15 @@
               <property name="text">
                <string>Area</string>
               </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
              </widget>
             </item>
             <item>
              <widget class="QRadioButton" name="sumRadioButton">
               <property name="text">
                <string>Sum</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
               </property>
              </widget>
             </item>

--- a/ui_files/ui_optimization_linear_fluence_params.ui
+++ b/ui_files/ui_optimization_linear_fluence_params.ui
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>optimizationRecoilParameters</class>
+ <widget class="QWidget" name="optimizationRecoilParameters">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>947</width>
+    <height>638</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>947</width>
+    <height>250</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Start Optimization</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Fluence</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <layout class="QFormLayout" name="fluence_form_layout"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>Optimization</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <item>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Interpolation samples</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="sampleCountSpinBox">
+            <property name="toolTip">
+             <string>Number of samples taken to generate the MeV-to-nm interpolation function</string>
+            </property>
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>1000</number>
+            </property>
+            <property name="value">
+             <number>12</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Interpolation peak width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="sampleWidthDoubleSpinBox">
+            <property name="toolTip">
+             <string>Width of a sample's peak for the MeV-to-nm interpolation function. Must be smaller than (X_upper_limit - X_lower_limit) / Interpolation_samples</string>
+            </property>
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="minimum">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>10000.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>3.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Interpolation min prominence</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="sampleProminenceDoubleSpinBox">
+            <property name="toolTip">
+             <string>Minimum prominence (height) factor for a sample to be accepted in the MeV-to-nm interpolation function data points</string>
+            </property>
+            <property name="minimum">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Fitting iterations</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="fittingIterationCountSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Number of fitting iterations</string>
+            </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>999999</number>
+            </property>
+            <property name="value">
+             <number>2</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_25">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Skewed recoil</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QCheckBox" name="skewedCheckBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>If enabled, allows non-rectangular recoil shape</string>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+            <property name="tristate">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QGroupBox" name="simGroupBox">
+          <property name="title">
+           <string>Simulation</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <layout class="QGridLayout" name="gridLayout_2">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_7">
+               <property name="text">
+                <string>Processes</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QSpinBox" name="processesSpinBox">
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="value">
+                <number>1</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_11">
+               <property name="text">
+                <string>Stopping percent</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="percentDoubleSpinBox">
+               <property name="minimum">
+                <double>0.010000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.700000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_12">
+               <property name="text">
+                <string>Seconds between checks</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QSpinBox" name="timeSpinBox">
+               <property name="maximum">
+                <number>60</number>
+               </property>
+               <property name="value">
+                <number>20</number>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>Min. run time</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QTimeEdit" name="minTimeEdit">
+               <property name="currentSection">
+                <enum>QDateTimeEdit::HourSection</enum>
+               </property>
+               <property name="displayFormat">
+                <string>H.mm.ss</string>
+               </property>
+               <property name="time">
+                <time>
+                 <hour>0</hour>
+                 <minute>10</minute>
+                 <second>0</second>
+                </time>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="label_6">
+               <property name="text">
+                <string>Max. run time</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QTimeEdit" name="maxTimeEdit">
+               <property name="maximumTime">
+                <time>
+                 <hour>23</hour>
+                 <minute>59</minute>
+                 <second>59</second>
+                </time>
+               </property>
+               <property name="currentSection">
+                <enum>QDateTimeEdit::HourSection</enum>
+               </property>
+               <property name="displayFormat">
+                <string>H.mm.ss</string>
+               </property>
+               <property name="time">
+                <time>
+                 <hour>0</hour>
+                 <minute>15</minute>
+                 <second>0</second>
+                </time>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="label_24">
+               <property name="text">
+                <string>Skip simulation</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QCheckBox" name="skip_sim_chk_box">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="layoutDirection">
+                <enum>Qt::LeftToRight</enum>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="tristate">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui_files/ui_optimization_linear_fluence_params.ui
+++ b/ui_files/ui_optimization_linear_fluence_params.ui
@@ -161,7 +161,7 @@
              <string/>
             </property>
             <property name="text">
-             <string>Skewed recoil</string>
+             <string>Skewed distribution shape</string>
             </property>
            </widget>
           </item>
@@ -171,7 +171,7 @@
              <bool>false</bool>
             </property>
             <property name="toolTip">
-             <string>If enabled, allows non-rectangular recoil shape</string>
+             <string>If enabled, allows non-rectangular distribution shape</string>
             </property>
             <property name="layoutDirection">
              <enum>Qt::LeftToRight</enum>

--- a/ui_files/ui_optimization_linear_recoil_params.ui
+++ b/ui_files/ui_optimization_linear_recoil_params.ui
@@ -1,0 +1,483 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>optimizationRecoilParameters</class>
+ <widget class="QWidget" name="optimizationRecoilParameters">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>947</width>
+    <height>403</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>947</width>
+    <height>250</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Start Optimization</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QGroupBox" name="recoilGroupBox">
+       <property name="title">
+        <string>Recoil element</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>X upper limit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="upperXDoubleSpinBox">
+            <property name="maximum">
+             <double>999999999.990000009536743</double>
+            </property>
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="value">
+             <double>120.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>X lower limit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="lowerXDoubleSpinBox">
+            <property name="maximum">
+             <double>9999999999990000.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.010000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Y upper limit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="upperYDoubleSpinBox">
+            <property name="decimals">
+             <number>4</number>
+            </property>
+            <property name="maximum">
+             <double>3.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.000100000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Y lower limit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="lowerYDoubleSpinBox">
+            <property name="decimals">
+             <number>4</number>
+            </property>
+            <property name="maximum">
+             <double>3.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.000100000000000</double>
+            </property>
+            <property name="value">
+             <double>0.000100000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_16">
+            <property name="text">
+             <string>Recoil type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="recoilTypeComboBox">
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>0</height>
+             </size>
+            </property>
+            <item>
+             <property name="text">
+              <string>4-point box</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>6-point box</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>8-point two-peak</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10-point two-peak</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="optimGroupBox">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="title">
+        <string>Optimization</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Interpolation samples</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="sampleCountSpinBox">
+            <property name="toolTip">
+             <string>Number of samples taken to generate the MeV-to-nm interpolation function</string>
+            </property>
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>1000</number>
+            </property>
+            <property name="value">
+             <number>12</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Interpolation peak width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="sampleWidthDoubleSpinBox">
+            <property name="toolTip">
+             <string>Width of a sample's peak for the MeV-to-nm interpolation function. Must be smaller than (X_upper_limit - X_lower_limit) / Interpolation_samples</string>
+            </property>
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="minimum">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>10000.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>3.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Interpolation min prominence</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="sampleProminenceDoubleSpinBox">
+            <property name="toolTip">
+             <string>Minimum prominence (height) factor for a sample to be accepted in the MeV-to-nm interpolation function data points</string>
+            </property>
+            <property name="minimum">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Fitting iterations</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="fittingIterationCountSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Number of fitting iterations</string>
+            </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>999999</number>
+            </property>
+            <property name="value">
+             <number>2</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_25">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Skewed recoil</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QCheckBox" name="skewedCheckBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>If enabled, allows non-rectangular recoil shape</string>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+            <property name="tristate">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QGroupBox" name="simGroupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Simulation</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <item>
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_7">
+               <property name="text">
+                <string>Processes</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QSpinBox" name="processesSpinBox">
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="value">
+                <number>1</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_11">
+               <property name="text">
+                <string>Stopping percent</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="percentDoubleSpinBox">
+               <property name="minimum">
+                <double>0.010000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.300000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_12">
+               <property name="text">
+                <string>Seconds between checks</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QSpinBox" name="timeSpinBox">
+               <property name="maximum">
+                <number>60</number>
+               </property>
+               <property name="value">
+                <number>20</number>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_13">
+               <property name="text">
+                <string>Min. run time</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QTimeEdit" name="minTimeEdit">
+               <property name="currentSection">
+                <enum>QDateTimeEdit::HourSection</enum>
+               </property>
+               <property name="displayFormat">
+                <string>H.mm.ss</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="label_14">
+               <property name="text">
+                <string>Max. run time</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QTimeEdit" name="maxTimeEdit">
+               <property name="currentSection">
+                <enum>QDateTimeEdit::HourSection</enum>
+               </property>
+               <property name="displayFormat">
+                <string>H.mm.ss</string>
+               </property>
+               <property name="time">
+                <time>
+                 <hour>0</hour>
+                 <minute>10</minute>
+                 <second>0</second>
+                </time>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="label_24">
+               <property name="text">
+                <string>Skip simulation</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QCheckBox" name="skip_sim_chk_box">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="layoutDirection">
+                <enum>Qt::LeftToRight</enum>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+               <property name="tristate">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui_files/ui_optimization_linear_recoil_params.ui
+++ b/ui_files/ui_optimization_linear_recoil_params.ui
@@ -294,7 +294,7 @@
              <string/>
             </property>
             <property name="text">
-             <string>Skewed recoil</string>
+             <string>Skewed distribution shape</string>
             </property>
            </widget>
           </item>
@@ -304,7 +304,7 @@
              <bool>false</bool>
             </property>
             <property name="toolTip">
-             <string>If enabled, allows non-rectangular recoil shape</string>
+             <string>If enabled, allows non-rectangular distribution shape</string>
             </property>
             <property name="layoutDirection">
              <enum>Qt::LeftToRight</enum>

--- a/ui_files/ui_optimization_params.ui
+++ b/ui_files/ui_optimization_params.ui
@@ -97,7 +97,36 @@
         </spacer>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="methodGroupBox">
+         <property name="title">
+          <string/>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="QRadioButton" name="nsgaiiRadioButton">
+            <property name="text">
+             <string>NSGA-II (slow)</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="linearRadioButton">
+            <property name="text">
+             <string>Linear (fast)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="typeGroupBox">
          <property name="title">
           <string/>
          </property>

--- a/ui_files/ui_optimization_params.ui
+++ b/ui_files/ui_optimization_params.ui
@@ -73,9 +73,9 @@
        <item>
         <widget class="QCheckBox" name="optimization_verbose_box">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically
-           sets the X upper limit depending on the distribution of the selected
-           simulation element&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;
+           If enabled, displays get_espe's stderr messages in the console
+           &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
           </string>
          </property>
          <property name="text">

--- a/ui_files/ui_optimization_recoil_params.ui
+++ b/ui_files/ui_optimization_recoil_params.ui
@@ -265,15 +265,15 @@
               <property name="text">
                <string>Area</string>
               </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
              </widget>
             </item>
             <item>
              <widget class="QRadioButton" name="sumRadioButton">
               <property name="text">
                <string>Sum</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
               </property>
              </widget>
             </item>

--- a/ui_files/ui_optimization_recoil_params.ui
+++ b/ui_files/ui_optimization_recoil_params.ui
@@ -175,6 +175,66 @@
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
          <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Population size</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="populationSpinBox">
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>1000</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Generations</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="generationSpinBox">
+            <property name="maximum">
+             <number>999999</number>
+            </property>
+            <property name="value">
+             <number>50</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Crossover probability</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="crossoverProbDoubleSpinBox">
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.900000000000000</double>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="label_9">
             <property name="text">
@@ -195,63 +255,16 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="crossoverProbDoubleSpinBox">
-            <property name="decimals">
-             <number>2</number>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_23">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <property name="maximum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.900000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
             <property name="text">
-             <string>Population size</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Generations</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="populationSpinBox">
-            <property name="minimum">
-             <number>10</number>
-            </property>
-            <property name="maximum">
-             <number>1000</number>
-            </property>
-            <property name="value">
-             <number>100</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="generationSpinBox">
-            <property name="maximum">
-             <number>999999</number>
-            </property>
-            <property name="value">
-             <number>50</number>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Crossover probability</string>
+             <string>Prioritize optimization by:</string>
             </property>
            </widget>
           </item>
@@ -279,19 +292,6 @@
             </item>
            </layout>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_23">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Prioritize optimization by:</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </item>
        </layout>
@@ -314,58 +314,10 @@
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
             <layout class="QGridLayout" name="gridLayout_3">
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_12">
-               <property name="text">
-                <string>Seconds between checks</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="label_13">
-               <property name="text">
-                <string>Min. run time</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="QTimeEdit" name="maxTimeEdit">
-               <property name="currentSection">
-                <enum>QDateTimeEdit::HourSection</enum>
-               </property>
-               <property name="displayFormat">
-                <string>H.mm.ss</string>
-               </property>
-               <property name="time">
-                <time>
-                 <hour>0</hour>
-                 <minute>10</minute>
-                 <second>0</second>
-                </time>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_11">
-               <property name="text">
-                <string>Stopping percent</string>
-               </property>
-              </widget>
-             </item>
              <item row="0" column="0">
               <widget class="QLabel" name="label_7">
                <property name="text">
                 <string>Processes</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QSpinBox" name="timeSpinBox">
-               <property name="maximum">
-                <number>60</number>
-               </property>
-               <property name="value">
-                <number>20</number>
                </property>
               </widget>
              </item>
@@ -376,6 +328,13 @@
                </property>
                <property name="value">
                 <number>1</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_11">
+               <property name="text">
+                <string>Stopping percent</string>
                </property>
               </widget>
              </item>
@@ -395,6 +354,30 @@
                </property>
               </widget>
              </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_12">
+               <property name="text">
+                <string>Seconds between checks</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QSpinBox" name="timeSpinBox">
+               <property name="maximum">
+                <number>60</number>
+               </property>
+               <property name="value">
+                <number>20</number>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_13">
+               <property name="text">
+                <string>Min. run time</string>
+               </property>
+              </widget>
+             </item>
              <item row="3" column="1">
               <widget class="QTimeEdit" name="minTimeEdit">
                <property name="currentSection">
@@ -409,6 +392,23 @@
               <widget class="QLabel" name="label_14">
                <property name="text">
                 <string>Max. run time</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QTimeEdit" name="maxTimeEdit">
+               <property name="currentSection">
+                <enum>QDateTimeEdit::HourSection</enum>
+               </property>
+               <property name="displayFormat">
+                <string>H.mm.ss</string>
+               </property>
+               <property name="time">
+                <time>
+                 <hour>0</hour>
+                 <minute>10</minute>
+                 <second>0</second>
+                </time>
                </property>
               </widget>
              </item>

--- a/widgets/matplotlib/simulation/recoil_atom_optimization.py
+++ b/widgets/matplotlib/simulation/recoil_atom_optimization.py
@@ -87,7 +87,10 @@ class RecoilAtomOptimizationWidget(MatplotlibWidget):
         self.parent.recoilListLayout.addWidget(widget)
 
         # TODO move these to parent
-        btn_txts = "First solution", "Median solution", "Last solution"
+        # TODO could check if simulation method is NSGAII or Linear
+        #   and choose the button texts based on that
+        # TODO also gray out Pareto front radio button for Linear
+        btn_txts = "Initial solution", "Middle solution", "Last solution"
         for t in btn_txts:
             radio_btn = QtWidgets.QRadioButton(t)
             radio_btn.setEnabled(False)

--- a/widgets/simulation/optimization_linear_parameters.py
+++ b/widgets/simulation/optimization_linear_parameters.py
@@ -130,7 +130,13 @@ class LinearOptimizationParameterWidget(QtWidgets.QWidget,
         Args:
             *_: not used
         """
-        self.simGroupBox.setEnabled(not self.skip_simulation)
+        enable = not self.skip_simulation
+
+        self.processesSpinBox.setEnabled(enable)
+        self.percentDoubleSpinBox.setEnabled(enable)
+        self.timeSpinBox.setEnabled(enable)
+        self.minTimeEdit.setEnabled(enable)
+        self.maxTimeEdit.setEnabled(enable)
 
 
 class LinearOptimizationRecoilParameterWidget(LinearOptimizationParameterWidget):

--- a/widgets/simulation/optimization_linear_parameters.py
+++ b/widgets/simulation/optimization_linear_parameters.py
@@ -1,0 +1,205 @@
+"""
+Created on 18.01.2022
+
+Potku is a graphical user interface for analyzation and
+visualization of measurement data collected from a ToF-ERD
+telescope. For physics calculations Potku uses external
+analyzation components.
+Copyright (C) 2019 Heta Rekilä, 2020 Juhani Sundell; 2022 Tuomas Pitkänen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (file named 'LICENCE').
+"""
+__author__ = "Heta Rekilä \n Juhani Sundell \n Tuomas Pitkänen"
+__version__ = "2.0"
+
+
+import abc
+
+import widgets.binding as bnd
+import widgets.gui_utils as gutils
+
+from modules.nsgaii import OptimizationType
+
+from widgets.binding import PropertyBindingWidget
+from widgets.gui_utils import QtABCMeta
+from widgets.scientific_spinbox import ScientificSpinBox
+
+from PyQt5 import QtWidgets
+from PyQt5 import uic
+from PyQt5.QtCore import QLocale
+from PyQt5.QtCore import Qt
+
+
+# TODO: Reduce copy-paste
+
+_REC_TYPES = {
+    "4-point box": ("box", 5),
+    "6-point box": ("box", 7),
+    "8-point two-peak": ("two-peak", 9),
+    "10-point two-peak": ("two-peak", 11),
+}
+# Update _REC_TYPES to enable two-way binding based on solution sizes.
+_REC_TYPES.update({
+    (sol_size, key)
+    for key, (rtype, sol_size) in _REC_TYPES.items()
+})
+
+
+def recoil_from_combobox(instance, combobox):
+    """Converts the text value shown in combobox to a recoil type.
+    """
+    qbox = getattr(instance, combobox)
+    return _REC_TYPES[qbox.currentText()][0]
+
+
+def sol_size_from_combobox(instance, combobox):
+    """Converts the text value shown in combobox to solution size.
+    """
+    qbox = getattr(instance, combobox)
+    return _REC_TYPES[qbox.currentText()][1]
+
+
+def sol_size_to_combobox(instance, combobox, value):
+    """Sets the selected item in the given combobox based on the solution size.
+    """
+    qbox = getattr(instance, combobox)
+    try:
+        str_value = _REC_TYPES[value]
+        qbox.setCurrentIndex(qbox.findText(str_value, Qt.MatchFixedString))
+    except KeyError:
+        pass
+
+
+class LinearOptimizationParameterWidget(QtWidgets.QWidget,
+                                        PropertyBindingWidget,
+                                        abc.ABC,
+                                        metaclass=QtABCMeta):
+    """Abstract base class for linear recoil and fluence optimization parameter
+    widgets.
+    """
+    # Common properties
+    sample_count = bnd.bind("sampleCountSpinBox")
+    sample_width = bnd.bind("sampleWidthDoubleSpinBox")
+    sample_prominence = bnd.bind("sampleProminenceDoubleSpinBox")
+    fitting_iteration_count = bnd.bind("fittingIterationCountSpinBox")
+    is_skewed = bnd.bind("skewedCheckBox")
+    stop_percent = bnd.bind("percentDoubleSpinBox")
+    check_time = bnd.bind("timeSpinBox")
+    check_max = bnd.bind("maxTimeEdit")
+    check_min = bnd.bind("minTimeEdit")
+    skip_simulation = bnd.bind("skip_sim_chk_box")
+
+    @abc.abstractmethod
+    def optimization_type(self) -> OptimizationType:
+        pass
+
+    def __init__(self, ui_file, **kwargs):
+        """Initializes a optimization parameter widget.
+
+        Args:
+            ui_file: relative path to a ui_file
+            kwargs: values to show in the widget
+        """
+        super().__init__()
+        uic.loadUi(ui_file, self)
+
+        locale = QLocale.c()
+        self.sampleWidthDoubleSpinBox.setLocale(locale)
+        self.sampleProminenceDoubleSpinBox.setLocale(locale)
+        self.percentDoubleSpinBox.setLocale(locale)
+
+        self.skip_sim_chk_box.stateChanged.connect(self.enable_sim_params)
+        self.set_properties(**kwargs)
+        self.enable_sim_params()
+
+    def enable_sim_params(self, *_):
+        """Either enables or disables simulation parameters depending on the
+        value of skip_simulation parameter.
+
+        Args:
+            *_: not used
+        """
+        self.simGroupBox.setEnabled(not self.skip_simulation)
+
+
+class LinearOptimizationRecoilParameterWidget(LinearOptimizationParameterWidget):
+    """
+    Class that handles linear recoil optimization parameters' ui.
+    """
+
+    # Recoil specific properties
+    upper_limits = bnd.multi_bind(
+        ("upperXDoubleSpinBox", "upperYDoubleSpinBox")
+    )
+    lower_limits = bnd.multi_bind(
+        ("lowerXDoubleSpinBox", "lowerYDoubleSpinBox")
+    )
+
+    # sol_size values are unique (5, 7, 9 or 11) so they can be used in
+    # two-way binding
+    sol_size = bnd.bind("recoilTypeComboBox", fget=sol_size_from_combobox,
+                        fset=sol_size_to_combobox)
+    recoil_type = bnd.bind("recoilTypeComboBox", fget=recoil_from_combobox,
+                           twoway=False)
+
+    @property
+    def optimization_type(self) -> OptimizationType:
+        return OptimizationType.RECOIL
+
+    def __init__(self, **kwargs):
+        """Initialize the widget.
+
+        Args:
+            kwargs: property values to be shown in the widget.
+        """
+        ui_file = gutils.get_ui_dir() / "ui_optimization_linear_recoil_params.ui"
+        super().__init__(ui_file, **kwargs)
+        locale = QLocale.c()
+        self.upperXDoubleSpinBox.setLocale(locale)
+        self.lowerXDoubleSpinBox.setLocale(locale)
+        self.upperYDoubleSpinBox.setLocale(locale)
+        self.lowerYDoubleSpinBox.setLocale(locale)
+
+
+class LinearOptimizationFluenceParameterWidget(LinearOptimizationParameterWidget):
+    """
+    Class that handles linear fluence optimization parameters' ui.
+    """
+
+    # Fluence specific properties
+    upper_limits = bnd.bind("fluenceDoubleSpinBox")
+
+    @property
+    def lower_limits(self):
+        return 0.0
+
+    @property
+    def sol_size(self):
+        return 1
+
+    @property
+    def optimization_type(self) -> OptimizationType:
+        return OptimizationType.FLUENCE
+
+    def __init__(self, **kwargs):
+        """Initialize the widget.
+
+        Args:
+            kwargs: property values to be shown in the widget.
+        """
+        ui_file = gutils.get_ui_dir() / "ui_optimization_linear_fluence_params.ui"
+        super().__init__(ui_file, **kwargs)
+        self.fluenceDoubleSpinBox = ScientificSpinBox(10e12)
+        self.fluence_form_layout.addRow(
+            "Upper limit", self.fluenceDoubleSpinBox)

--- a/widgets/simulation/optimization_parameters.py
+++ b/widgets/simulation/optimization_parameters.py
@@ -131,7 +131,13 @@ class OptimizationParameterWidget(QtWidgets.QWidget,
         Args:
             *_: not used
         """
-        self.simGroupBox.setEnabled(not self.skip_simulation)
+        enable = not self.skip_simulation
+
+        self.processesSpinBox.setEnabled(enable)
+        self.percentDoubleSpinBox.setEnabled(enable)
+        self.timeSpinBox.setEnabled(enable)
+        self.minTimeEdit.setEnabled(enable)
+        self.maxTimeEdit.setEnabled(enable)
 
     # TODO: Make this work the same way as the rest of the radio buttons
     #  in Potku

--- a/widgets/simulation/optimization_parameters.py
+++ b/widgets/simulation/optimization_parameters.py
@@ -111,6 +111,8 @@ class OptimizationParameterWidget(QtWidgets.QWidget,
             kwargs: values to show in the widget
         """
         super().__init__()
+        self.optimize_by_area = True
+        self.radios = QtWidgets.QButtonGroup(self)
         uic.loadUi(ui_file, self)
 
         locale = QLocale.c()
@@ -133,10 +135,8 @@ class OptimizationParameterWidget(QtWidgets.QWidget,
     def radio_buttons(self):
         """Radio buttons for optimization parameters Sum and Area
         """
-        self.optimize_by_area = True
-        self.radios = QtWidgets.QButtonGroup(self)
         self.radios.buttonToggled[QtWidgets.QAbstractButton, bool].connect(
-        self.isChecked)
+            self.isChecked)
         self.radios.addButton(self.areaRadioButton)
         self.radios.addButton(self.sumRadioButton)
 
@@ -161,7 +161,7 @@ class OptimizationRecoilParameterWidget(OptimizationParameterWidget):
     lower_limits = bnd.multi_bind(
         ("lowerXDoubleSpinBox", "lowerYDoubleSpinBox")
     )
-    
+
     # sol_size values are unique (5, 7, 9 or 11) so they can be used in
     # two-way binding
     sol_size = bnd.bind("recoilTypeComboBox", fget=sol_size_from_combobox,
@@ -187,6 +187,7 @@ class OptimizationRecoilParameterWidget(OptimizationParameterWidget):
         self.lowerXDoubleSpinBox.setLocale(locale)
         self.upperYDoubleSpinBox.setLocale(locale)
         self.lowerYDoubleSpinBox.setLocale(locale)
+
 
 class OptimizationFluenceParameterWidget(OptimizationParameterWidget):
     """

--- a/widgets/simulation/optimization_parameters.py
+++ b/widgets/simulation/optimization_parameters.py
@@ -84,7 +84,7 @@ class OptimizationParameterWidget(QtWidgets.QWidget,
                                   PropertyBindingWidget,
                                   abc.ABC,
                                   metaclass=QtABCMeta):
-    """Abstract base class for recoil and fluence optimization parameter
+    """Abstract base class for NSGA-II recoil and fluence optimization parameter
     widgets.
     """
     # Common properties
@@ -122,6 +122,7 @@ class OptimizationParameterWidget(QtWidgets.QWidget,
 
         self.skip_sim_chk_box.stateChanged.connect(self.enable_sim_params)
         self.set_properties(**kwargs)
+        self.enable_sim_params()
 
     def enable_sim_params(self, *_):
         """Either enables or disables simulation parameters depending on the
@@ -153,7 +154,7 @@ class OptimizationParameterWidget(QtWidgets.QWidget,
 
 class OptimizationRecoilParameterWidget(OptimizationParameterWidget):
     """
-    Class that handles the recoil optimization parameters' ui.
+    Class that handles NSGA-II recoil optimization parameters' ui.
     """
 
     # Recoil specific properties
@@ -193,7 +194,7 @@ class OptimizationRecoilParameterWidget(OptimizationParameterWidget):
 
 class OptimizationFluenceParameterWidget(OptimizationParameterWidget):
     """
-    Class that handles the fluence optimization parameters' ui.
+    Class that handles NSGA-II fluence optimization parameters' ui.
     """
 
     # Fluence specific properties

--- a/widgets/simulation/optimization_parameters.py
+++ b/widgets/simulation/optimization_parameters.py
@@ -111,7 +111,7 @@ class OptimizationParameterWidget(QtWidgets.QWidget,
             kwargs: values to show in the widget
         """
         super().__init__()
-        self.optimize_by_area = True
+        self.optimize_by_area = False
         self.radios = QtWidgets.QButtonGroup(self)
         uic.loadUi(ui_file, self)
 
@@ -132,6 +132,8 @@ class OptimizationParameterWidget(QtWidgets.QWidget,
         """
         self.simGroupBox.setEnabled(not self.skip_simulation)
 
+    # TODO: Make this work the same way as the rest of the radio buttons
+    #  in Potku
     def radio_buttons(self):
         """Radio buttons for optimization parameters Sum and Area
         """

--- a/widgets/simulation/optimized_recoils.py
+++ b/widgets/simulation/optimized_recoils.py
@@ -122,15 +122,22 @@ class OptimizedRecoilsWidget(QtWidgets.QWidget, GUIObserver):
             text = f"{state}."
         self.progressLabel.setText(text)
 
-    def show_results(self, evaluations):
+    def show_results(self, evaluations=None, errors=None):
         """
-        Show optimized recoils and finished amount of evaluations.
+        Show optimized recoils. Optionally show finished amount of evaluations
+        and/or errors.
         """
+        progress_text = ""
+
         if evaluations is not None:
-            self.progressLabel.setText(
-                f"{evaluations} evaluations done. Finished.")
+            progress_text += f"{evaluations} evaluations done. Finished."
         else:
-            self.progressLabel.setText("Finished.")
+            progress_text += "Finished."
+
+        if errors is not None:
+            progress_text += str(errors)
+
+        self.progressLabel.setText(progress_text)
         self.recoil_atoms.show_recoils()
 
     def on_next_handler(self, msg):
@@ -155,4 +162,5 @@ class OptimizedRecoilsWidget(QtWidgets.QWidget, GUIObserver):
     def on_completed_handler(self, msg=None):
         if msg is not None:
             evaluations_done = msg.get("evaluations_done")
-            self.show_results(evaluations_done)
+            error = msg.get("error")
+            self.show_results(evaluations_done, errors=error)

--- a/widgets/simulation/optimized_recoils.py
+++ b/widgets/simulation/optimized_recoils.py
@@ -127,12 +127,10 @@ class OptimizedRecoilsWidget(QtWidgets.QWidget, GUIObserver):
         Show optimized recoils. Optionally show finished amount of evaluations
         and/or errors.
         """
-        progress_text = ""
-
         if evaluations is not None:
-            progress_text += f"{evaluations} evaluations done. Finished."
+            progress_text = f"{evaluations} evaluations done. Finished."
         else:
-            progress_text += "Finished."
+            progress_text = "Finished."
 
         if errors is not None:
             progress_text += str(errors)

--- a/widgets/simulation/optimized_recoils.py
+++ b/widgets/simulation/optimized_recoils.py
@@ -112,25 +112,33 @@ class OptimizedRecoilsWidget(QtWidgets.QWidget, GUIObserver):
             pass
         super().closeEvent(evnt)
 
-    def update_progress(self, evaluations, state):
+    def update_progress(self, state, evaluations=None):
         """
         Show calculated solutions in the widget.
         """
-        text = f"{evaluations} evaluations left. {state}."
+        if evaluations is not None:
+            text = f"{evaluations} evaluations left. {state}."
+        else:
+            text = f"{state}."
         self.progressLabel.setText(text)
 
     def show_results(self, evaluations):
         """
         Show optimized recoils and finished amount of evaluations.
         """
-        if evaluations:
+        if evaluations is not None:
             self.progressLabel.setText(
                 f"{evaluations} evaluations done. Finished.")
+        else:
+            self.progressLabel.setText("Finished.")
         self.recoil_atoms.show_recoils()
 
     def on_next_handler(self, msg):
         if "evaluations_left" in msg:
-            self.update_progress(msg["evaluations_left"], msg["state"])
+            self.update_progress(
+                msg["state"], evaluations=msg["evaluations_left"])
+        else:
+            self.update_progress(msg["state"])
         if "pareto_front" in msg:
             self.pareto_front.update_pareto_front(msg["pareto_front"])
 

--- a/widgets/simulation/optimized_recoils.py
+++ b/widgets/simulation/optimized_recoils.py
@@ -123,7 +123,9 @@ class OptimizedRecoilsWidget(QtWidgets.QWidget, GUIObserver):
         """
         Show optimized recoils and finished amount of evaluations.
         """
-        self.progressLabel.setText(f"{evaluations} evaluations done. Finished.")
+        if evaluations:
+            self.progressLabel.setText(
+                f"{evaluations} evaluations done. Finished.")
         self.recoil_atoms.show_recoils()
 
     def on_next_handler(self, msg):
@@ -144,4 +146,5 @@ class OptimizedRecoilsWidget(QtWidgets.QWidget, GUIObserver):
 
     def on_completed_handler(self, msg=None):
         if msg is not None:
-            self.show_results(msg["evaluations_done"])
+            evaluations_done = msg.get("evaluations_done")
+            self.show_results(evaluations_done)


### PR DESCRIPTION
Issue: #193

TODO:
- [ ] `_generate_mev_to_nm_function()`: handle the case where there are really short peaks at surface or between valid peaks (ignore missing peaks or use the longest streak of non-zeroish peaks)
- [ ] unit tests
- [ ] add an option to get the starting solution from user

Future TODO:
- [ ] remember which combination of *NSGA-II/Linear* and *recoil/fluence* is selected (not as simple as saving the other settings because the settings are saved using `PropertySavingWidget`, which doesn't work well on individual variables). As a quick fix, linear optimization could be the new default selection.
- [ ] add support for fluence optimization (currently only recoil optimization is supported)
- [ ] multi-thread initial espe runs (`ElementSimulation.calculate_espe()` uses multiple recoils for some reason, including `self.optimization_recoils[0]`. Check if a single recoil can be safely used instead.)
- [ ] customizable shape (number of peaks, rectangular or not, peak at surface or deeper)
- [ ] selectable number of iterations