### PR TITLE
Fix makefile and packaging issues

### DIFF
--- a/.github/workflows/package_potku.yml
+++ b/.github/workflows/package_potku.yml
@@ -16,22 +16,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
-      - name: Download old C artifact
-        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
-        with:
-          name: c-apps-windows
-          workflow: version_bump.yml
-          path: ${{runner.workspace}}/potku/external/bin
-          check_artifacts: true
-          search_artifacts: true
-          if_no_artifact_found: ignore
-      - name: Check file existence
-        id: check_files
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-        with:
-          files: "${{runner.workspace}}/potku/external/bin/mcerd.exe"
       - name: Download current C artifact
-        if: steps.check_files.outputs.files_exists == 'false'
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-windows
@@ -40,6 +25,21 @@ jobs:
           check_artifacts: true
           search_artifacts: true
           workflow_conclusion: 'in_progress'
+          if_no_artifact_found: ignore
+      - name: Check file existence
+        id: check_files
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
+        with:
+          files: "${{runner.workspace}}/potku/external/bin/mcerd.exe"
+      - name: Download old C artifact
+        if: steps.check_files.outputs.files_exists == 'false'
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
+        with:
+          name: c-apps-windows
+          workflow: version_bump.yml
+          path: ${{runner.workspace}}/potku/external/bin
+          check_artifacts: true
+          search_artifacts: true
       - name: Set up Python 3.10
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
         with:
@@ -80,30 +80,30 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
-      - name: Download old C artifact
+      - name: Download current C artifact
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-linux
           workflow: version_bump.yml
-          path: ${{runner.workspace}}/potku/external
+          path: ${{runner.workspace}}/potku/external/bin
           check_artifacts: true
           search_artifacts: true
+          workflow_conclusion: 'in_progress'
           if_no_artifact_found: ignore
       - name: Check file existence
         id: check_files
         uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
         with:
           files: "${{runner.workspace}}/potku/external/bin/mcerd"
-      - name: Download current C artifact
+      - name: Download old C artifact
         if: steps.check_files.outputs.files_exists == 'false'
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-linux
           workflow: version_bump.yml
-          path: ${{runner.workspace}}/potku/external
+          path: ${{runner.workspace}}/potku/external/bin
           check_artifacts: true
           search_artifacts: true
-          workflow_conclusion: 'in_progress'
       - name: Set up Python 3.10
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
         with:
@@ -144,30 +144,30 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
-      - name: Download old C artifact
+      - name: Download current C artifact
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-macos
           workflow: version_bump.yml
-          path: ${{runner.workspace}}/potku/external
+          path: ${{runner.workspace}}/potku/external/bin
           check_artifacts: true
           search_artifacts: true
+          workflow_conclusion: 'in_progress'
           if_no_artifact_found: ignore
       - name: Check file existence
         id: check_files
         uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
         with:
           files: "${{runner.workspace}}/potku/external/bin/mcerd"
-      - name: Download current C artifact
+      - name: Download old C artifact
         if: steps.check_files.outputs.files_exists == 'false'
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
         with:
           name: c-apps-macos
           workflow: version_bump.yml
-          path: ${{runner.workspace}}/potku/external
+          path: ${{runner.workspace}}/potku/external/bin
           check_artifacts: true
           search_artifacts: true
-          workflow_conclusion: 'in_progress'
       - name: Set up Python 3.10
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
         with:

--- a/.github/workflows/package_potku.yml
+++ b/.github/workflows/package_potku.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           name: c-apps-linux
           workflow: version_bump.yml
-          path: ${{runner.workspace}}/potku/external/bin
+          path: ${{runner.workspace}}/potku/external
           check_artifacts: true
           search_artifacts: true
           workflow_conclusion: 'in_progress'
@@ -101,7 +101,7 @@ jobs:
         with:
           name: c-apps-linux
           workflow: version_bump.yml
-          path: ${{runner.workspace}}/potku/external/bin
+          path: ${{runner.workspace}}/potku/external
           check_artifacts: true
           search_artifacts: true
       - name: Set up Python 3.10
@@ -149,7 +149,7 @@ jobs:
         with:
           name: c-apps-macos
           workflow: version_bump.yml
-          path: ${{runner.workspace}}/potku/external/bin
+          path: ${{runner.workspace}}/potku/external
           check_artifacts: true
           search_artifacts: true
           workflow_conclusion: 'in_progress'
@@ -165,7 +165,7 @@ jobs:
         with:
           name: c-apps-macos
           workflow: version_bump.yml
-          path: ${{runner.workspace}}/potku/external/bin
+          path: ${{runner.workspace}}/potku/external
           check_artifacts: true
           search_artifacts: true
       - name: Set up Python 3.10


### PR DESCRIPTION
Fixes a logical error in the automatic packaging process. Currently the packaging will ignore artifacts of newly compiled C apps in favour of artifacts of old packages due to the order of operations being: download old artifact -> check if exists -> if doesn't exist, download current -> if doesn't exist, then fail. This however is the wrong order of operations.

This fixes the order of operations to download current artifact -> check if exists -> if doesn't exist, download old-> if doesn't exist, then fail. With this order of operations the current artifact is preferred over an old one.