### PR TITLE
Fixes depth profile file character error in simple character sets

### DIFF
--- a/dialogs/measurement/depth_profile.py
+++ b/dialogs/measurement/depth_profile.py
@@ -446,7 +446,7 @@ class DepthProfileWidget(QtWidgets.QWidget):
                 str(element) for element in self.elements])))
             fh.write("{0}\n".format("\t".join([
                 str(cut) for cut in self.use_cuts])))
-            fh.write("{0}\n".format(self.x_units))
+            fh.write("{0}\n".format(self.x_units.simple_str()))
             fh.write("{0}\n".format(self._line_zero_shown))
             fh.write("{0}\n".format(self._line_scale_shown))
             fh.write("{0}".format(self._systematic_error))

--- a/modules/enums.py
+++ b/modules/enums.py
@@ -252,12 +252,9 @@ class DepthProfileUnit(str, Enum):
 
     @classmethod
     def from_string(cls, string: str) -> "DepthProfileUnit":
-        print(f"from_string: {string}")
         if string in {"1e15 at./cm²", "1e15 at./cm2"}:
-            print("return: ATOMS_PER_SQUARE_CM")
             return cls.ATOMS_PER_SQUARE_CM
         if string in {"nm"}:
-            print("return: NM")
             return cls.NM
         raise ValueError("Unknown unit string")
 

--- a/modules/enums.py
+++ b/modules/enums.py
@@ -245,6 +245,21 @@ class DepthProfileUnit(str, Enum):
     def __str__(self):
         return self.value
 
+    def simple_str(self):
+        if self is DepthProfileUnit.ATOMS_PER_SQUARE_CM:
+            return "1e15 at./cm2"
+        return self.__str__()
+
+    @classmethod
+    def from_string(cls, string: str) -> "DepthProfileUnit":
+        print(f"from_string: {string}")
+        if string in {"1e15 at./cm²", "1e15 at./cm2"}:
+            print("return: ATOMS_PER_SQUARE_CM")
+            return cls.ATOMS_PER_SQUARE_CM
+        if string in {"nm"}:
+            print("return: NM")
+            return cls.NM
+        raise ValueError("Unknown unit string")
 
 @enum.unique
 class SumSpectrumType(str, Enum):

--- a/widgets/measurement/tab.py
+++ b/widgets/measurement/tab.py
@@ -232,7 +232,8 @@ class MeasurementTabWidget(BaseTab):
             elements = [Element.from_string(element)
                         for element in elements_string]
             try:
-                x_unit = DepthProfileUnit(lines[3].strip())
+                #x_unit = DepthProfileUnit(lines[3].strip())
+                x_unit = DepthProfileUnit.from_string(lines[3].strip())
             except ValueError:
                 x_unit = DepthProfileUnit.ATOMS_PER_SQUARE_CM
             line_zero = False

--- a/widgets/measurement/tab.py
+++ b/widgets/measurement/tab.py
@@ -232,7 +232,6 @@ class MeasurementTabWidget(BaseTab):
             elements = [Element.from_string(element)
                         for element in elements_string]
             try:
-                #x_unit = DepthProfileUnit(lines[3].strip())
                 x_unit = DepthProfileUnit.from_string(lines[3].strip())
             except ValueError:
                 x_unit = DepthProfileUnit.ATOMS_PER_SQUARE_CM


### PR DESCRIPTION
Windows uses simple character sets in some languages which doesn't include '²'-character. It is better to use just plain '2' in save file and use from_string method to read input.