### PR TITLE
Pin the GitHub actions references via hashes instead of tags.

### DIFF
--- a/.github/workflows/compile_c_apps.yml
+++ b/.github/workflows/compile_c_apps.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           mkdir -p ${{runner.workspace}}/artifact
       - name: Download C artifact
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-windows
           workflow: version_bump.yml
@@ -32,7 +32,7 @@ jobs:
             echo "artifact_exists=false" >> $GITHUB_OUTPUT
           fi
       - name: Checkout master
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: master
           fetch-depth: 0
@@ -65,12 +65,12 @@ jobs:
         shell: cmd
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         submodules: recursive
         path: repo
     - name: vcpkg build
-      uses: johnwason/vcpkg-action@v5
+      uses: johnwason/vcpkg-action@3839b028ca2400865ef5e83a899f336b1b8fd711 # v5
       id: vcpkg
       with:
         pkgs: gsl getopt
@@ -86,7 +86,7 @@ jobs:
         cd ${{runner.workspace}}\potku\repo\dev
         build.bat ${{ runner.workspace }}\potku\vcpkg\scripts\buildsystems\vcpkg.cmake
     - name: Archive windows executables
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
       with:
         name: c-apps-windows
         path: ${{runner.workspace}}\potku\repo\external\bin
@@ -99,7 +99,7 @@ jobs:
       needs.check_artifacts.outputs.ext_changed == 'true'
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         submodules: recursive
     - name: Build linux executables
@@ -108,7 +108,7 @@ jobs:
         cd ${{runner.workspace}}/potku/dev
         ./build.sh
     - name: Archive linux executables
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
       with:
         name: c-apps-linux
         path: |
@@ -123,7 +123,7 @@ jobs:
       needs.check_artifacts.outputs.ext_changed == 'true'
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         submodules: recursive
     - name: Build MacOS executables
@@ -133,7 +133,7 @@ jobs:
         cd ${{runner.workspace}}/potku/dev
         ./build.sh
     - name: Archive macos executables
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
       with:
         name: c-apps-macos
         path: |

--- a/.github/workflows/package_potku.yml
+++ b/.github/workflows/package_potku.yml
@@ -13,11 +13,11 @@ jobs:
         shell: cmd
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
       - name: Download old C artifact
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-windows
           workflow: version_bump.yml
@@ -27,12 +27,12 @@ jobs:
           if_no_artifact_found: ignore
       - name: Check file existence
         id: check_files
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
         with:
           files: "${{runner.workspace}}/potku/external/bin/mcerd.exe"
       - name: Download current C artifact
         if: steps.check_files.outputs.files_exists == 'false'
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-windows
           workflow: version_bump.yml
@@ -41,7 +41,7 @@ jobs:
           search_artifacts: true
           workflow_conclusion: 'in_progress'
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.10'
@@ -60,14 +60,14 @@ jobs:
           pipenv run pip install pyinstaller
           pipenv run pyinstaller potku.spec
       - name: Create archive
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@a24011d8d445e4da5935a7e73c1f98e22a439464 # 0.7.1
         with:
           type: 'zip'
           filename: 'Potku-Windows.zip'
           directory: ${{runner.workspace}}/potku/dist
           path: potku
       - name: Archive Windows release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: Potku-Windows
           path: ${{runner.workspace}}/potku/dist/Potku-Windows.zip
@@ -77,11 +77,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
       - name: Download old C artifact
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-linux
           workflow: version_bump.yml
@@ -91,12 +91,12 @@ jobs:
           if_no_artifact_found: ignore
       - name: Check file existence
         id: check_files
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
         with:
           files: "${{runner.workspace}}/potku/external/bin/mcerd"
       - name: Download current C artifact
         if: steps.check_files.outputs.files_exists == 'false'
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-linux
           workflow: version_bump.yml
@@ -105,7 +105,7 @@ jobs:
           search_artifacts: true
           workflow_conclusion: 'in_progress'
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.10'
@@ -125,14 +125,14 @@ jobs:
           pipenv run pip install pyinstaller
           pipenv run pyinstaller potku.spec
       - name: Create archive
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@a24011d8d445e4da5935a7e73c1f98e22a439464 # 0.7.1
         with:
           type: 'zip'
           filename: 'Potku-Linux.zip'
           directory: ${{runner.workspace}}/potku/dist
           path: potku
       - name: Archive Linux release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: Potku-Linux
           path: ${{runner.workspace}}/potku/dist/Potku-Linux.zip
@@ -141,11 +141,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
       - name: Download old C artifact
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-macos
           workflow: version_bump.yml
@@ -155,12 +155,12 @@ jobs:
           if_no_artifact_found: ignore
       - name: Check file existence
         id: check_files
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
         with:
           files: "${{runner.workspace}}/potku/external/bin/mcerd"
       - name: Download current C artifact
         if: steps.check_files.outputs.files_exists == 'false'
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-macos
           workflow: version_bump.yml
@@ -169,7 +169,7 @@ jobs:
           search_artifacts: true
           workflow_conclusion: 'in_progress'
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.10'
@@ -189,14 +189,14 @@ jobs:
           pipenv run pip install pyinstaller
           pipenv run pyinstaller potku.spec
       - name: Create archive
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@a24011d8d445e4da5935a7e73c1f98e22a439464 # 0.7.1
         with:
           type: 'zip'
           filename: 'Potku-macOS.zip'
           directory: ${{runner.workspace}}/potku/dist
           path: potku
       - name: Archive macOS release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: Potku-macOS
           path: ${{runner.workspace}}/potku/dist/Potku-macOS.zip
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Read version file
         id: get_content
         run: |
@@ -224,7 +224,7 @@ jobs:
         run: |
           mkdir -p ${{runner.workspace}}/potku/artifact
       - name: Download Windows release artifact
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: Potku-Windows
           workflow: version_bump.yml
@@ -233,7 +233,7 @@ jobs:
           skip_unpack: true
           workflow_conclusion: 'in_progress'
       - name: Download Linux release artifact
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: Potku-Linux
           workflow: version_bump.yml
@@ -242,7 +242,7 @@ jobs:
           skip_unpack: true
           workflow_conclusion: 'in_progress'
       - name: Download macOS release artifact
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: Potku-macOS
           workflow: version_bump.yml
@@ -252,7 +252,7 @@ jobs:
           workflow_conclusion: 'in_progress'
       - name: Create prerelease
         if: steps.pre_release.outputs.pre_release == 'true'
-        uses: marvinpinto/action-automatic-releases@v1.2.1
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: ${{ steps.get_content.outputs.version }}
@@ -265,7 +265,7 @@ jobs:
             ${{runner.workspace}}/potku/artifact/Potku-macOS.zip
       - name: Create release
         if: steps.pre_release.outputs.pre_release == 'false'
-        uses: marvinpinto/action-automatic-releases@v1.2.1
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: ${{ steps.get_content.outputs.version }}

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -18,19 +18,19 @@ jobs:
       files_ok: ${{ steps.changed_files.outputs.files_ok }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 2
         # Check if creator of pull request has write permission
       - name: Verify user
         id: check_user
-        uses: actions-cool/check-user-permission@v2.2.0
+        uses: actions-cool/check-user-permission@cd622002ff25c2311d2e7fb82107c0d24be83f9b # v2.2.0
         with:
           require: 'write'
         # Check all changed files between master and pull request head
       - name: Get diff of head to master
         id: get_diff
-        uses: tj-actions/changed-files@v36
+        uses: tj-actions/changed-files@54479c37f5eb47a43e595c6b71e1df2c112ce7f1 # v36
         # Check passed if only version.txt changed and user has write permission
       - name: Verify changed files
         id: changed_files
@@ -40,7 +40,7 @@ jobs:
           steps.check_user.outputs.require-result == 'true'
         run: |
           echo "files_ok=true" >> $GITHUB_OUTPUT
-      
+
   # Check the contents of version.txt
   content_verification:
     name: Verify version.txt content
@@ -53,7 +53,7 @@ jobs:
       version_date: ${{ steps.get_content.outputs.date }}
     steps:
       - name: Git checkout head
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Read version file
@@ -81,8 +81,8 @@ jobs:
           steps.match_content.outputs.date_match == 'true'
         run: |
           echo "content_ok=true" >> $GITHUB_OUTPUT
-  
-  # If branch_verification and content_verification jobs returns true 
+
+  # If branch_verification and content_verification jobs returns true
   # then the pull request is automatically approved by github-actions-bot.
   auto_approve:
     name: Auto approve
@@ -95,10 +95,10 @@ jobs:
       needs.content_verification.outputs.content_ok == 'true'
     steps:
       - name: Auto approve
-        uses: hmarr/auto-approve-action@v3
-        with: 
+        uses: hmarr/auto-approve-action@a2e6f2a0ccf5c63ef8754de360464edbf47e66ee # v3
+        with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-  
+
   # Automatically merge the approved version bump pull request. Version
   # bump branch is automatically deleted after merging.
   auto_merge:
@@ -110,13 +110,13 @@ jobs:
       needs.content_verification.outputs.content_ok == 'true'
     steps:
       - name: Auto merge
-        uses: pascalgn/automerge-action@v0.15.6
+        uses: pascalgn/automerge-action@22948e0bc22f0aa673800da838595a3e7347e584 # v0.15.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_METHOD: "merge"
           MERGE_LABELS: ""
           MERGE_DELETE_BRANCH: "true"
-  
+
   # Automatically create an annotated tag of master branch after
   # merging version bump pull request.
   auto_tag:
@@ -128,7 +128,7 @@ jobs:
       needs.content_verification.outputs.content_ok == 'true'
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: master
           submodules: recursive
@@ -139,7 +139,7 @@ jobs:
           git config user.email "<>"
           git tag -a ${{ needs.content_verification.outputs.version_number}} -m "Automatic tag for version ${{ needs.content_verification.outputs.version_number}}"
           git push origin ${{ needs.content_verification.outputs.version_number}}
-  
+
   # Building the C apps is run as a sub workflow in here.
   build_c:
     name: Build C apps
@@ -148,7 +148,7 @@ jobs:
       needs.branch_verification.outputs.files_ok == 'true' &&
       needs.content_verification.outputs.content_ok == 'true'
     uses: ./.github/workflows/compile_c_apps.yml
-  
+
   # Packaging Potku is run as a sub workflow in here.
   package_Potku:
     name: Package Potku
@@ -157,4 +157,3 @@ jobs:
       needs.branch_verification.outputs.files_ok == 'true' &&
       needs.content_verification.outputs.content_ok == 'true'
     uses: ./.github/workflows/package_potku.yml
-    


### PR DESCRIPTION
This changes the different third-party actions referred via version tags, to be referred via commit hashes for better security.