### PR TITLE
Remove unnecessary GlobalSettings inits

### DIFF
--- a/modules/get_espe.py
+++ b/modules/get_espe.py
@@ -48,16 +48,17 @@ class GetEspe:
     energy spectra coordinates.
     """
     __slots__ = "recoil_file", "beam_ion", "energy", "theta", \
-                "channel_width", "fluence", "timeres", "density", \
-                "solid", "erd_file", "tangle", "toflen", "_output_parser", \
-                "eres", "dtype"
+        "channel_width", "fluence", "timeres", "density", \
+        "solid", "erd_file", "tangle", "toflen", "_output_parser", \
+        "eres", "dtype"
 
     def __init__(self, beam_ion: str, energy: float, theta: float,
                  tangle: float, toflen: float, solid: float,
                  recoil_file: Path, erd_file: Path,
-                 reference_density: float = None,
+                 reference_density: float = GlobalSettings.DEFAULT_REF_DENSITY,
                  ch: float = 0.025, fluence: float = 5.00e+11,
-                 timeres: float = 250.0, eres: float = 25.0, dtype: str = "TOF"):
+                 timeres: float = 250.0, eres: float = 25.0,
+                 dtype: str = "TOF"):
         """Initializes the GetEspe class.
         Args:
             beam_ion: mass number and the chemical symbol of the primary ion
@@ -84,12 +85,8 @@ class GetEspe:
         self.timeres = timeres
         self.dtype = dtype
         self.eres = eres
+        self.density = reference_density
 
-        if reference_density is None:
-            self.density = GlobalSettings().get_default_reference_density()
-        else:
-            self.density = reference_density
-        
         self.solid = solid
         self.recoil_file = recoil_file
         self.erd_file = erd_file
@@ -162,7 +159,6 @@ class GetEspe:
                 espe_cmd, cwd=bin_dir, stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE, universal_newlines=True,
                 stderr=stderr) as espe_process:
-
             with espe_process.stdin as stdin:
                 for line in self.read_erd_files():
                     stdin.write(line)

--- a/modules/profile.py
+++ b/modules/profile.py
@@ -36,7 +36,6 @@ from typing import Set, Optional
 from .base import AdjustableSettings, Serializable
 from .ui_log_handlers import Logger
 
-REFERENCE_DENSITY = 4.98e22
 PROFILE_REFERENCE_DENSITY = 3.0
 
 

--- a/modules/recoil_element.py
+++ b/modules/recoil_element.py
@@ -48,7 +48,6 @@ from .point import Point
 from .parsing import CSVParser
 
 from modules.global_settings import GlobalSettings
-from .profile import REFERENCE_DENSITY
 
 from .enums import SimulationType
 
@@ -60,8 +59,8 @@ class RecoilElement(MCERDParameterContainer, Serializable):
     def __init__(self, element: Element, points: List[Point], color="red",
                  name="Default", rec_type=SimulationType.ERD,
                  description="These are default recoil settings.",
-                 reference_density=REFERENCE_DENSITY, modification_time=None,
-                 channel_width=None):
+                 reference_density=GlobalSettings.DEFAULT_REF_DENSITY,
+                 modification_time=None, channel_width=None):
         """Inits recoil element.
 
         Args:
@@ -79,11 +78,7 @@ class RecoilElement(MCERDParameterContainer, Serializable):
         self.prefix = element.get_prefix()
         self.description = description
         self.type = rec_type
-        
-        if reference_density is None:
-            self.reference_density = GlobalSettings().get_default_reference_density()
-        else:
-            self.reference_density = reference_density
+        self.reference_density = reference_density
             
         self.channel_width = channel_width
 


### PR DESCRIPTION
Remove unnecessary GlobalSettings inits, use GlobalSettings.DEFAULT_REF_DENSITY as default argument for reference_density. Remove unnecessary REFERENCE_DENSITY constant from profile.py.