### PR TITLE
Hotfixes 15112023

### DIFF
--- a/ui_files/ui_foil_widget.ui
+++ b/ui_files/ui_foil_widget.ui
@@ -63,6 +63,9 @@
            <height>16777215</height>
           </size>
          </property>
+         <property name="minimum">
+          <double>0.010000000000000</double>
+         </property>
          <property name="maximum">
           <double>99999999999999996881384047029926983435371269061279689406644211752791525136670645395254002395395884805259264.000000000000000</double>
          </property>

--- a/widgets/detector_settings.py
+++ b/widgets/detector_settings.py
@@ -643,14 +643,6 @@ class DetectorSettingsWidget(QtWidgets.QWidget, bnd.PropertyTrackingWidget,
         self.efficiencyListWidget: QtWidgets.QListWidget
         selected_items = self.efficiencyListWidget.selectedItems()
         if selected_items:
-            reply = QtWidgets.QMessageBox.question(
-                self, "Confirmation",
-                "Are you sure you want to delete selected efficiencies?",
-                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No |
-                QtWidgets.QMessageBox.Cancel, QtWidgets.QMessageBox.Cancel)
-            if reply == QtWidgets.QMessageBox.No or reply == \
-                    QtWidgets.QMessageBox.Cancel:
-                return
 
             for item in selected_items:
                 selected_eff_file = item.data(QtCore.Qt.UserRole)

--- a/widgets/foil.py
+++ b/widgets/foil.py
@@ -64,7 +64,7 @@ class FoilWidget(QtWidgets.QWidget):
         self.deleteButton.clicked.connect(self._delete_foil)
 
         self.name = foil.name
-        self.distance_from_previous = 0
+        self.distance_from_previous = 0.01
         self.cumulative_distance = foil.distance
 
     def _delete_foil(self):

--- a/widgets/matplotlib/measurement/energy_spectrum.py
+++ b/widgets/matplotlib/measurement/energy_spectrum.py
@@ -258,29 +258,7 @@ class MatplotlibEnergySpectrumWidget(MatplotlibWidget):
         area_1 = integrate.simps(y_1, x_1)
         area_2 = integrate.simps(y_2, x_2)
 
-        # Check if one of the self.lines_of_area is a hist file
-        # If so, use it as the one which is compare to the other
-        i = 0
-        j = 0
-        for line in self.lines_of_area:
-            for key, values in line.items():
-                if key.name.endswith(".hist"):
-                    i += 1
-                    break
-            if i != 0:
-                break
-            j += 1
-
-        if i != 0:
-            if j == 1 and i == 1 and area_2 != 0:
-                ratio = area_2 / area_1
-            else:
-                ratio = area_1 / area_2
-        else:
-            if area_1 > area_2:
-                ratio = area_2 / area_1
-            else:
-                ratio = area_1 / area_2
+        ratio = area_2 / area_1
 
         return ratio, area
 

--- a/widgets/matplotlib/simulation/composition.py
+++ b/widgets/matplotlib/simulation/composition.py
@@ -200,10 +200,11 @@ class _CompositionWidget(MatplotlibWidget):
                 if self.foil_behaviour:
                     zoom_to_bottom = True
 
-                self.simulation.target.reference_density.update_layers(
-                    self.layers)
+                if self.simulation is not None:
+                    self.simulation.target.reference_density.update_layers(
+                        self.layers)
 
-                self.update_target_info_labels()
+                    self.update_target_info_labels()
 
                 self.__update_figure(zoom_to_bottom=zoom_to_bottom)
 

--- a/widgets/matplotlib/simulation/composition.py
+++ b/widgets/matplotlib/simulation/composition.py
@@ -158,9 +158,9 @@ class _CompositionWidget(MatplotlibWidget):
         # Update layer start depths
         self.update_start_depths()
 
-        self.simulation.target.reference_density.update_layers(self.layers)
-
-        self.update_target_info_labels()
+        if self.simulation is not None:
+            self.simulation.target.reference_density.update_layers(self.layers)
+            self.update_target_info_labels()
 
         # Update canvas
         self.__update_figure(zoom_to_bottom=True)
@@ -372,9 +372,9 @@ class _CompositionWidget(MatplotlibWidget):
             self.__selected_layer = dialog.layer
             self.__update_figure(zoom_to_bottom=True)
 
-        self.simulation.target.reference_density.update_layers(self.layers)
-
-        self.update_target_info_labels()
+        if self.simulation is not None:
+            self.simulation.target.reference_density.update_layers(self.layers)
+            self.update_target_info_labels()
 
         if type(self.parent) is widgets.simulation.target.TargetWidget:
             self.parent.recoilRadioButton.setEnabled(True)


### PR DESCRIPTION
Set minimum value of distance spinboxes in detector foil widget to 0.01 mm to avoid issues in simulation. Additionally initialize the spinbox values to minimum.

Remove query about removing efficiency files in detector settings tab. Now the x button just directly removes a particular efficiency file from detector's efficiency directory.

Fix issue with energy spectra area ratios. Removed calculations that force the area ratio to [0, 1] interval. Additionally all energy spectra are handled in the same fashion.

Fix crashing issues when modifying, deleting or adding layers in FoilWidget in detector settings.