### PR TITLE
Added start_point initialization to None at init

### DIFF
--- a/widgets/matplotlib/measurement/tofe_histogram.py
+++ b/widgets/matplotlib/measurement/tofe_histogram.py
@@ -156,6 +156,7 @@ class MatplotlibHistogramWidget(MatplotlibWidget):
         self.cur_mid_points = None
         self.mid_point_elems = None
         self.end_point_elems = None
+        self.start_points = None
 
         self.background = None
 


### PR DESCRIPTION
When creating first selection and editing points Tofe-histogram crashes for not finding start_points attribute. Added initialization to None in class init.