### PR TITLE
Linear optimization improvements2

### DIFF
--- a/dialogs/simulation/optimization.py
+++ b/dialogs/simulation/optimization.py
@@ -151,17 +151,20 @@ class OptimizationDialog(QtWidgets.QDialog, PropertySavingWidget,
 
         self.method_radios.addButton(self.nsgaiiRadioButton)
         self.method_radios.addButton(self.linearRadioButton)
+        self.linearRadioButton.setChecked(True)
 
         self.mode_radios = QtWidgets.QButtonGroup(self)
         self.mode_radios.buttonToggled[QtWidgets.QAbstractButton, bool].connect(
             self.choose_optimization_mode)
         self.parametersLayout.addWidget(self.nsgaii_recoil_widget)
         self.parametersLayout.addWidget(self.nsgaii_fluence_widget)
+        self.nsgaii_recoil_widget.hide()
         self.nsgaii_fluence_widget.hide()
 
+        # TODO: Why does selecting linear_recoil_widget by default cause a
+        #   brief flash when opening the optimization dialog?
         self.parametersLayout.addWidget(self.linear_recoil_widget)
         self.parametersLayout.addWidget(self.linear_fluence_widget)
-        self.linear_recoil_widget.hide()
         self.linear_fluence_widget.hide()
 
         self.mode_radios.addButton(self.fluenceRadioButton)

--- a/modules/element_simulation.py
+++ b/modules/element_simulation.py
@@ -833,8 +833,10 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
             ch: Optional[float] = None,
             fluence: Optional[float] = None,
             optimization_type: Optional[OptimizationType] = None,
-            write_to_file: bool = True) -> Tuple[List, Optional[Path]]:
+            write_to_file: bool = True,
+            remove_recoil_file: bool = False) -> Tuple[List, Optional[Path]]:
         """Calculate the energy spectrum from the MCERD result file.
+
         Args:
             recoil_element: Recoil element.
             verbose: In terminal (disabled by default).
@@ -842,6 +844,9 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
             fluence: Fluence to use.
             optimization_type: Either recoil, fluence or None
             write_to_file: Whether spectrum is written to file
+            remove_recoil_file: Whether to remove temporary .recoil file
+                after getting the energy spectrum.
+
         Return:
             tuple consisting of spectrum data and espe file
         """
@@ -893,6 +898,10 @@ class ElementSimulation(Observable, Serializable, AdjustableSettings,
             recoil_file=recoil_file,
             verbose=verbose
         )
+
+        if remove_recoil_file:
+            recoil_file.unlink()
+
         # TODO returning espe_file is a bit pointless if write_to_file is
         #   False
         return spectrum, output_file

--- a/modules/linear_optimization.py
+++ b/modules/linear_optimization.py
@@ -484,7 +484,7 @@ class LinearOptimization(opt.BaseOptimizer):
 
         self.solution = initial_solution
 
-    def _get_spectra_difference(self, optim_espe) -> float:
+    def _get_spectra_difference(self, optim_espe: Espe) -> float:
         """Returns the difference between spectra points or area.
 
         self.optimize_by_area defines which result to get.
@@ -506,7 +506,7 @@ class LinearOptimization(opt.BaseOptimizer):
 
         return sum_diff
 
-    def form_recoil(self, current_solution, name="") -> RecoilElement:
+    def form_recoil(self, current_solution: "BaseSolution", name="") -> RecoilElement:
         """Create a recoil element based on given solution.
         """
         if not name:
@@ -644,7 +644,7 @@ class LinearOptimization(opt.BaseOptimizer):
 
         return espes
 
-    def _run_solution(self, solution) -> Espe:
+    def _run_solution(self, solution: "BaseSolution") -> Espe:
         """Form a recoil based on the given solution and return its espe."""
         if self.optimization_type is OptimizationType.RECOIL:
             self.element_simulation.optimization_recoils = [
@@ -667,7 +667,7 @@ class LinearOptimization(opt.BaseOptimizer):
         return espe
 
     # TODO: Unused, remove if not needed for fluence optimization
-    def evaluate_solution(self, solution) -> float:
+    def evaluate_solution(self, solution: "BaseSolution") -> float:
         """Evaluate solution based on its difference from measured espe.
         """
         espe = self._run_solution(solution)
@@ -684,7 +684,8 @@ class LinearOptimization(opt.BaseOptimizer):
 
     # TODO: Unify with BaseOptimizer.modify_measurement?
     def _resize_simulated_espe(
-            self, espe_x, espe_y, step_decimals=4) -> Tuple[np.ndarray, np.ndarray]:
+            self, espe_x: np.ndarray, espe_y: np.ndarray, step_decimals: int = 4
+    ) -> Tuple[np.ndarray, np.ndarray]:
         """Pad and/or slice simulated espe so that it has the same x axis
          values as the measured espe.
 
@@ -795,7 +796,7 @@ class LinearOptimization(opt.BaseOptimizer):
 
         return solution
 
-    def _fix_and_check_solution(self, solution) -> bool:
+    def _fix_and_check_solution(self, solution: "BaseSolution") -> bool:
         """Check and correct the solution if it has overlapping peaks or
         it exceeds the beginning or the end.
 


### PR DESCRIPTION
Issue: #193

Done (from task list):
- [x] multi-thread initial espe runs (`ElementSimulation.calculate_espe()` uses multiple recoils for some reason, including `self.optimization_recoils[0]`. Check if a single recoil can be safely used instead.)
- [x] remember which combination of *NSGA-II/Linear* and *recoil/fluence* is selected (not as simple as saving the other settings because the settings are saved using `PropertySavingWidget`, which doesn't work well on individual variables). As a quick fix, linear optimization could be the new default selection.

Future TODO:
- [ ] add an option to get the starting solution from user
- [ ] unit tests
- [ ] add support for fluence optimization (currently only recoil optimization is supported)
- [ ] customizable shape (number of peaks, rectangular or not, peak at surface or deeper)

The less significant recoil in `ElementSimulation.calculate_espe()` is either `self.optimization_recoils[0]` or `self.get_main_recoil()`. That one is only used to get the **.erd** data file name. The passed `recoil_element` argument is used for the **.recoil** name and contents (recoil point locations). I just added a dummy `ElementSimulation.optimization_recoils` list object to get around this multi-recoil issue in initial sampling. This could be done more elegantly, but it should work.

I changed the default optimization to *Linear & recoil*.