### PR TITLE
Fix more saving issues

### DIFF
--- a/modules/simulation.py
+++ b/modules/simulation.py
@@ -587,6 +587,8 @@ class Simulation(SimulationLogger, ElementSimulationContainer, Serializable):
         time_stamp = time.time()
         sim_config = ConfigManager()
         sim_config.set_simulation(self)
+        if self.path.name.split('.')[-1] != 'simulation':
+            sim_config.set_config_file(self.path)
         sim_config.save()
     #    obj = {
     #        "name": self.name,

--- a/widgets/matplotlib/simulation/composition.py
+++ b/widgets/matplotlib/simulation/composition.py
@@ -517,7 +517,10 @@ class TargetCompositionWidget(_CompositionWidget):
         if dialog.isOk:
             old_target = Path(self.simulation.directory,
                               f"{self.target.name}.target")
-            os.remove(old_target)
+            try:
+                os.remove(old_target)
+            except FileNotFoundError:
+                pass
             self.target.name = dialog.name
             self.target.description = dialog.description
             self.parent.targetNameLabel.setText(self.target.name)

--- a/widgets/simulation/tab.py
+++ b/widgets/simulation/tab.py
@@ -213,7 +213,7 @@ class SimulationTabWidget(BaseTab):
                     lines = save_file.readlines()
                 if not lines:
                     return
-                used_files = [Path(f) for f in lines[0].strip().split("\t")]
+                used_files = [Path(f) for f in lines[0].strip().split("\t") if f != '']
                 used_files_confirmed = []
                 for u_f in used_files:
                     if u_f.exists():


### PR DESCRIPTION
Fixes multiple saving-related issues.

Firstly on MCERD side opening saved widgets of energy spectra caused Potku to crash as occasionally Path objects were created from empty strings, which point to current folder, i.e.  Path('') is basically pointing to directory ./. This caused crashing issues.

Secondly frequently changing settings in MCERD side relating to the target could lead to a situation where Potku tries to delete a non-existent file. I put the deletion in a try-expect block to prevent crashing + nuking the target due to the crash.

Finally there was an issue, where if multiple simulations were open simultaneously, the saving of the simulations could save the settings to a wrong file. This was fixed by properly updating the file where config_manager is pointed to in the to_file method of Simulation class.