### PR TITLE
Fix closing of ToFE histogram and target widgets on MacOS

### DIFF
--- a/widgets/measurement/tofe_histogram.py
+++ b/widgets/measurement/tofe_histogram.py
@@ -132,3 +132,14 @@ class TofeHistogramWidget(QtWidgets.QWidget):
         self.__paste_selection = QtWidgets.QShortcut(QKeySequence(QtCore.Qt.CTRL+QtCore.Qt.Key_V), self)
         self.__paste_selection.activated.connect(self.matplotlib.paste_selection)
 
+    def closeEvent(self, close_event):
+        """Event which happens when the windows is closing.
+        Instead of closing, minimize the window. Fixes close buttons on macOS,
+        which for the time being cannot be disabled.
+
+        Args:
+            close_event: Close event
+        """
+        close_event.ignore()
+        self.showMinimized()
+

--- a/widgets/simulation/target.py
+++ b/widgets/simulation/target.py
@@ -247,3 +247,14 @@ class TargetWidget(QtWidgets.QWidget):
         self.del_points.setKey(QtCore.Qt.Key_Delete)
         self.del_points.activated.connect(
             lambda: self.recoil_distribution_widget.remove_points())
+
+    def closeEvent(self, close_event):
+        """Event which happens when the windows is closing.
+        Instead of closing, minimize the window. Fixes close buttons on macOS,
+        which for the time being cannot be disabled.
+
+        Args:
+            close_event: Close event
+        """
+        close_event.ignore()
+        self.showMinimized()


### PR DESCRIPTION
On MacOS the ToFE histogram and target widgets were closeable despite is_closaeble attribute being set to False. To circumvent this issue the closeEvent function for these widgets was overridden and set to instead just minimize the widgets. Has no effect on Windows side of things.