### PR TITLE
Fix makefile and packaging issues

### DIFF
--- a/.github/workflows/package_potku.yml
+++ b/.github/workflows/package_potku.yml
@@ -57,7 +57,7 @@ jobs:
             exit /b 1
           )
           cd ${{runner.workspace}}/potku
-          pipenv run pip install pyinstaller
+          pipenv run pip install pyinstaller==5.13.2
           pipenv run pyinstaller potku.spec
       - name: Create archive
         uses: thedoctor0/zip-release@a24011d8d445e4da5935a7e73c1f98e22a439464 # 0.7.1
@@ -122,7 +122,7 @@ jobs:
             exit 1
           fi
           cd ${{runner.workspace}}/potku
-          pipenv run pip install pyinstaller
+          pipenv run pip install pyinstaller==5.13.2
           pipenv run pyinstaller potku.spec
       - name: Create archive
         uses: thedoctor0/zip-release@a24011d8d445e4da5935a7e73c1f98e22a439464 # 0.7.1
@@ -186,7 +186,7 @@ jobs:
             exit 1
           fi
           cd ${{runner.workspace}}/potku
-          pipenv run pip install pyinstaller
+          pipenv run pip install pyinstaller==5.13.2
           pipenv run pyinstaller potku.spec
       - name: Create archive
         uses: thedoctor0/zip-release@a24011d8d445e4da5935a7e73c1f98e22a439464 # 0.7.1

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ For quick deployment, run these commands in the root directory:
 ````
 $ pipenv install (if the virtual environment has not already been created)
 $ pipenv shell
-$ pip install pyinstaller
+$ pip install pyinstaller==5.13.2
 $ pyinstaller potku.spec
 ````
 This creates a `dist/potku` folder which contains the executable and all 

--- a/README_macOS.txt
+++ b/README_macOS.txt
@@ -1,0 +1,7 @@
+Before running Potku you should run the following command in the Potku directory:
+
+$ xattr -r -d com.apple.quarantine .
+
+after this you can run Potku with
+
+$ ./potku

--- a/external/Potku-erd_depth/Makefile
+++ b/external/Potku-erd_depth/Makefile
@@ -11,8 +11,8 @@ CFLAGS += -I$(INCDIR) -DDATAPATH=$(DATADIR)
 # CFLAGS= -Wall -O2 -fomit-frame-pointer
 # CFLAGS= -O6 -mcpu=pentiumpro -funroll-loops -ffast-math -malign-double -fomit-frame-pointer
 
-LIB= -lm
-LIB+= -lgsto
+LIB= -lgsto
+LIB+= -lm
 
 LDFLAGS = -g -L$(LIBDIR)
 

--- a/external/Potku-erd_depth/Makefile
+++ b/external/Potku-erd_depth/Makefile
@@ -28,7 +28,7 @@ clean:
 
 depend .depend:
 	$(CC) -I$(INCDIR) -MM *.c > .depend
-include .depend
+    include .depend
 
 install:
 	install -d $(INSTALLDIR) 

--- a/external/Potku-tof_list/Makefile
+++ b/external/Potku-tof_list/Makefile
@@ -28,7 +28,7 @@ clean:
 
 depend .depend:
 	$(CC) -I$(INCDIR) -MM *.c > .depend
-include .depend
+    include .depend
 
 install:
 	install -d $(INSTALLDIR) 

--- a/external/Potku-tof_list/Makefile
+++ b/external/Potku-tof_list/Makefile
@@ -10,8 +10,8 @@ CFLAGS  = -g -Wall -Wmissing-prototypes # -DDEBUG
 #CFLAGS += -I$(INCDIR) -DDATAPATH=$(DATADIR) -DDEBUG
 CFLAGS += -I$(INCDIR) -DDATAPATH=$(DATADIR) -DDEBUG
 
-LIB= -lm
-LIB += -lgsto
+LIB= -lgsto
+LIB+= -lm
 
 #LDFLAGS=-g -L${PWD}/$(LIBDIR)
 LDFLAGS=-g -L$(LIBDIR)

--- a/potku.spec
+++ b/potku.spec
@@ -6,7 +6,7 @@ system = platform.system()
 
 if system == "Darwin":
     ADD_TK_AND_TCL = False
-    extras = [("external/lib/*.dylib", ".")]
+    extras = [("external/lib/*.dylib", "."), ("README_macOS.txt", "./") ]
     icon = "ui_icons/potku/potku_logo_icons/potku_logo_icon.icns"
     console = False
 


### PR DESCRIPTION
I noticed some issues with the compilation of the C apps (tof_list and erd_depth specifically) in the automatic packaging process. In the logs there were errors about undefined references and not finding header files. On Linux there was problems with linking math.h and on macOS there was an issue about finding gsto_masses.h.

I fixed these issues in the makefiles by setting the compiler argument -lm as the last one and fixing a bad indentation in the depend rule, which is used to link the dependencies.

Additionally PyInstaller version isn't pinned anywhere and it recently updated to version 6.0.0, which caused some packaging issues. I pinned the PyInstaller version in package_potku.yaml file to 5.13.2 and also wrote it in the README.md.

Finally I added a README_macOS.txt to be bundled in the macOS distribution to get users to run `$ xattr -r -d com.apple.quarantine .`  before running Potku.