### PR TITLE
Reads eff_dir with space in the path string

### DIFF
--- a/external/Potku-tof_list/tof_list.c
+++ b/external/Potku-tof_list/tof_list.c
@@ -703,11 +703,18 @@ void read_input(const char *input_file, Input *input)
             fprintf(stderr,"Faulty input file %s\n",input_file);
             exit(7);
          }
-         if(fscanf(fp,"%s",read) == 0){
+
+         // read the space before directory string
+         if(fgetc(fp) != ' ') {
             fprintf(stderr,"Faulty input file %s\n",input_file);
             exit(7);
          }
-		 sscanf(read,"%s",input->eff_dir);
+         // Read directory string, with max length of buffer
+         // if too long line, extra characters are not read.
+         if(fgets(input->eff_dir, EFF_DIR_LENGTH, fp) == NULL){
+            fprintf(stderr,"Faulty input file %s\n",input_file);
+            exit(7);
+         }
       }
    }
    fclose(fp);


### PR DESCRIPTION
Reads string with space in in. Does not work if string is longer than allocated buffer, but whole operation fails to use eff files anyway.