### PR TITLE
Fix element export crash and new simulations

### DIFF
--- a/modules/element.py
+++ b/modules/element.py
@@ -41,7 +41,7 @@ class Element(MCERDParameterContainer):
     """
     Element class that handles information about one element.
     """
-    def __init__(self, symbol, isotope=None, amount=0.0, RRectype=None):
+    def __init__(self, symbol, isotope=None, amount=0.0, RRectype="REC"):
         """Initializes an element object.
         Args:
               symbol: Two letter symbol of the element. E.g. 'He' for Helium.

--- a/modules/sample.py
+++ b/modules/sample.py
@@ -225,7 +225,7 @@ class Sample:
                         directory[len(name_prefix):len(name_prefix) + 2])
                     for file in os.listdir(Path(
                             self.request.directory, self.directory, directory)):
-                        if file.endswith(".simulation"):
+                        if file.endswith(".mccfg"):
                             all_simulations.append(Path(
                                 self.request.directory, self.directory,
                                 directory, file))

--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -574,56 +574,56 @@ class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
             measurement_file: path to a .measurement_file
         """
 
-        # if simulation_file is None:
-        #     simulation_file = self.path
-        #
-        # time_stamp = time.time()
-        # obj = {
-        #     "name": self.name,
-        #     "description": self.description,
-        #     "modification_time": time.strftime("%c %z %Z", time.localtime(
-        #         time_stamp)),
-        #     "modification_time_unix": time_stamp,
-        #     "use_request_settings": self.use_request_settings
-        # }
-        # with simulation_file.open("w") as file:
-        #     json.dump(obj, file, indent=4)
-        #
-        # if not self.use_request_settings:
-        #     # Save measurement settings parameters.
-        #     if measurement_file is None:
-        #         measurement_file = self.get_measurement_file()
-        #
-        #     general_obj = {
-        #         "name": self.measurement_setting_file_name,
-        #         "description":
-        #             self.measurement_setting_file_description,
-        #         "modification_time":
-        #             time.strftime("%c %z %Z", time.localtime(time_stamp)),
-        #         "modification_time_unix": time_stamp,
-        #     }
-        #
-        #     if measurement_file.exists():
-        #         with measurement_file.open("r") as mesu:
-        #             obj = json.load(mesu)
-        #         obj["general"] = general_obj
-        #     else:
-        #         obj = {
-        #             "general": general_obj
-        #         }
-        #
-        #     # Write measurement settings to file
-        #     with measurement_file.open("w") as file:
-        #         json.dump(obj, file, indent=4)
-        #
-        #     # Save Run object to file
-        #     self.run.to_file(measurement_file)
-        #     # Save Detector object to file
-        #     self.detector.to_file(self.detector.path)
-        #
-        #     # Save Target object to file
-        #     target_file = Path(self.directory, f"{self.target.name}.target")
-        #     self.target.to_file(target_file)
+        if simulation_file is None:
+            simulation_file = self.path
+
+        time_stamp = time.time()
+        obj = {
+            "name": self.name,
+            "description": self.description,
+            "modification_time": time.strftime("%c %z %Z", time.localtime(
+                time_stamp)),
+            "modification_time_unix": time_stamp,
+            "use_request_settings": self.use_request_settings
+        }
+        with simulation_file.open("w") as file:
+            json.dump(obj, file, indent=4)
+
+        if not self.use_request_settings:
+            # Save measurement settings parameters.
+            if measurement_file is None:
+                measurement_file = self.get_measurement_file()
+
+            general_obj = {
+                "name": self.measurement_setting_file_name,
+                "description":
+                    self.measurement_setting_file_description,
+                "modification_time":
+                    time.strftime("%c %z %Z", time.localtime(time_stamp)),
+                "modification_time_unix": time_stamp,
+            }
+
+            if measurement_file.exists():
+                with measurement_file.open("r") as mesu:
+                    obj = json.load(mesu)
+                obj["general"] = general_obj
+            else:
+                obj = {
+                    "general": general_obj
+                }
+
+            # Write measurement settings to file
+            with measurement_file.open("w") as file:
+                json.dump(obj, file, indent=4)
+
+            # Save Run object to file
+            self.run.to_file(measurement_file)
+            # Save Detector object to file
+            self.detector.to_file(self.detector.path)
+
+            # Save Target object to file
+            target_file = Path(self.directory, f"{self.target.name}.target")
+            self.target.to_file(target_file)
 
     def update_directory_references(self, new_dir: Path):
         """Update simulation's directory references.

--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -574,56 +574,56 @@ class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
             measurement_file: path to a .measurement_file
         """
 
-        if simulation_file is None:
-            simulation_file = self.path
-
-        time_stamp = time.time()
-        obj = {
-            "name": self.name,
-            "description": self.description,
-            "modification_time": time.strftime("%c %z %Z", time.localtime(
-                time_stamp)),
-            "modification_time_unix": time_stamp,
-            "use_request_settings": self.use_request_settings
-        }
-        with simulation_file.open("w") as file:
-            json.dump(obj, file, indent=4)
-
-        if not self.use_request_settings:
-            # Save measurement settings parameters.
-            if measurement_file is None:
-                measurement_file = self.get_measurement_file()
-
-            general_obj = {
-                "name": self.measurement_setting_file_name,
-                "description":
-                    self.measurement_setting_file_description,
-                "modification_time":
-                    time.strftime("%c %z %Z", time.localtime(time_stamp)),
-                "modification_time_unix": time_stamp,
-            }
-
-            if measurement_file.exists():
-                with measurement_file.open("r") as mesu:
-                    obj = json.load(mesu)
-                obj["general"] = general_obj
-            else:
-                obj = {
-                    "general": general_obj
-                }
-
-            # Write measurement settings to file
-            with measurement_file.open("w") as file:
-                json.dump(obj, file, indent=4)
-
-            # Save Run object to file
-            self.run.to_file(measurement_file)
-            # Save Detector object to file
-            self.detector.to_file(self.detector.path)
-
-            # Save Target object to file
-            target_file = Path(self.directory, f"{self.target.name}.target")
-            self.target.to_file(target_file)
+    #    if simulation_file is None:
+    #        simulation_file = self.path
+    #
+    #    time_stamp = time.time()
+    #    obj = {
+    #        "name": self.name,
+    #        "description": self.description,
+    #        "modification_time": time.strftime("%c %z %Z", time.localtime(
+    #            time_stamp)),
+    #        "modification_time_unix": time_stamp,
+    #        "use_request_settings": self.use_request_settings
+    #    }
+    #    with simulation_file.open("w") as file:
+    #        json.dump(obj, file, indent=4)
+    #
+    #    if not self.use_request_settings:
+    #        # Save measurement settings parameters.
+    #        if measurement_file is None:
+    #            measurement_file = self.get_measurement_file()
+    #
+    #        general_obj = {
+    #            "name": self.measurement_setting_file_name,
+    #            "description":
+    #                self.measurement_setting_file_description,
+    #            "modification_time":
+    #                time.strftime("%c %z %Z", time.localtime(time_stamp)),
+    #            "modification_time_unix": time_stamp,
+    #        }
+    #
+    #        if measurement_file.exists():
+    #            with measurement_file.open("r") as mesu:
+    #                obj = json.load(mesu)
+    #            obj["general"] = general_obj
+    #        else:
+    #            obj = {
+    #                "general": general_obj
+    #            }
+    #
+    #        # Write measurement settings to file
+    #        with measurement_file.open("w") as file:
+    #            json.dump(obj, file, indent=4)
+    #
+    #        # Save Run object to file
+    #        self.run.to_file(measurement_file)
+    #        # Save Detector object to file
+    #        self.detector.to_file(self.detector.path)
+    #
+    #        # Save Target object to file
+    #        target_file = Path(self.directory, f"{self.target.name}.target")
+    #        self.target.to_file(target_file)
 
     def update_directory_references(self, new_dir: Path):
         """Update simulation's directory references.

--- a/widgets/matplotlib/simulation/recoil_atom_distribution.py
+++ b/widgets/matplotlib/simulation/recoil_atom_distribution.py
@@ -1439,6 +1439,8 @@ class RecoilAtomDistributionWidget(MatplotlibWidget):
                 if not self.element_manager.has_element(element):
                     color = self.colormap[element.symbol]
                     self.add_element(element, color=color, **kwargs)
+        # Saving here prevents issues with mismatching data files
+        self.parent._save_target_and_recoils(True)
 
     def on_draw(self):
         """Draw method for matplotlib.


### PR DESCRIPTION
Fix crash that occurs in MCERD by pressing the export elements button on the target tab. Crash occured due to the exported elements not having a set recoiltype type, so I set the default value of an element object's RRectype to "REC". Also fix a follow-up bug where simulations break if user doesn't view the recoil atom distribution tab after exporting, but before closing Potku.

Also fixes new simulations not showing up by changing the sought filetype from .simulation to .mccfg.