### PR TITLE
Linear optimization improvements

### DIFF
--- a/ui_files/ui_optimization_linear_fluence_params.ui
+++ b/ui_files/ui_optimization_linear_fluence_params.ui
@@ -103,26 +103,26 @@
           <item row="2" column="0">
            <widget class="QLabel" name="label_9">
             <property name="text">
-             <string>Interpolation min prominence</string>
+             <string>Interpolation poly degree</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="sampleProminenceDoubleSpinBox">
+           <widget class="QSpinBox" name="samplePolynomialDegreeSpinBox">
             <property name="toolTip">
-             <string>Minimum prominence (height) factor for a sample to be accepted in the MeV-to-nm interpolation function data points</string>
+             <string>Degree of the polynomial used to fit the MeV-to-nm conversion function</string>
             </property>
             <property name="minimum">
-             <double>0.010000000000000</double>
+             <number>0</number>
             </property>
             <property name="maximum">
-             <double>1.000000000000000</double>
+             <number>20</number>
             </property>
             <property name="singleStep">
-             <double>0.010000000000000</double>
+             <number>1</number>
             </property>
             <property name="value">
-             <double>0.100000000000000</double>
+             <number>2</number>
             </property>
            </widget>
           </item>

--- a/ui_files/ui_optimization_linear_fluence_params.ui
+++ b/ui_files/ui_optimization_linear_fluence_params.ui
@@ -138,11 +138,8 @@
           </item>
           <item row="3" column="1">
            <widget class="QSpinBox" name="fittingIterationCountSpinBox">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
             <property name="toolTip">
-             <string>Number of fitting iterations</string>
+             <string>Number of fitting iterations. Initial solution does not count</string>
             </property>
             <property name="minimum">
              <number>0</number>

--- a/ui_files/ui_optimization_linear_recoil_params.ui
+++ b/ui_files/ui_optimization_linear_recoil_params.ui
@@ -271,11 +271,8 @@
           </item>
           <item row="3" column="1">
            <widget class="QSpinBox" name="fittingIterationCountSpinBox">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
             <property name="toolTip">
-             <string>Number of fitting iterations</string>
+             <string>Number of fitting iterations. Initial solution does not count</string>
             </property>
             <property name="minimum">
              <number>0</number>

--- a/ui_files/ui_optimization_linear_recoil_params.ui
+++ b/ui_files/ui_optimization_linear_recoil_params.ui
@@ -236,26 +236,26 @@
           <item row="2" column="0">
            <widget class="QLabel" name="label_9">
             <property name="text">
-             <string>Interpolation min prominence</string>
+             <string>Interpolation poly degree</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="sampleProminenceDoubleSpinBox">
+           <widget class="QSpinBox" name="samplePolynomialDegreeSpinBox">
             <property name="toolTip">
-             <string>Minimum prominence (height) factor for a sample to be accepted in the MeV-to-nm interpolation function data points</string>
+             <string>Degree of the polynomial used to fit the MeV-to-nm conversion function</string>
             </property>
             <property name="minimum">
-             <double>0.010000000000000</double>
+             <number>0</number>
             </property>
             <property name="maximum">
-             <double>1.000000000000000</double>
+             <number>20</number>
             </property>
             <property name="singleStep">
-             <double>0.010000000000000</double>
+             <number>1</number>
             </property>
             <property name="value">
-             <double>0.100000000000000</double>
+             <number>2</number>
             </property>
            </widget>
           </item>

--- a/widgets/simulation/optimization_linear_parameters.py
+++ b/widgets/simulation/optimization_linear_parameters.py
@@ -91,7 +91,7 @@ class LinearOptimizationParameterWidget(QtWidgets.QWidget,
     # Common properties
     sample_count = bnd.bind("sampleCountSpinBox")
     sample_width = bnd.bind("sampleWidthDoubleSpinBox")
-    sample_prominence = bnd.bind("sampleProminenceDoubleSpinBox")
+    sample_polynomial_degree = bnd.bind("samplePolynomialDegreeSpinBox")
     fitting_iteration_count = bnd.bind("fittingIterationCountSpinBox")
     is_skewed = bnd.bind("skewedCheckBox")
     stop_percent = bnd.bind("percentDoubleSpinBox")
@@ -116,7 +116,7 @@ class LinearOptimizationParameterWidget(QtWidgets.QWidget,
 
         locale = QLocale.c()
         self.sampleWidthDoubleSpinBox.setLocale(locale)
-        self.sampleProminenceDoubleSpinBox.setLocale(locale)
+        self.samplePolynomialDegreeSpinBox.setLocale(locale)
         self.percentDoubleSpinBox.setLocale(locale)
 
         self.skip_sim_chk_box.stateChanged.connect(self.enable_sim_params)


### PR DESCRIPTION
Issue: #193

- improved optimization accuracy: `numpy.polyfit` is far better than `scipy.interpolate.interp1d`
- improved optimization stability: doesn't need monotonous sampled values anymore
- prominences are used for statistical weights instead of as cut-off values
- added user-selectable fitting polynomial degree

Done (from task list):
- [x] `_generate_mev_to_nm_function()`: handle the case where there are really short peaks at surface or between valid peaks (ignore missing peaks or use the longest streak of non-zeroish peaks)
- [x] selectable number of iterations

Future TODO:
- [ ] multi-thread initial espe runs (`ElementSimulation.calculate_espe()` uses multiple recoils for some reason, including `self.optimization_recoils[0]`. Check if a single recoil can be safely used instead.)
- [ ] remember which combination of *NSGA-II/Linear* and *recoil/fluence* is selected (not as simple as saving the other settings because the settings are saved using `PropertySavingWidget`, which doesn't work well on individual variables). As a quick fix, linear optimization could be the new default selection.
- [ ] add an option to get the starting solution from user
- [ ] unit tests
- [ ] add support for fluence optimization (currently only recoil optimization is supported)
- [ ] customizable shape (number of peaks, rectangular or not, peak at surface or deeper)