### PR TITLE
Fix simulation resetting settings changes

### DIFF
--- a/dialogs/request_settings.py
+++ b/dialogs/request_settings.py
@@ -209,6 +209,8 @@ class RequestSettingsDialog(QtWidgets.QDialog):
 
             # Detector settings
             self.detector_settings_widget.update_settings()
+            detector_file = Path(self.request.default_detector.path)
+            self.detector_settings_widget.obj.to_file(detector_file)
 
             # Simulation settings
             self.simulation_settings_widget.update_settings()

--- a/widgets/detector_settings.py
+++ b/widgets/detector_settings.py
@@ -158,19 +158,17 @@ class DetectorSettingsWidget(QtWidgets.QWidget, bnd.PropertyTrackingWidget,
         self.formLayout_2.removeRow(self.angleOffsetLineEdit)
 
         self.scientific_tof_slope = ScientificSpinBox(
-            minimum=-math.inf, maximum=math.inf
+            float(self.obj.tof_slope), minimum=-math.inf, maximum=math.inf
         )
         self.scientific_tof_offset = ScientificSpinBox(
-            minimum=-math.inf, maximum=math.inf
+            float(self.obj.tof_offset), minimum=-math.inf, maximum=math.inf
         )
         self.scientific_angle_slope = ScientificSpinBox(
-            minimum=-math.inf, maximum=math.inf
+            float(self.obj.angle_slope), minimum=-math.inf, maximum=math.inf
         )
         self.scientific_angle_offset = ScientificSpinBox(
-            minimum=-math.inf, maximum=math.inf
+            float(self.obj.angle_offset), minimum=-math.inf, maximum=math.inf
         )
-
-
 
         self.formLayout_2.insertRow(
             0, "ToF slope [s/channel]:", self.scientific_tof_slope)


### PR DESCRIPTION
Element simulations were resetting needlessly when changing both request-wide settings or specific settings. This happened due to ScientificSpinBox values for ToF slope, ToF offset, angle offset and angle slope in detector settings in detector settings being initialized with zero value and only after initialization was the actual value from the detector object set in the fields. This caused the change tracking feature to trigger and think that there were changes that require resetting simulations.

This was fixed by initializing the field values with required values, instead of setting them later.

Additionally fixes an issue, where detector settings didn't save after closing request settings dialog. In the function that is called upon clicking ok in the dialog, there was no call to save the updated settings to the request default detector. I added the call to `detector.to_file()` method to save the updated settings to the default detector file, fixing the problem.