### PR TITLE
Fix simulation specific settings and simulation discovery

### DIFF
--- a/modules/sample.py
+++ b/modules/sample.py
@@ -206,10 +206,10 @@ class Sample:
         return all_measurements
 
     def get_simulation_files(self) -> List[Path]:
-        """Get .simulation files inside simulation directories.
+        """Get .simulation or .mccfg files inside simulation directories.
 
         Return:
-            A list of full paths to .simulation files.
+            A list of full paths to .simulation or .mccfg files.
         """
         all_simulations = []    # TODO refactor
         name_prefix = Simulation.DIRECTORY_PREFIX
@@ -225,10 +225,11 @@ class Sample:
                         directory[len(name_prefix):len(name_prefix) + 2])
                     for file in os.listdir(Path(
                             self.request.directory, self.directory, directory)):
-                        if file.endswith(".mccfg"):
+                        if file.endswith(".mccfg") or file.endswith(".simulation"):
                             all_simulations.append(Path(
                                 self.request.directory, self.directory,
                                 directory, file))
+                            break
                 except ValueError:
                     # Couldn't add simulation directory because the number
                     # could not be read

--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -577,7 +577,11 @@ class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
     #    if simulation_file is None:
     #        simulation_file = self.path
     #
-    #    time_stamp = time.time()
+        time_stamp = time.time()
+        sim_config = ConfigManager()
+        sim_config.set_simulation(self)
+        sim_config.read_simulation()
+        sim_config.save()
     #    obj = {
     #        "name": self.name,
     #        "description": self.description,
@@ -589,41 +593,41 @@ class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
     #    with simulation_file.open("w") as file:
     #        json.dump(obj, file, indent=4)
     #
-    #    if not self.use_request_settings:
-    #        # Save measurement settings parameters.
-    #        if measurement_file is None:
-    #            measurement_file = self.get_measurement_file()
-    #
-    #        general_obj = {
-    #            "name": self.measurement_setting_file_name,
-    #            "description":
-    #                self.measurement_setting_file_description,
-    #            "modification_time":
-    #                time.strftime("%c %z %Z", time.localtime(time_stamp)),
-    #            "modification_time_unix": time_stamp,
-    #        }
-    #
-    #        if measurement_file.exists():
-    #            with measurement_file.open("r") as mesu:
-    #                obj = json.load(mesu)
-    #            obj["general"] = general_obj
-    #        else:
-    #            obj = {
-    #                "general": general_obj
-    #            }
-    #
-    #        # Write measurement settings to file
-    #        with measurement_file.open("w") as file:
-    #            json.dump(obj, file, indent=4)
-    #
-    #        # Save Run object to file
-    #        self.run.to_file(measurement_file)
-    #        # Save Detector object to file
-    #        self.detector.to_file(self.detector.path)
-    #
-    #        # Save Target object to file
-    #        target_file = Path(self.directory, f"{self.target.name}.target")
-    #        self.target.to_file(target_file)
+        if not self.use_request_settings:
+            # Save measurement settings parameters.
+            if measurement_file is None:
+                measurement_file = self.get_measurement_file()
+
+            general_obj = {
+                "name": self.measurement_setting_file_name,
+                "description":
+                    self.measurement_setting_file_description,
+                "modification_time":
+                    time.strftime("%c %z %Z", time.localtime(time_stamp)),
+                "modification_time_unix": time_stamp,
+            }
+
+            if measurement_file.exists():
+                with measurement_file.open("r") as mesu:
+                    obj = json.load(mesu)
+                obj["general"] = general_obj
+            else:
+                obj = {
+                    "general": general_obj
+                }
+
+            # Write measurement settings to file
+            with measurement_file.open("w") as file:
+                json.dump(obj, file, indent=4)
+
+            # Save Run object to file
+            self.run.to_file(measurement_file)
+            # Save Detector object to file
+            self.detector.to_file(self.detector.path)
+
+            # Save Target object to file
+            target_file = Path(self.directory, f"{self.target.name}.target")
+            self.target.to_file(target_file)
 
     def update_directory_references(self, new_dir: Path):
         """Update simulation's directory references.


### PR DESCRIPTION
I noticed that when not using request settings on the simulation side, the settings were not saved properly due to `modules/simulation.py` function `to_file` being commented out completely. Saving is fixed by adding few lines that use the `ConfigManager` class to save the actual simulation data and uncommenting the lines corresponding to simulation specific settings.

Additionally in PR #295 I changed the discovery of simulation files to be tied to .mccfg files instead of .simulation files. This lead to a problem with discovering old simulations that don't yet have a .mccfg file in them. I changed the discovery to look for both .simulation and .mccfg files and to break the for file loop once either one is dicovered in order to prevent one simulation being discovered twice.