### PR TITLE
Show actually used eff file

### DIFF
--- a/dialogs/dialog_functions.py
+++ b/dialogs/dialog_functions.py
@@ -120,7 +120,7 @@ def get_efficiency_text_cuts(cuts: Iterable[Path], detector: Detector) -> str:
 
     if eff_files_used:
         eff_file_txt = "\t\n".join(str(f) for f in eff_files_used)
-        return f"Efficiency files used:\t\n{eff_file_txt}"
+        return f"Efficiency files found:\t\n{eff_file_txt}"
 
     return "No efficiency files."
 

--- a/modules/depth_files.py
+++ b/modules/depth_files.py
@@ -99,9 +99,29 @@ class DepthFileGenerator:
         bin_dir = gf.get_bin_dir()
         tof, erd = self.get_command()
         # Pipe the output from tof_list to erd_depth
-        tof_process = subprocess.Popen(tof, cwd=bin_dir, stdout=subprocess.PIPE)
+        tof_process = subprocess.Popen(tof, cwd=bin_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        tof_stdout, tof_stderr = tof_process.communicate()
+
+        eff_filename = None
+        used_eff_files = []
+        used_eff_filename = self._output_path.parents[0] / 'used_eff_files.txt'
+        lines = tof_stderr.decode().split('\n')
+        for n, _ in enumerate(lines):
+            if lines[n][0:22] == "Used efficiency file: ":
+                eff_filename = lines[n][22:].replace('\\','/').split('/')[-1]
+                if lines[n+1].split()[0] == "Got":
+                    used_eff_files.append(eff_filename)
+        try:
+            with open(used_eff_filename, "w") as f:
+                f.write("Efficiency files used:\n")
+                for line in used_eff_files:
+                    f.write(line)
+                    f.write("\n")
+        except Exception as e:
+            print(f"Error: {e}")
+
         ret = subprocess.run(
-            erd, cwd=bin_dir, stdin=tof_process.stdout).returncode
+            erd, cwd=bin_dir, input=tof_stdout).returncode
         if ret != 0:
             print(f"tof_list|erd_depth pipeline returned an error code: {ret}")
 

--- a/widgets/matplotlib/measurement/depth_profile.py
+++ b/widgets/matplotlib/measurement/depth_profile.py
@@ -106,6 +106,8 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
         self.used_eff_str = used_eff_str
         self.eff_text = None
 
+        self.used_eff_file = parent.output_dir / 'used_eff_files.txt'
+
         # Set default filename for saving figure
         default_filename = "Depth_profile_" + parent.measurement.name
         self.canvas.get_default_filename = lambda: default_filename
@@ -313,7 +315,11 @@ class MatplotlibDepthProfileWidget(MatplotlibWidget):
         # If "Show used efficiency files" is checked and text-object is not
         # yet created.
         if self._show_eff_files and self.eff_text is None:
-            eff_str = self.used_eff_str.replace("\t", "")
+            try:
+                with open(self.used_eff_file, 'r') as f:
+                    eff_str = f.read()
+            except:
+                eff_str = self.used_eff_str.replace("\t", "")
 
             # Set position of text according to amount of lines in the string
             line_count = eff_str.count("\n") + 1


### PR DESCRIPTION
Writes used efficiency files to used_eff_files.txt and uses that to display actually used eff files in depth profile as "files used" instead of "files found" that is used otherwice.